### PR TITLE
v2: replace StageId enum with stage type list

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -6,5 +6,3 @@ CompileFlags:
   BuiltinHeaders: QueryDriver
   Remove:
     - -march=*
-    - -mcpu=*
-    - -mthumb

--- a/lib/tempo/include/tempo/app/application.h
+++ b/lib/tempo/include/tempo/app/application.h
@@ -1,6 +1,6 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <type_traits>
 
 #include "tempo/bus/event_queue.h"
@@ -8,7 +8,11 @@
 #include "tempo/core/panic.h"
 #include "tempo/diag/logger.h"
 #include "tempo/hardware/stream.h"
+#include "tempo/sched/background_task.h"
 #include "tempo/sched/cooperative_scheduler.h"
+#include "tempo/sched/periodic_task.h"
+#include "tempo/sched/stage_scoped_task.h"
+#include "tempo/sched/task.h"
 #include "tempo/stage/conductor.h"
 
 namespace tempo {
@@ -19,33 +23,40 @@ namespace tempo {
     /**
      * @brief Single-core application orchestrator.
      *
-     * Application is a thin wrapper around the scheduler, conductor, and event queues. It does not
-     * own any hardware, drivers, app data, or other product-specific runtime data.
+     * Application is a thin wrapper around the scheduler, conductor, and event queues. It
+     * does not own any hardware, drivers, app data, or other product-specific runtime data.
      *
      * The two things it borrows by reference: Clock and StreamWriter.
      *
-     * Anything else (Display, inputs, Storage, sensors) is wired directly from
-     * main.cpp into whichever Task or Stage needs it.
+     * Anything else (Display, inputs, Storage, sensors) is wired directly from main.cpp into
+     * whichever Task or Stage needs it.
      *
-     * @tparam StageId An enum type representing all possible stages.
-     * @tparam Event An event type of std::variant<...>.
-     * @tparam MaxTasks The maximum number of tasks that can be added to the scheduler.
-     * @tparam EventQueueCapacity The capacity of the event queue.
+     * Stage identity is the Stage's type. The Stages... pack defines the slot order for the
+     * Conductor and StageMask.
+     *
+     * @tparam TEvent An event type of std::variant<...>.
+     * @tparam Stages The compile-time list of Stage types.
      */
-    template <
-        typename StageId,
-        typename Event,
-        size_t MaxTasks = DEFAULT_MAX_TASKS,
-        size_t EventQueueCapacity = DEFAULT_EVENT_QUEUE_CAP>
-    class Application : public UseLog<Application<StageId, Event, MaxTasks, EventQueueCapacity>> {
+    template <typename Event, typename... Stages>
+    class Application : public UseLog<Application<Event, Stages...>> {
     public:
         // clang-format off
-        using Scheduler  = tempo::CooperativeScheduler<StageId, Event, MaxTasks>;
-        using Queue      = tempo::EventQueue<Event, EventQueueCapacity>;
-        using Publisher  = tempo::QueuePublisher<Event, EventQueueCapacity>;
-        using Conductor  = tempo::Conductor<StageId>;
-        using Task       = tempo::Task<StageId, Event>;
-        using Stage      = tempo::Stage<StageId>;
+        static constexpr size_t MaxTasks           = DEFAULT_MAX_TASKS;
+        static constexpr size_t EventQueueCapacity = DEFAULT_EVENT_QUEUE_CAP;
+
+        using Conductor       = tempo::Conductor<Stages...>;
+        using Stage           = typename Conductor::StageType;
+        using StageMask       = typename Conductor::StageMaskType;
+
+        using Task            = tempo::Task<Conductor, Event>;
+        using PeriodicTask    = tempo::PeriodicTask<Conductor, Event>;
+        using BackgroundTask  = tempo::BackgroundTask<Conductor, Event>;
+        using StageScopedTask = tempo::StageScopedTask<Conductor, Event>;
+
+        using Scheduler       = tempo::CooperativeScheduler<Conductor, Event, MaxTasks>;
+        using Queue           = tempo::EventQueue<Event, EventQueueCapacity>;
+        using Publisher       = tempo::QueuePublisher<Event, EventQueueCapacity>;
+
         using UseLog<Application>::log;
         // clang-format on
 
@@ -63,6 +74,7 @@ namespace tempo {
 
         Queue m_task_queue;
         Queue m_isr_queue;
+        
         Publisher m_task_publisher;
         Publisher m_isr_publisher;
 
@@ -75,16 +87,14 @@ namespace tempo {
             return instance ? instance->m_conductor.current_name() : "?";
         }
 
-        const char* name_of_stage(StageId id) const {
-            const Stage* s = m_conductor.stage_for(id);
-            return s ? s->name() : "?";
+        const char* name_of_stage_at(size_t idx) const {
+            return m_conductor.name_at(idx);
         }
 
     public:
         Application(const Clock& clock, StreamWriter& stream_writer)
             : m_clock(clock),
               m_stream_writer(stream_writer),
-              m_conductor(clock),
               m_task_publisher(m_task_queue),
               m_isr_publisher(m_isr_queue) {
 
@@ -107,37 +117,37 @@ namespace tempo {
             return m_scheduler.add(task);
         }
 
-        template <typename T>
-        void register_stage(StageId id, T& stage) {
-            if constexpr (std::is_base_of_v<UseLog<T>, T>) {
-                auto& use_log = static_cast<UseLog<T>&>(stage);
+        template <typename S>
+        void register_stage(S& stage) {
+            if constexpr (std::is_base_of_v<UseLog<S>, S>) {
+                auto& use_log = static_cast<UseLog<S>&>(stage);
                 use_log.attach_log(m_clock, m_stream_writer);
             }
 
-            m_conductor.register_stage(id, stage);
+            m_conductor.template register_stage<S>(stage);
         }
 
         /**
          * @brief Setup services and start the application.
          *
-         * Unregistered stage slots fall back to a no-op NullStage, so calling start with no stages
-         * registered is allowed but staging functionality is effective disabled
+         * Unregistered stage slots fall back to a no-op NullStage, so calling start with no
+         * stages registered is allowed but staging functionality is effectively disabled.
          *
-         * @param initial_stage The stage to enter on startup.
+         * @tparam InitialStage The stage type to enter on startup.
          */
-        void start(StageId initial_stage) {
+        template <typename InitialStage>
+        void start() {
             TEMPO_CHECK(!m_started, "Application::start called twice");
 
             m_scheduler.start();
-            m_conductor.start(initial_stage);
+            m_conductor.template start<InitialStage>();
 
             m_started = true;
             log.info("tempo: started, Stage=%s", m_conductor.current_name());
         }
 
         /**
-         * @brief Main tick loop
-         *
+         * @brief Main tick loop.
          */
         void tick() {
             if (!m_started) {
@@ -147,27 +157,25 @@ namespace tempo {
             const uint32_t now = m_clock.now_ms();
 
             // 1. Apply any pending Stage transition from the previous tick.
-            const StageId before = m_conductor.current_id();
+            const size_t before = m_conductor.current_index();
             if (m_conductor.apply_pending_transition()) {
-                const StageId after = m_conductor.current_id();
+                const size_t after = m_conductor.current_index();
                 m_scheduler.notify_stage_changed(before, after);
-                log.info("Stage %s -> %s", name_of_stage(before), name_of_stage(after));
+                log.info("Stage %s -> %s", name_of_stage_at(before), name_of_stage_at(after));
             }
 
-            const StageId current = m_conductor.current_id();
+            const size_t current = m_conductor.current_index();
 
-            // 2. Drainer: pop ISR queue first as it's more sensitive, then the task queue.
-            //    Each event is dispatched to every task whose stage filter matches.
+            // 2. Drain ISR queue first (more sensitive), then task queue.
             Event e;
             while (m_isr_queue.pop(e)) {
                 m_scheduler.dispatch_event(e, current, now);
             }
-
             while (m_task_queue.pop(e)) {
                 m_scheduler.dispatch_event(e, current, now);
             }
 
-            // 3. Run periodic on_tick on every task whose stage matches.
+            // 3. Run periodic on_tick on every task whose stage filter matches.
             m_scheduler.tick(now, current);
 
             // 4. Give the current stage a chance to run its own on_tick.
@@ -175,32 +183,28 @@ namespace tempo {
         }
 
         // —— Accessors
+
         Queue& task_queue() {
             return m_task_queue;
         }
-
         Queue& isr_queue() {
             return m_isr_queue;
         }
-
         Publisher& task_publisher() {
             return m_task_publisher;
         }
-
         Publisher& isr_publisher() {
             return m_isr_publisher;
         }
-
         Scheduler& scheduler() {
             return m_scheduler;
         }
-
         Conductor& conductor() {
             return m_conductor;
         }
 
-        StageId current_stage() const {
-            return m_conductor.current_id();
+        size_t current_stage_index() const {
+            return m_conductor.current_index();
         }
     };
 

--- a/lib/tempo/include/tempo/core/type_list.h
+++ b/lib/tempo/include/tempo/core/type_list.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+namespace tempo {
+
+    // —— Compile-time 0-based index of T in Ts...
+    //
+    // Resolved via recursive template specialization:
+    //   - base case:      T at head of pack          -> 0
+    //   - recursive case: some other U at head       -> 1 + type_index<T, tail...>
+    //   - T not in pack:  primary template (undefined) selected -> compile error
+    //
+    // This is what makes register_stage<S> / request<S> reject types that aren't in
+    // the stage list. type_index_v is the usual variable-template shortcut for
+    // ::value.
+
+    template <typename T, typename... Ts>
+    struct type_index;
+
+    template <typename T, typename... Rest>
+    struct type_index<T, T, Rest...> : std::integral_constant<size_t, 0> {};
+
+    template <typename T, typename U, typename... Rest>
+    struct type_index<T, U, Rest...>
+        : std::integral_constant<size_t, 1 + type_index<T, Rest...>::value> {};
+
+    template <typename T, typename... Ts>
+    constexpr inline size_t type_index_v = type_index<T, Ts...>::value;
+
+} // namespace tempo

--- a/lib/tempo/include/tempo/diag/logger.h
+++ b/lib/tempo/include/tempo/diag/logger.h
@@ -265,7 +265,7 @@ namespace tempo {
         friend Derived;
 
         // Must match tempo::Application's full template signature
-        template <typename StageId, typename Event, size_t MaxTasks, size_t EventQueueCap>
+        template <typename Event, typename... Stages>
         friend class Application;
     };
 

--- a/lib/tempo/include/tempo/sched/background_task.h
+++ b/lib/tempo/include/tempo/sched/background_task.h
@@ -1,25 +1,23 @@
-// src/tempo/sched/BackgroundTask.h
 #pragma once
 
-#include <tempo/stage/stage_mask.h>
-
-#include "periodic_task.h"
+#include "tempo/sched/periodic_task.h"
 
 namespace tempo {
+
     /**
      * @brief Background Task. Runs in every Stage.
      *
-     * @tparam TStageId An enum type representing all possible stages.
+     * @tparam Conductor The concrete Conductor instantiation.
      * @tparam TEvent An event type. Usually std::variant<...>.
      */
-    template <typename TStageId, typename TEvent>
-    class BackgroundTask : public PeriodicTask<TStageId, TEvent> {
+    template <typename Conductor, typename Event>
+    class BackgroundTask : public PeriodicTask<Conductor, Event> {
     public:
-        using PeriodicTask<TStageId,TEvent>::PeriodicTask;
-        using stage_mask_t = StageMask<TStageId>;
+        using PeriodicTask<Conductor, Event>::PeriodicTask;
+        using StageMaskType = typename Conductor::StageMaskType;
 
-        stage_mask_t allowed_stages() const final {
-            return stage_mask_t::all();
+        StageMaskType allowed_stages() const final {
+            return StageMaskType::all();
         }
     };
 

--- a/lib/tempo/include/tempo/sched/cooperative_scheduler.h
+++ b/lib/tempo/include/tempo/sched/cooperative_scheduler.h
@@ -1,4 +1,3 @@
-// src/tempo/sched/CooperativeScheduler.h
 #pragma once
 
 #include <array>
@@ -10,28 +9,26 @@
 namespace tempo {
 
     /**
-     * @brief Cooperative scheduler for the variant-event model. Drains the event queue
-     * first (dispatching each event to every Task whose Stage filter matches),
-     * then ticks every Task whose period has elapsed.
+     * @brief Cooperative scheduler for the variant-event model. Drains the event queue first
+     * (dispatching each event to every Task whose Stage filter matches), then ticks every
+     * Task whose period has elapsed.
      *
-     * @tparam StageId An enum type representing all possible stages.
+     * @tparam Conductor The concrete Conductor instantiation.
      * @tparam TEvent An event type. Usually std::variant<...>.
-     * @tparam MaxTasks The maximum number of tasks that can be added to the scheduler.
-     * @tparam QueueCapacity The capacity of the event queue.
+     * @tparam MaxTasks The maximum number of tasks that can be added.
      */
-    template <typename TStageId, typename TEvent, size_t MaxTasks>
+    template <typename Conductor, typename Event, size_t MaxTasks>
     class CooperativeScheduler {
-        using task_t = Task<TStageId, TEvent>;
+        using TaskType = Task<Conductor, Event>;
 
-        std::array<task_t*, MaxTasks> m_tasks{};
+        std::array<TaskType*, MaxTasks> m_tasks{};
         size_t m_count = 0;
 
     public:
-        bool add(task_t& t) {
+        bool add(TaskType& t) {
             if (m_count == MaxTasks) {
                 return false;
             }
-
             m_tasks[m_count++] = &t;
             return true;
         }
@@ -44,31 +41,24 @@ namespace tempo {
 
         /**
          * @brief Route a single event to every task whose stage filter matches.
-         *
-         * @param event The event to route.
-         * @param stage The stage to route the event to.
-         * @param now_ms The current time in milliseconds.
          */
-        void dispatch_event(const TEvent& event, TStageId current_stage, uint32_t now_ms) {
-            for (size_t i = 0; i < m_count; i++) {
+        void dispatch_event(const Event& event, size_t current_idx, uint32_t now_ms) {
+            for (size_t i = 0; i < m_count; ++i) {
                 auto* t = m_tasks[i];
-                if (t->allowed_stages().contains(current_stage)) {
+                if (t->allowed_stages().contains_index(current_idx)) {
                     t->on_event(event, now_ms);
                 }
             }
         }
 
         /**
-         * @brief Run periodic on_tick on every task whose stage filter matches and
-         * whose period has elapsed.
-         *
-         * @param now_ms The current time in milliseconds.
-         * @param current The current stage.
+         * @brief Run periodic on_tick on every task whose stage filter matches and whose
+         * period has elapsed.
          */
-        void tick(uint32_t now_ms, TStageId current_stage) {
+        void tick(uint32_t now_ms, size_t current_idx) {
             for (size_t i = 0; i < m_count; ++i) {
                 auto* t = m_tasks[i];
-                if (t->allowed_stages().contains(current_stage)) {
+                if (t->allowed_stages().contains_index(current_idx)) {
                     t->tick(now_ms);
                 }
             }
@@ -76,24 +66,24 @@ namespace tempo {
 
         /**
          * @brief Notify all tasks that the stage has changed.
-         *
-         * @param from The previous stage.
-         * @param to The new stage.
          */
-        void notify_stage_changed(TStageId from, TStageId to) {
-            for (size_t i = 0; i < m_count; i++) {
+        void notify_stage_changed(size_t from_idx, size_t to_idx) {
+            for (size_t i = 0; i < m_count; ++i) {
                 auto* t = m_tasks[i];
-                if (t->allowed_stages().contains(from) || t->allowed_stages().contains(to)) {
-                    t->on_stage_changed(from, to);
+                const auto mask = t->allowed_stages();
+                if (mask.contains_index(from_idx) || mask.contains_index(to_idx)) {
+                    t->on_stage_changed(from_idx, to_idx);
                 }
             }
         }
+
         size_t task_count() const {
             return m_count;
         }
 
-        task_t* task_at(size_t index) const {
+        TaskType* task_at(size_t index) const {
             return index < m_count ? m_tasks[index] : nullptr;
         }
     };
+
 } // namespace tempo

--- a/lib/tempo/include/tempo/sched/periodic_task.h
+++ b/lib/tempo/include/tempo/sched/periodic_task.h
@@ -4,22 +4,19 @@
 
 #include "tempo/core/time.h"
 #include "tempo/sched/task.h"
-#include "tempo/stage/stage_mask.h"
 
 namespace tempo {
 
-    template <typename StageId, typename Event>
-    class PeriodicTask : public Task<StageId, Event> {
-        using stage_mask_t = StageMask<StageId>;
+    template <typename Conductor, typename Event>
+    class PeriodicTask : public Task<Conductor, Event> {
+        using stage_mask_t = typename Conductor::StageMaskType;
 
         uint32_t m_period = std::numeric_limits<uint32_t>::max();
         uint32_t m_next_deadline = 0;
         bool m_armed = false;
 
     protected:
-        virtual void on_tick(uint32_t now_ms) {
-            // do nothing unless overriden
-        }
+        virtual void on_tick(uint32_t now_ms) {}
 
     public:
         explicit PeriodicTask(uint32_t period_ms) : m_period(period_ms) {}
@@ -28,12 +25,6 @@ namespace tempo {
             return m_period;
         }
 
-        /**
-         * @brief Run immediate if not armed, otherwise check if the period has elapsed and run if
-         * it has.
-         *
-         * @param now_ms
-         */
         void tick(uint32_t now_ms) final {
             if (!m_armed) {
                 m_next_deadline = now_ms + m_period;

--- a/lib/tempo/include/tempo/sched/stage_scoped_task.h
+++ b/lib/tempo/include/tempo/sched/stage_scoped_task.h
@@ -1,37 +1,29 @@
 #pragma once
 
 #include "tempo/sched/periodic_task.h"
-#include "tempo/stage/stage_mask.h"
 
 namespace tempo {
 
     /**
-     * @brief Stage-scoped Task. Runs only in stages listed in the mask supplied at construction.
+     * @brief Stage-scoped Task. Runs only in stages listed in the mask supplied at
+     * construction.
      *
-     * @tparam TStageId
-     * @tparam TEvent
+     * @tparam Conductor The concrete Conductor instantiation.
+     * @tparam TEvent An event type. Usually std::variant<...>.
      */
-    template <typename TStageId, typename TEvent>
-    class StageScopedTask : public PeriodicTask<TStageId, TEvent> {
-        using stage_mask_t = StageMask<TStageId>;
-        stage_mask_t m_scope;
+    template <typename Conductor, typename TEvent>
+    class StageScopedTask : public PeriodicTask<Conductor, TEvent> {
+    public:
+        using StageMaskType = typename Conductor::StageMaskType;
+
+    private:
+        StageMaskType m_scope;
 
     public:
-        /**
-         * @brief Construct a new Stage-scoped Task object.
-         *
-         * @param period_ms The period of the Task in milliseconds.
-         * @param scope The stages in which the Task is allowed to run.
-         */
-        StageScopedTask(uint32_t period_ms, stage_mask_t scope)
-            : PeriodicTask<TStageId, TEvent>(period_ms), m_scope(scope) {}
+        StageScopedTask(uint32_t period_ms, StageMaskType scope)
+            : PeriodicTask<Conductor, TEvent>(period_ms), m_scope(scope) {}
 
-        /**
-         * @brief The stages in which the Task is allowed to run.
-         *
-         * @return StageMask<TStageId>
-         */
-        stage_mask_t allowed_stages() const final {
+        StageMaskType allowed_stages() const final {
             return m_scope;
         }
     };

--- a/lib/tempo/include/tempo/sched/task.h
+++ b/lib/tempo/include/tempo/sched/task.h
@@ -1,35 +1,32 @@
 #pragma once
-#include <cstdint>
 
-#include "tempo/stage/stage_mask.h"
+#include <cstddef>
+#include <cstdint>
 
 namespace tempo {
 
     /**
      * @brief Task interface.
      *
-     * @tparam TStageId An enum type representing all possible stages.
+     * @tparam Conductor The concrete Conductor instantiation that drives this Task. Used to
+     *                   derive the StageMask type.
      * @tparam TEvent An event type. Usually std::variant<...>.
      */
-    template <typename TStageId, typename TEvent>
+    template <typename Conductor, typename TEvent>
     class Task {
     public:
-        using stage_mask_t = StageMask<TStageId>;
+        using StageMaskType = typename Conductor::StageMaskType;
 
         virtual ~Task() = default;
 
         /**
          * @brief Required. The period of the Task in milliseconds.
-         *
-         * @return uint32_t
          */
         virtual uint32_t period_ms() const = 0;
 
         /**
-         * @brief Required. This function is called on every scheduler tick if the Task's period has
-         * elapsed and the current Stage is in allowed_stages().
-         *
-         * @param now_ms
+         * @brief Required. Called on every scheduler tick if the Task's period has elapsed
+         * and the current Stage is in allowed_stages().
          */
         virtual void tick(uint32_t now_ms) = 0;
 
@@ -39,38 +36,23 @@ namespace tempo {
             return "<unnamed_task>";
         }
 
-        /**
-         * @brief Lifecycle. Called when the Task is started.
-         *
-         */
         virtual void on_start() {}
 
         /**
-         * @brief Event handling. Called once per event in the queue, in order, for every
-         * Task whose Stage filter matches. The Task inspects the variant and
-         * chooses what to do with it.
-         *
-         * Default implementation ignores all events — a Task that doesn't care
-         * about events simply doesn't override this.
-         *
-         * @param e The event.
-         * @param now_ms The current time in milliseconds.
+         * @brief Called once per event in the queue, in order, for every Task whose Stage
+         * filter matches.
          */
         virtual void on_event(const TEvent& event, uint32_t now_ms) {}
 
         /**
-         * @brief Lifecycle. Called when the Task's Stage changes.
-         *
+         * @brief Called when the Stage changes. Indices map to slots in the Conductor's
+         * stage type list.
          */
-        virtual void on_stage_changed(TStageId from, TStageId to) {}
+        virtual void on_stage_changed(size_t from_idx, size_t to_idx) {}
 
-        /**
-         * @brief The stages in which the Task is allowed to run.
-         *
-         * @return stage_mask_t
-         */
-        virtual stage_mask_t allowed_stages() const {
-            return stage_mask_t::none();
+        virtual StageMaskType allowed_stages() const {
+            return StageMaskType::none();
         }
     };
+
 } // namespace tempo

--- a/lib/tempo/include/tempo/stage/conductor.h
+++ b/lib/tempo/include/tempo/stage/conductor.h
@@ -4,63 +4,97 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "tempo/core/time.h"
+#include "tempo/core/type_list.h"
 #include "tempo/stage/null_stage.h"
 #include "tempo/stage/stage.h"
+#include "tempo/stage/stage_mask.h"
 
 namespace tempo {
 
-    inline constexpr size_t MAX_STAGES = 32;
-
-    template <typename StageId>
+    /**
+     * @brief Owns a set of Stages identified by type, dispatches lifecycle callbacks, and
+     * applies pending transitions on demand.
+     *
+     * Stage identity = type. Each Stage S has a slot index equal to its position in the
+     * Stages... type list. Use register_stage<S>(stage) to bind a slot to a Stage instance,
+     * and request<S>() to schedule a transition.
+     *
+     * Up to 32 stages (mirrors StageMask).
+     *
+     * @tparam Stages The compile-time stage type list.
+     */
+    template <typename... Stages>
     class Conductor {
-    private:
-        using stage_t = tempo::Stage<StageId>;
-        const Clock& m_clock;
+    public:
+        using StageType = Stage<Stages...>;
+        using StageMaskType = StageMask<Stages...>;
 
-        static inline NullStage<StageId> s_null_stage{};
+        static constexpr size_t STAGE_COUNT = sizeof...(Stages);
+        static_assert(STAGE_COUNT > 0, "Conductor needs at least one stage type");
+        static_assert(STAGE_COUNT <= 32, "Conductor supports up to 32 stage types");
 
-        stage_t* lookup_stage(StageId id) const {
-            const auto idx = static_cast<size_t>(id);
-            return idx < MAX_STAGES ? m_stages[idx] : &s_null_stage;
+        template <typename S>
+        static constexpr size_t index_of() {
+            return type_index_v<S, Stages...>;
         }
 
-        std::array<stage_t*, MAX_STAGES> m_stages{};
-        stage_t* m_current = &s_null_stage;
-        StageId m_current_id{};
-        StageId m_pending_id{};
-        bool m_has_pending = false;
+    private:
+        static inline NullStage<Stages...> s_null_stage{};
 
-    public:
-        Conductor(const Clock& clock) : m_clock(clock) {
-            for (auto& s : m_stages) {
-                s = &s_null_stage;
+        std::array<StageType*, STAGE_COUNT> m_slots{};
+        StageType* m_current = &s_null_stage;
+        size_t m_current_idx = STAGE_COUNT;
+
+        bool m_has_pending = false;
+        size_t m_pending_idx = 0;
+
+        StageType* lookup(size_t idx) const {
+            if (idx >= STAGE_COUNT) {
+                return &s_null_stage;
             }
 
-            static_assert(
-                static_cast<std::size_t>(StageId::COUNT_) <= MAX_STAGES,
-                "Too many TStageIds; raise MAX_STAGES or shrink the enum."
-            );
+            StageType* s = m_slots[idx];
+            return s ? s : &s_null_stage;
         }
 
-        void register_stage(StageId id, stage_t& stage) {
-            const auto idx = static_cast<size_t>(id);
-            m_stages[idx] = &stage;
-            stage.set_clock(m_clock);
+    public:
+        Conductor() {
+            for (auto& s : m_slots) {
+                s = nullptr;
+            }
         }
 
-        void start(StageId initial) {
-            m_current_id = initial;
-            m_current = lookup_stage(initial);
+        ~Conductor() = default;
+
+        Conductor(const Conductor&) = delete;
+        Conductor& operator=(const Conductor&) = delete;
+        Conductor(Conductor&&) = delete;
+        Conductor& operator=(Conductor&&) = delete;
+
+        template <typename S>
+        void register_stage(S& stage) {
+            constexpr size_t idx = index_of<S>();
+            m_slots[idx] = &stage;
+        }
+
+        template <typename S>
+        void start() {
+            constexpr size_t idx = index_of<S>();
+            m_current_idx = idx;
+            m_current = lookup(idx);
             m_current->on_enter(*this);
         }
 
-        void request(StageId next) {
-            m_pending_id = next;
+        /**
+         * @brief Request a transition to stage S. on_enter(Conductor&) is called when the
+         * transition is applied.
+         */
+        template <typename S>
+        void request() {
+            m_pending_idx = index_of<S>();
             m_has_pending = true;
         }
 
-        [[nodiscard]]
         bool has_pending() const {
             return m_has_pending;
         }
@@ -70,17 +104,17 @@ namespace tempo {
                 return false;
             }
 
-            const StageId next_id = m_pending_id;
+            const size_t next_idx = m_pending_idx;
             m_has_pending = false;
 
-            if (next_id == m_current_id) {
+            if (next_idx == m_current_idx) {
                 return false;
             }
 
-            stage_t* next = lookup_stage(next_id);
+            StageType* next = lookup(next_idx);
 
             m_current->on_exit(*this);
-            m_current_id = next_id;
+            m_current_idx = next_idx;
             m_current = next;
             m_current->on_enter(*this);
             return true;
@@ -90,22 +124,24 @@ namespace tempo {
             m_current->on_tick(*this, now_ms);
         }
 
-        StageId current_id() const {
-            return m_current_id;
+        size_t current_index() const {
+            return m_current_idx;
         }
 
-        const stage_t* current_stage() const {
+        const StageType* current_stage() const {
             return m_current;
         }
 
-        [[nodiscard]]
         const char* current_name() const {
             return m_current->name();
         }
 
-        const stage_t* stage_for(StageId id) const {
-            const auto idx = static_cast<size_t>(id);
-            return idx < MAX_STAGES ? m_stages[idx] : &s_null_stage;
+        const StageType* stage_at(size_t idx) const {
+            return lookup(idx);
+        }
+
+        const char* name_at(size_t idx) const {
+            return lookup(idx)->name();
         }
     };
 

--- a/lib/tempo/include/tempo/stage/null_stage.h
+++ b/lib/tempo/include/tempo/stage/null_stage.h
@@ -4,8 +4,8 @@
 
 namespace tempo {
 
-    template <typename TStageId>
-    class NullStage : public Stage<TStageId> {
+    template <typename... Stages>
+    class NullStage : public Stage<Stages...> {
     public:
         const char* name() const override {
             return "<null>";

--- a/lib/tempo/include/tempo/stage/stage.h
+++ b/lib/tempo/include/tempo/stage/stage.h
@@ -1,37 +1,41 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
-#include <optional>
-
-#include "tempo/core/time.h"
 
 namespace tempo {
 
-    template <typename TStageId>
+    template <typename... Stages>
     class Conductor;
 
-    template <typename TStageId>
+    /**
+     * @brief Stage interface.
+     *
+     * Each Stage subclass represents one mode the application can be in. The Conductor that owns
+     * the Stage is passed to every lifecycle callback so the Stage can request transitions
+     * (`conductor.request<Other>()`) or read its current_index().
+     *
+     * @tparam Conductor The concrete Conductor instantiation that owns this Stage. Forward
+     * declaration is sufficient.
+     */
+    template <typename ...Stages>
     class Stage {
-    private:
-        friend class Conductor<TStageId>;
-        std::optional<std::reference_wrapper<const Clock>> m_clock;
-
-        void set_clock(const Clock& clock) {
-            m_clock = clock;
-        }
-
     public:
-        using ConductorType = tempo::Conductor<TStageId>;
-
+        using Conductor = tempo::Conductor<Stages...>;
         virtual ~Stage() = default;
 
         virtual const char* name() const {
             return "<unnamed_stage>";
-        };
+        }
 
-        virtual void on_enter(ConductorType& conductor) {};
-        virtual void on_exit(ConductorType& conductor) {};
-        virtual void on_tick(ConductorType& conductor, uint32_t now_ms) {};
+        virtual void on_enter(Conductor& conductor) {
+            //
+        }
+        virtual void on_exit(Conductor& conductor) {
+            //
+        }
+        virtual void on_tick(Conductor& conductor, uint32_t now_ms) {
+            //
+        }
     };
+
 } // namespace tempo

--- a/lib/tempo/include/tempo/stage/stage_mask.h
+++ b/lib/tempo/include/tempo/stage/stage_mask.h
@@ -1,27 +1,41 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <initializer_list>
-#include <type_traits>
+
+#include "tempo/core/type_list.h"
 
 namespace tempo {
 
-    template <typename TStageId>
+    /**
+     * @brief Bitset over a compile-time stage type list.
+     *
+     * StageMask<Idle, Run, Error>::of<Idle, Run>() yields a mask with the bits matching
+     * those types' positions in the type list. Indices map 1:1 to Conductor slot indices.
+     *
+     * Up to 32 stages.
+     *
+     * @tparam Stages The compile-time stage type list (same order as Conductor's).
+     */
+    template <typename... Stages>
     class StageMask {
-        static_assert(std::is_enum_v<TStageId>, "TStageId must be a scoped enum");
-        using underlying_t = std::underlying_type_t<TStageId>;
-
-        static constexpr uint32_t mask_bit(TStageId id) {
-            return uint32_t{1} << static_cast<underlying_t>(id);
-        }
+    private:
+        uint32_t m_bits = 0;
 
     public:
+        static constexpr size_t STAGE_COUNT = sizeof...(Stages);
+        static_assert(STAGE_COUNT <= 32, "StageMask supports up to 32 stages");
+
         constexpr StageMask() = default;
 
-        constexpr StageMask(std::initializer_list<TStageId> ids) {
-            for (const auto& id : ids) {
-                m_bits |= mask_bit(id);
-            }
+        /**
+         * @brief Build a mask containing the given stage types.
+         */
+        template <typename... Selected>
+        static constexpr StageMask of() {
+            StageMask mask;
+            ((mask.m_bits |= (uint32_t{1} << type_index_v<Selected, Stages...>) ), ...);
+            return mask;
         }
 
         static constexpr StageMask none() {
@@ -29,19 +43,20 @@ namespace tempo {
         }
 
         static constexpr StageMask all() {
-            const auto count = static_cast<underlying_t>(TStageId::COUNT_);
-            static_assert(
-                static_cast<std::size_t>(TStageId::COUNT_) <= 32,
-                "Too many TStageIds; StageMask supports up to 32."
-            );
-            StageMask m;
-            m.m_bits = (count >= 32) ? 0xFFFFFFFFu : ((uint32_t{1} << count) - 1u);
-            return m;
+            StageMask mask;
+            mask.m_bits = 0xFFFFFFFFu;
+            return mask;
         }
 
-        constexpr bool contains(TStageId id) const {
-            return (m_bits & mask_bit(id)) != 0;
+        template <typename S>
+        constexpr bool contains() const {
+            return (m_bits & (uint32_t{1} << type_index_v<S, Stages...>) ) != 0;
         }
+
+        constexpr bool contains_index(size_t idx) const {
+            return idx < 32 && (m_bits & (uint32_t{1} << idx)) != 0;
+        }
+
         constexpr bool empty() const {
             return m_bits == 0;
         }
@@ -86,18 +101,6 @@ namespace tempo {
         friend constexpr bool operator!=(StageMask a, StageMask b) {
             return a.m_bits != b.m_bits;
         }
-
-        constexpr TStageId first() const {
-            for (underlying_t i = 0; i < static_cast<underlying_t>(TStageId::COUNT_); ++i) {
-                if (m_bits & (uint32_t{1} << i)) {
-                    return static_cast<TStageId>(i);
-                }
-            }
-            return TStageId::COUNT_;
-        }
-
-    private:
-        uint32_t m_bits = 0;
     };
 
 } // namespace tempo

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 
 #include <cmath>
 
+#include "tempo/diag/logger.h"
+
 #ifdef HW1_1_V2
 #include <tempo/tempo.h>
 
@@ -10,7 +12,7 @@
  *
  */
 
-// Hardware
+// —— Hardware
 
 class ArduinoClock : public tempo::Clock {
 public:
@@ -26,48 +28,82 @@ public:
     }
 };
 
-// Events
+// —— Events
 
-class LoggingEmitted {};
-using Event = tempo::Events<LoggingEmitted>;
-
-// Stages
-
-enum class StageId : uint8_t {
-    INIT,
-    MAIN,
-    ERROR,
-    COUNT_,
+class LoggingEmitted {
+    uint32_t ms;
 };
 
-// Tasks
+using Event = tempo::Events<LoggingEmitted>;
+// —— Stage forward declarations
 
-class LoggingTask : public tempo::BackgroundTask<StageId, Event>,
-                    public tempo::UseLog<LoggingTask> {
+class BootStage;
+class ObtainStage;
+
+// —— Application alias (depends on stage list, not on stage definitions)
+
+using App = tempo::Application<Event, BootStage, ObtainStage>;
+
+// —— Stage definitions
+
+class BootStage : public App::Stage, public tempo::UseLog<BootStage> {
+public:
+    static constexpr const char* LOG_TAG = "BootStage";
+
+    const char* name() const override {
+        return "INIT";
+    }
+
+    void on_tick(Conductor& conductor, uint32_t now_ms) override {
+        if (!tempo::time_reached(now_ms, 3000)) {
+            return;
+        }
+
+        log.info("BootStage: 3 seconds elapsed, requesting ObtainStage");
+        conductor.request<ObtainStage>();
+    }
+};
+
+class ObtainStage : public App::Stage {
+public:
+    const char* name() const override {
+        return "MAIN";
+    }
+};
+
+// —— Tasks
+
+class LoggingTask : public App::StageScopedTask, public tempo::UseLog<LoggingTask> {
 public:
     static constexpr const char* LOG_TAG = "LoggingTask";
-    LoggingTask() : tempo::BackgroundTask<StageId, Event>(1000) {}
+    static constexpr uint32_t PERIOD_MS = 1000;
+
+    LoggingTask() : App::StageScopedTask(PERIOD_MS, StageMaskType::of<ObtainStage>()) {}
 
     void on_tick(uint32_t now_ms) override {
         log.info("Time since boot: %dms", now_ms);
     }
 };
 
-// Application
-using App = tempo::Application<StageId, Event>;
+// —— Application
 
 ArduinoClock arduino_clock;
 ArduinoStreamWriter arduino_stream_writer;
 
 App app(arduino_clock, arduino_stream_writer);
 
+BootStage boot_stage;
+ObtainStage obtain_stage;
+
 LoggingTask logging_task;
 
 void setup() {
-
     Serial.begin(115200);
     app.add_task(logging_task);
-    app.start(StageId::MAIN);
+
+    app.register_stage(boot_stage);
+    app.register_stage(obtain_stage);
+    app.start<BootStage>();
 }
 
 void loop() {


### PR DESCRIPTION
## Summary

- `Conductor`, `StageMask`, and `Stage` are now templated on the stage type pack (`Stages...`) instead of using a separate StageId enum—this simplifies the user code
- New `type_index_v<T, Ts...>` compile-time helper maps a stage type to its slot index, with a hard compile error if the type isn't in the list
- `Application` exposes `Stage`, `Task`, `BackgroundTask`, `PeriodicTask`, `StageScopedTask`, `Conductor`, `Scheduler`, `Queue`, `Publisher` aliases so user code doesn't need to thread the conductor + event template args through every base class
- `app.register_stage<S>(s)` / `app.start<S>()` / `conductor.request<S>()` are all type-safe — the type list is the single source of truth
- v2 stub in `main.cpp` rewritten to use `BootStage` / `ObtainStage` as types instead of an enum

## Example

```cpp
class BootStage;
class ObtainStage;
using App = tempo::Application<Event, BootStage, ObtainStage>;

class BootStage : public App::Stage {
    void on_tick(Conductor& c, uint32_t now) override {
        c.request<ObtainStage>();
    }
};

class LoggingTask : public App::BackgroundTask { ... };
```