### PR TITLE
Fix left long press only transitioning to PPS mode

### DIFF
--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -89,6 +89,7 @@ void StateMachine::update()
             if (menu.menuPosition == usbpd.getPPSIndex()) {
                 transitionTo(State::NORMAL_PPS);
             } else {
+                forceSave = true;
                 transitionTo(State::NORMAL_PDO);
             }   
         }

--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -86,7 +86,11 @@ void StateMachine::update()
         if (button_selectVI.longPressedFlag) // Long press
         {
             button_selectVI.clearLongPressedFlag();
-            transitionTo(State::NORMAL_PPS);
+            if (menu.menuPosition == usbpd.getPPSIndex()) {
+                transitionTo(State::NORMAL_PPS);
+            } else {
+                transitionTo(State::NORMAL_PDO);
+            }   
         }
         if (button_encoder.longPressedFlag) // Long press
         {


### PR DESCRIPTION
Fix #5 and potentially #27 .
Long press of the wheel would correctly transition to PDO mode when selected. Long pressing the left button would always transition the device to PPS mode.