### PR TITLE
v0.9.8 bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pio
 .vscode
+.history

--- a/include/AP33772_PocketPD.h
+++ b/include/AP33772_PocketPD.h
@@ -181,6 +181,8 @@ public:
   void setSupplyVoltageCurrent(int targetVoltage, int targetCurrent);
   byte existPPS = 0; // PPS flag for setVoltage()
 
+  void checkVoltageCurrent(int &targetVoltage, int &targetCurrent);
+
 private:
   void i2c_read(byte slvAddr, byte cmdAddr, byte len);
   void i2c_write(byte slvAddr, byte cmdAddr, byte len);

--- a/include/Button.h
+++ b/include/Button.h
@@ -26,7 +26,7 @@ private:
     bool isLongDetected = false;
     const int debounceTime = 50;                 // Set default debounce time to 50ms
     const unsigned long SHORT_PRESS_TIME = 1000; // Short is less than 1s, more than 50ms
-    const unsigned long LONG_PRESS_TIME = 3000;  // Long is longer than 4s
+    const unsigned long LONG_PRESS_TIME = 1500;  // Long is longer than 1.5s
 };
 
 #endif

--- a/include/EEPROMHandler.hpp
+++ b/include/EEPROMHandler.hpp
@@ -1,0 +1,94 @@
+#ifndef EEPROMHANDLER_HPP
+#define EEPROMHANDLER_HPP
+
+#include <Arduino.h>
+#include <EEPROM.h>
+
+#define EEPROM_SIZE          4096              // Size of EEPROM in bytes
+#define EEPROM_SAVE_INTERVAL 2000              // Time interval to save settings to EEPROM in milliseconds
+
+
+struct Settings {
+        uint32_t           crc;                // CRC for settings validation
+        int32_t            targetVoltage;      // Target voltage in mV
+        int32_t            targetCurrent;      // Target current in mA
+        int32_t            menuPosition;       // Current menu position
+};
+
+class EEPROMHandler {
+    bool     initialized   = false;            // Flag to check if EEPROM is initialized
+    bool     firstReadOk   = false;            // Flag to check if the first read from EEPROM was successful
+    Settings settings;
+ public:
+    EEPROMHandler() { }
+    virtual ~EEPROMHandler() { }
+    
+    void begin() {
+        if(!initialized) {
+            EEPROM.begin(EEPROM_SIZE);
+            Serial.printf("EEPROM initialized %4d bytes | Settings size: %4d\n\r", EEPROM_SIZE, sizeof(Settings));
+            initialized = true;
+        }
+    }
+
+    uint32_t calculateCRC() {
+        uint32_t crc = 0;
+        for(size_t i = 1; i < sizeof(Settings)/sizeof(uint32_t); ++i) {
+            crc ^= ((uint32_t*)&settings)[i];
+        }
+        return crc;
+    }
+
+    bool loadSettings(Settings &outSettings) {
+        begin();
+
+        if(firstReadOk) {
+            Serial.println("Using cached settings.");
+            outSettings = settings;
+            return true;
+        }
+        
+        EEPROM.get(0, settings);
+        uint32_t crc = calculateCRC();
+        
+        Serial.printf("Crc calculated: %08X, stored crc: %08X\n\r", crc, settings.crc);
+        Serial.printf("Target Voltage: %d mV, Target Current: %d mA, Menu Position: %d\n\r", 
+                       settings.targetVoltage, settings.targetCurrent, settings.menuPosition);
+
+        if(settings.crc != 0 && settings.crc == crc) {
+            outSettings = settings;
+            Serial.println("Settings loaded successfully.");
+            firstReadOk = true;
+        } else {
+            Serial.println("Invalid settings in EEPROM.");
+            firstReadOk = false;
+        }
+        return firstReadOk;
+    }
+
+    bool saveSettings(Settings &newSettings) {
+        if(!initialized) {
+            Serial.println("EEPROM not initialized, cannot save settings.");
+            return false;
+        }
+
+        newSettings.crc = calculateCRC();
+        // Compare new settings with current settings
+        if(firstReadOk && memcmp(&settings, &newSettings, sizeof(Settings)) == 0) {
+            Serial.println("No changes in settings, skipping save.");
+            return true;
+        }
+
+        settings = newSettings;
+        
+        EEPROM.put(0, settings);
+        if(EEPROM.commit()) {
+            Serial.println("Settings saved successfully.");
+            return true;
+        } else {
+            Serial.println("Failed to save settings.");
+            return false;
+        }
+    }
+};
+#endif // EEPROMHANDLER_HPP

