### PR TITLE
Add native test env and move calibration out of test/

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,8 @@
+Documentation:
+  CommentFormat: Doxygen
+---
+If:
+  PathMatch: .*\.h$
+CompileFlags:
+  Add:
+    - -xc++

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Build PlatformIO Project
         run: pio run
+
+      - name: Run Unit Tests
+        run: pio test -e native

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .pio
 .vscode
 .history
+.cache
+.worktrees
+compile_commands.json

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,18 +8,23 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env]
+[platformio]
+default_envs = HW1_0, HW1_1
+
+[pico_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = pico
 framework = arduino
 board_build.core = earlephilhower
-lib_deps = 
+test_ignore = *
+lib_deps =
 	olikraus/U8g2@^2.35.19
 	arduinogetstarted/ezButton@^1.0.4
 	mathertel/RotaryEncoder@^1.5.3
 	khoih-prog/RPI_PICO_TimerInterrupt@^1.3.1
 
 [env:HW1_0]
+extends = pico_base
 # debug_tool = cmsis-dap
 # upload_protocol = cmsis-dap
 # debug_speed = 5000
@@ -28,10 +33,40 @@ build_flags =
 	-DVERSION="\"1.0.0\""
 
 [env:HW1_1]
+extends = pico_base
 debug_tool = cmsis-dap
 upload_protocol = cmsis-dap
 debug_speed = 5000
-build_flags = 
+build_flags =
 	-DHW1_1
 	-DVERSION="\"1.0.0\""
 
+[env:native]
+platform = native
+build_type = test
+test_framework = googletest
+build_flags =
+	-std=gnu++17
+	-DUNIT_TEST
+	-I include
+	-I test/mocks
+	-Wno-missing-template-arg-list-after-template-kw
+lib_deps =
+	fabiobatsilva/ArduinoFake @ ^0.4.0
+
+[env:native_clangd]
+platform = native
+test_ignore = *
+build_src_filter =
+	-<*>
+	+<../test/**/*.cpp>
+build_flags =
+	-std=gnu++17
+	-DUNIT_TEST
+	-I include
+	-I test/mocks
+	-Wno-missing-template-arg-list-after-template-kw
+lib_deps =
+	fabiobatsilva/ArduinoFake @ ^0.4.0
+	google/googletest @ ^1.17.0
+extra_scripts = pre:scripts/set_test_compiledb_path.py

--- a/scripts/set_test_compiledb_path.py
+++ b/scripts/set_test_compiledb_path.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+Import("env")  # type: ignore  # noqa: F821
+
+project_dir = Path(env["PROJECT_DIR"])  # type: ignore  # noqa: F821
+env.Replace(COMPILATIONDB_PATH=str(project_dir / "test" / "compile_commands.json"))  # type: ignore  # noqa: F821

--- a/test/.clangd
+++ b/test/.clangd
@@ -1,0 +1,7 @@
+# Use test/compile_commands.json (host clang++) for this tree only.
+# Root compile_commands.json stays arm-none-eabi so include/ and src/ are not
+# associated with the macOS SDK.
+Documentation:
+  CommentFormat: Doxygen
+CompileFlags:
+  CompilationDatabase: .

--- a/test/test_smoke/test_smoke.cpp
+++ b/test/test_smoke/test_smoke.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+TEST(Smoke, TestFrameworkWorks) {
+    EXPECT_EQ(4, 2 + 2);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tools/calibration.cpp
+++ b/tools/calibration.cpp
@@ -4,6 +4,7 @@
 //     url: https://github.com/pk17r/INA226
 
 #include "INA226.h"
+#include "Arduino.h"
 
 INA226 INA(0x40);
 


### PR DESCRIPTION
## Summary
- Moves `calibration.cpp` from `test/` to `tools/` — it's a manual calibration procedure, not a test
- Adds PlatformIO `native` test env for host-side unit tests
- Adds `.clangd` configs (project + test) to point clangd at the right compile DBs
- Adds `scripts/set_test_compiledb_path.py` helper for test env compile DB path injection
- Updates `.gitignore` for test build outputs

Groundwork for upcoming driver unit tests. No runtime firmware changes.