### PR TITLE
Add clang-format config (LLVM base, 100col, 4-indent)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+BasedOnStyle: LLVM
+ColumnLimit: 100
+IndentWidth: 4
+
+AlwaysBreakTemplateDeclarations: Yes
+AccessModifierOffset: -4
+AlignAfterOpenBracket: BlockIndent
+AlignConsecutiveMacros: Consecutive
+AlignOperands: AlignAfterOperator
+AllowShortFunctionsOnASingleLine: Empty
+InsertBraces: true
+NamespaceIndentation: All
+PointerAlignment: Left
+DerivePointerAlignment: false
+ReflowComments: true
+# Header include ordering — Google C++ Style Guide
+# https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes
+#   1. C system headers      (<stdint.h>, <string.h>)
+#   2. C++ standard library  (<cstdint>, <vector>, <algorithm>)
+#   3. Other libraries / project headers (Arduino, third-party, local)
+SortIncludes: CaseSensitive
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<[[:lower:]_/]+\.h>$'
+    Priority: 1
+  - Regex: '^<[[:alpha:]_]+>$'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3


### PR DESCRIPTION
## Summary

Set project-wide formatting baseline to create styling consistency in the project. No source files touched in this PR. Format passes will happen in future commit. There is no right standard and this simply a reasonable default that is most pleasant to my eyeballs.

- Adds `.clang-format` with LLVM base, 100 column limit, 4-space indent
- Enforces Google C++ Style include ordering via `IncludeBlocks: Regroup`