--- a/include/Menu.h
+++ b/include/Menu.h
@@ -27,6 +27,7 @@ public:
     void set_qc3flag(bool flag);
     void page_selectCapability();
     void page_bootProfile();
+    void checkMenuPosition(bool wrapAround); // Check if menuPosition is within range, wrap around if not
 
 private:
     U8G2_SSD1306_128X64_NONAME_F_HW_I2C *u8g2;

--- a/include/StateMachine.h
+++ b/include/StateMachine.h
@@ -7,6 +7,7 @@
 #include <PocketPDPinOut.h>
 #include <image.h>
 #include <Menu.h>
+#include <EEPROMHandler.hpp>
 
 #define ALARM_NUM0 0 // Timer 0
 #define ALARM_IRQ0 TIMER_IRQ_0
@@ -70,7 +71,10 @@ public:
                      supply_mode(MODE_CV),
                      voltageIncrement{20, 100, 1000},
                      currentIncrement{50, 200},
-                     menu(&u8g2, &usbpd, &encoder, &button_encoder, &button_output, &button_selectVI) {};
+                     menu(&u8g2, &usbpd, &encoder, &button_encoder, &button_output, &button_selectVI),
+                     eepromHandler(),
+                     forceSave(false),
+                     saveStamp(0) {};
 
     void update();
     const char *getState();
@@ -85,6 +89,9 @@ private:
     Button button_output;
     Button button_selectVI;
     Menu menu;
+    EEPROMHandler eepromHandler;
+    bool forceSave;
+    uint32_t saveStamp;
 
     unsigned long startTime;
     bool bootInitialized;
@@ -140,6 +147,11 @@ private:
     char buffer[10];
 
     int counter_gif = 0; //Count up to 27
+
+    void handleInitialMode();
+    bool saveSettingsToEEPROM();
+    bool loadSettingsFromEEPROM(bool vc);
+    void updateSaveStamp();
 };
 
 #endif // STATEMACHINE_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
 # debug_speed = 5000
 build_flags =
 	-DHW1_0
-	-DVERSION="\"0.9.7\""
+	-DVERSION="\"0.9.8\""
 
 [env:HW1_1]
 debug_tool = cmsis-dap
@@ -33,5 +33,5 @@ upload_protocol = cmsis-dap
 debug_speed = 5000
 build_flags = 
 	-DHW1_1
-	-DVERSION="\"0.9.7\""
+	-DVERSION="\"0.9.8\""
 

--- a/src/AP33772_PocketPD.cpp
+++ b/src/AP33772_PocketPD.cpp
@@ -74,6 +74,27 @@ void AP33772::begin()
 }
 
 /**
+ * @brief  Check if target voltage and current are in range
+ * 
+ * @param targetVoltage 
+ * @param targetCurrent 
+ */
+void AP33772::checkVoltageCurrent(int& targetVoltage, int& targetCurrent)
+{   int maxVoltage = pdoData[PPSindex].pps.maxVoltage * 100;
+    int minVoltage = pdoData[PPSindex].pps.minVoltage * 100;
+    // Check if target voltage is in range
+    if(targetVoltage < minVoltage)
+        targetVoltage = minVoltage; // Minimum 5V
+    else if (targetVoltage > maxVoltage)
+        targetVoltage = maxVoltage; // Maximum 20V
+
+    int maxCurrent = pdoData[PPSindex].pps.maxCurrent * 50; // Convert to mA
+    // Check if target current is in range
+    if(targetCurrent > maxCurrent)
+        targetCurrent = maxCurrent; // Maximum 3000mA
+}
+
+/**
  * @brief Set VBUS voltage and max current
  * Current will automatically be in limit mode
  * @param targetVoltage, targetCurrent, - mV and mA
@@ -162,9 +183,9 @@ void AP33772::setPDO(uint8_t PDOindex)
 
     if (PDOindex <= guarding)
     {
-        rdoData.fixed.objPosition = PDOindex + 1; // Index 0 to Index 1
-        rdoData.fixed.maxCurrent = pdoData[PDOindex].fixed.maxCurrent;
-        rdoData.fixed.opCurrent = pdoData[PDOindex].fixed.maxCurrent;
+        rdoData.fixed.objPosition   = PDOindex + 1; // Index 0 to Index 1
+        rdoData.fixed.maxCurrent    = pdoData[PDOindex].fixed.maxCurrent;
+        rdoData.fixed.opCurrent     = pdoData[PDOindex].fixed.maxCurrent;
         writeRDO();
     }
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -18,6 +18,26 @@ Menu::Menu(U8G2_SSD1306_128X64_NONAME_F_HW_I2C *oled, AP33772 *usb, RotaryEncode
     qc3_0available = 0;
 }
 
+/**
+ * @brief Check if menuPosition is within range, wrap around if not
+ * 
+ * @param wrapAround 
+ */
+void Menu::checkMenuPosition(bool wrapAround) {
+    if(usbpd) numPDO = usbpd->getNumPDO();
+    if (menuPosition < 0) {
+            if(wrapAround) menuPosition = numPDO + qc3_0available - 1; // wrap around
+            else menuPosition = 0; // reset to 0 if not wrapping around
+    }
+    if(menuPosition > (numPDO + qc3_0available - 1)) {
+        menuPosition = 0; // wrap around
+    }
+}
+
+/**
+ * @brief Handle main menu page for selecting capability
+ * 
+ */
 void Menu::page_selectCapability()
 {
     uint8_t linelocation;
@@ -26,10 +46,7 @@ void Menu::page_selectCapability()
     if (val = (int8_t)_encoder->getDirection())
     {
         menuPosition = menuPosition - val;
-        if (menuPosition < 0)
-            menuPosition = numPDO + qc3_0available - 1; // wrap around
-        if (menuPosition > (numPDO + qc3_0available - 1))
-            menuPosition = 0; // wrap around
+        checkMenuPosition(true);
     }
 
     u8g2->clearBuffer();

--- a/to_do_list.md
+++ b/to_do_list.md
@@ -5,7 +5,7 @@ List of requested UI changes:
 + [x] Add mV suffix to set value
 + [x] Pressing encoder in current mode can change between 50mA to 200mA
 + [x] Skipping bootup screen by pressing any button
-+ [ ] Default is PPS but turning knob at bootup screen to select desire profile (PPS, PDO, QC3.0).
++ [x] Default is PPS but turning knob at bootup screen to select desire profile (PPS, PDO, QC3.0).
 + [x] Corner of the screen now display protocol PPS, Fixed, or QC3.0
 + [x] Addition all menu afterboot up to switch between mode if long press Voltage/Current button
 
@@ -13,6 +13,8 @@ List of requested UI changes:
 + [x] Calibrate current sensor
 + [x] Delay CC/CV update to reduce mode flicker.
 + [x] Fix CC/CV bug at no load.
+
++ [x] Add EEPROM function to remember last used voltage/current and PD mode settings.
 
 + [ ] Add more cable loss when connect through Android adapter, detect computer connection.
 


### PR DESCRIPTION
Use encoder during boot lets you select mode you want.
 
Added EEPROM functionality to remember last chosen PD mode + voltage/current settings.

Changed 4s long press to 1.5s (feels much better IMO).