### PR TITLE
feat(ap33772): v2 AP33772 header-only driver

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: "
   -cppcoreguidelines-pro-type-cstyle-cast,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard

--- a/.clangd
+++ b/.clangd
@@ -6,3 +6,9 @@ CompileFlags:
   BuiltinHeaders: QueryDriver
   Remove:
     - -march=*
+
+---
+If:
+  PathMatch: .*\.(h|hpp)$
+CompileFlags:
+  Add: [-xc++]

--- a/lib/AP33772/AP33772.h
+++ b/lib/AP33772/AP33772.h
@@ -1,0 +1,554 @@
+/**
+ * @file AP33772.h
+ * AP33772 USB PD 3.0 Sink Controller Driver
+ *
+ * Reference: AP33772 Sink Controller EVB User Guide
+ * https://www.diodes.com/assets/Evaluation-Boards/AP33772-Sink-Controller-EVB-User-Guide.pdf
+ *
+ * Register map and bit definitions derived from official documentation.
+ */
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+#include "I2CDevice.h"
+#include "usb_pd_types.h"
+
+namespace ap33772 {
+
+    template <typename T>
+    constexpr T clamp(T v, T lo, T hi) {
+        return v < lo ? lo : (v > hi ? hi : v);
+    }
+
+    // ── AP33772 constants
+    constexpr uint8_t ADDRESS = 0x51;
+    constexpr uint8_t MAX_PDO = 7;
+    constexpr uint8_t SRCPDO_LENGTH = 28; // 7 PDOs x 4 bytes each
+
+    // ── Register addresses (Table 4 – EVB User Guide)
+    // clang-format off
+    namespace reg {
+        constexpr uint8_t SRCPDO  = 0x00; // RO   28 bytes  Source PDOs (7 x 4 bytes)
+        constexpr uint8_t PDONUM  = 0x1C; // RO    1 byte   Number of valid source PDOs
+        constexpr uint8_t STATUS  = 0x1D; // RC    1 byte   Status (read-clear)
+        constexpr uint8_t MASK    = 0x1E; // RW    1 byte   Interrupt enable mask
+        constexpr uint8_t VOLTAGE = 0x20; // RO    1 byte   VBUS voltage   (LSB = 80 mV)
+        constexpr uint8_t CURRENT = 0x21; // RO    1 byte   VBUS current   (LSB = 24 mA)
+        constexpr uint8_t TEMP    = 0x22; // RO    1 byte   NTC temperature (LSB = 1 °C)
+        constexpr uint8_t OCPTHR  = 0x23; // RW    1 byte   OCP threshold (LSB = 50 mA)
+        constexpr uint8_t OTPTHR  = 0x24; // RW    1 byte   OTP threshold (LSB = 1 °C)
+        constexpr uint8_t DRTHR   = 0x25; // RW    1 byte   Derating threshold (LSB = 1 °C)
+        constexpr uint8_t TR25    = 0x28; // RW    2 bytes  NTC resistance @ 25 °C  (Ω)
+        constexpr uint8_t TR50    = 0x2A; // RW    2 bytes  NTC resistance @ 50 °C  (Ω)
+        constexpr uint8_t TR75    = 0x2C; // RW    2 bytes  NTC resistance @ 75 °C  (Ω)
+        constexpr uint8_t TR100   = 0x2E; // RW    2 bytes  NTC resistance @ 100 °C (Ω)
+        constexpr uint8_t RDO     = 0x30; // WO    4 bytes  Request Data Object
+        constexpr uint8_t VID     = 0x34; // RW    2 bytes  Vendor ID (reserved)
+        constexpr uint8_t PID     = 0x36; // RW    2 bytes  Product ID (reserved)
+    } // namespace reg
+    // clang-format on
+
+    // ── Register LSB scale factors
+    constexpr int VOLTAGE_LSB = 80; // mV per LSB
+    constexpr int CURRENT_LSB = 24; // mA per LSB
+    constexpr int OCP_LSB = 50;     // mA per LSB
+
+    // ── NTC defaults (Table 4)
+    constexpr int NTC_DEFAULT_TR25 = 10000; // 0x2710
+    constexpr int NTC_DEFAULT_TR50 = 4161;  // 0x1041
+    constexpr int NTC_DEFAULT_TR75 = 1928;  // 0x0788
+    constexpr int NTC_DEFAULT_TR100 = 974;  // 0x03CE
+
+    /**
+     * STATUS register (0x1D) — read-clear (Table 7)
+     */
+    struct status_reg_t {
+        union {
+            struct {
+                uint8_t ready : 1;   // B0 – bits[2:1] valid when set
+                uint8_t success : 1; // B1 – negotiation result
+                uint8_t newpdo : 1;  // B2 – source PDOs received
+                uint8_t : 1;         // B3 – reserved
+                uint8_t ovp : 1;     // B4 – over-voltage protection
+                uint8_t ocp : 1;     // B5 – over-current protection
+                uint8_t otp : 1;     // B6 – over-temp protection
+                uint8_t dr : 1;      // B7 – derating started
+            };
+            uint8_t raw;
+        };
+    };
+
+    /**
+     * MASK register (0x1E) — interrupt enable (Table 9)
+     *
+     * Mirrors STATUS layout. Set bit to 1 to enable interrupt for that event.
+     * Default value: 0x01 (only READY enabled).
+     */
+    struct mask_reg_t {
+        union {
+            struct {
+                uint8_t ready_en : 1;   // B0 – default 1
+                uint8_t success_en : 1; // B1
+                uint8_t newpdo_en : 1;  // B2
+                uint8_t : 1;            // B3 – reserved
+                uint8_t ovp_en : 1;     // B4
+                uint8_t ocp_en : 1;     // B5
+                uint8_t otp_en : 1;     // B6
+                uint8_t dr_en : 1;      // B7
+            };
+            uint8_t raw;
+        };
+    };
+
+    using delay_fn_t = void (*)(unsigned long);
+
+    /**
+     * AP33772 USB PD 3.0 Sink Controller driver
+     *
+     * Supports multiple PPS profiles, fixed PDOs, voltage/current requests,
+     * protection thresholds, and NTC temperature sensing.
+     */
+    class AP33772 {
+    private:
+        const I2CDevice& m_i2c;
+        const delay_fn_t m_delay;
+
+        int m_pdo_active = 0;
+        int m_pdo_count = 0;
+        std::array<pdo_t, MAX_PDO> m_pdo_list{0};
+
+        int m_pps_count = 0;
+        int m_pps_voltage_20mv = 0; // Last PPS voltage in 20 mV units
+        uint8_t m_pps_mask = 0;     // Bitmask: bit N set if PDO[N] is PPS
+
+        // —— RDO helpers
+
+        bool write_rdo(const rdo_t& rdo) const {
+            std::array<uint8_t, 4> buffer{0};
+            memcpy(buffer.data(), &rdo.raw, buffer.size());
+            return m_i2c.write(reg::RDO, buffer.data(), buffer.size());
+        }
+
+        bool request_pps(int pdo_index, int voltage_mv, int current_ma) {
+            const int voltage_20mv = voltage_mv / PPS_RDO_VOLTAGE_LSB;
+
+            const rdo_t rdo = {
+                .pps = {
+                    .op_current = static_cast<uint32_t>(current_ma / PPS_RDO_CURRENT_LSB),
+                    .voltage = static_cast<uint32_t>(voltage_20mv),
+                    .obj_position = static_cast<uint32_t>(pdo_index + 1),
+                }
+            };
+
+            const bool success = write_rdo(rdo);
+            if (success) {
+                m_pdo_active = pdo_index;
+                m_pps_voltage_20mv = voltage_20mv;
+            }
+
+            return success;
+        }
+
+        bool request_fixed(int pdo_index, int current_ma) {
+            const rdo_t rdo = {
+                .fixed = {
+                    .max_current = static_cast<uint32_t>(current_ma / FIXED_RDO_CURRENT_LSB),
+                    .op_current = static_cast<uint32_t>(current_ma / FIXED_RDO_CURRENT_LSB),
+                    .obj_position = pdo_index + 1u,
+                }
+            };
+
+            const bool success = write_rdo(rdo);
+            if (success) {
+                m_pdo_active = pdo_index;
+            }
+
+            return success;
+        }
+
+        /** Write a 16-bit little-endian NTC register */
+        bool write_ntc_register(uint8_t reg, int value) const {
+            std::array<uint8_t, 2> buffer{
+                static_cast<uint8_t>(value & 0xFF),
+                static_cast<uint8_t>((value >> 8) & 0xFF),
+            };
+
+            return m_i2c.write(reg, buffer.data(), buffer.size());
+        }
+
+        int clamp_voltage(int index, int voltage_mv) const {
+            int min_voltage = m_pdo_list.at(index).min_voltage_mv();
+            int max_voltage = m_pdo_list.at(index).max_voltage_mv();
+            return clamp(voltage_mv, min_voltage, max_voltage);
+        }
+
+        int clamp_current(int index, int current_ma) const {
+            int max_current = m_pdo_list.at(index).max_current_ma();
+            return clamp(current_ma, 0, max_current);
+        }
+
+    public:
+        /**
+         * Construct a new AP33772 driver
+         * @param i2c   I2C device interface (e.g. TwoWireDevice)
+         * @param delay Delay function (ms). Use Arduino `delay` in firmware, no-op in tests.
+         */
+        AP33772(const I2CDevice& i2c, const delay_fn_t delay) : m_i2c(i2c), m_delay(delay) {}
+
+        int get_count_pdo() const {
+            return m_pdo_count;
+        }
+
+        int get_count_pps() const {
+            return m_pps_count;
+        }
+
+        int get_active_pdo() const {
+            return m_pdo_active;
+        }
+
+        bool has_pps_profile() const {
+            return m_pps_mask != 0;
+        }
+
+        /**
+         * Initialize the controller and load source PDOs from charger
+         * @return true if negotiation succeeded and PDOs were loaded
+         */
+        [[nodiscard]]
+        bool begin() {
+            const status_reg_t status = read_status();
+            if (status.ovp || status.ocp || !status.ready || !status.success || !status.newpdo) {
+                return false;
+            }
+
+            m_delay(10);
+
+            uint8_t count = 0;
+            if (!m_i2c.read(reg::PDONUM, &count, 1)) {
+                return false;
+            }
+
+            m_pdo_count = clamp<int>(count, 0, MAX_PDO);
+
+            std::array<uint8_t, SRCPDO_LENGTH> pdo_buf{0};
+            if (!m_i2c.read(reg::SRCPDO, pdo_buf.data(), pdo_buf.size())) {
+                return false;
+            }
+
+            m_pps_mask = 0;
+            m_pps_count = 0;
+
+            for (int i = 0; i < m_pdo_count; i++) {
+                memcpy(&m_pdo_list.at(i).raw, &pdo_buf.at(i * 4), 4);
+
+                if (m_pdo_list.at(i).is_pps()) {
+                    m_pps_mask |= (1 << i);
+                    m_pps_count++;
+                }
+            }
+
+            return true;
+        }
+
+        // ── Power requests
+
+        /**
+         * Select a fixed PDO by index
+         * @param pdo_index zero-based PDO index (must be a fixed PDO)
+         * @return true if request was sent, false on invalid index or I2C error
+         */
+        [[nodiscard]]
+        bool set_pdo(int pdo_index) {
+            if (!is_index_fixed(pdo_index)) {
+                return false;
+            }
+
+            return request_fixed(pdo_index, m_pdo_list.at(pdo_index).max_current_ma());
+        }
+
+        /**
+         * Request a specific PPS profile with voltage and current
+         * @param pdo_index zero-based PDO index (must be a PPS APDO)
+         * @param voltage_mv target voltage in millivolts (clamped to range)
+         * @param current_ma current limit in milliamps (clamped to max)
+         * @return true if request was sent, false on invalid index or I2C error
+         */
+        [[nodiscard]]
+        bool set_pps_pdo(int pdo_index, int voltage_mv, int current_ma) {
+            if (!is_index_pps(pdo_index)) {
+                return false;
+            }
+
+            voltage_mv = clamp_voltage(pdo_index, voltage_mv);
+            current_ma = clamp_current(pdo_index, current_ma);
+
+            return request_pps(pdo_index, voltage_mv, current_ma);
+        }
+
+        /**
+         * Adjust voltage on the active PPS profile
+         *
+         * Only works if the active profile is PPS. Uses max current.
+         * For specific current, use set_pps_pdo() or call set_current() after.
+         *
+         * @param voltage_mv target voltage in millivolts (clamped to range)
+         * @return true if request was sent, false if active profile is fixed or I2C error
+         */
+        [[nodiscard]]
+        bool set_voltage(int voltage_mv) {
+            if (!is_index_pps(m_pdo_active)) {
+                return false;
+            }
+
+            int voltage = clamp_voltage(m_pdo_active, voltage_mv);
+            int max_current = get_pdo_max_current(m_pdo_active);
+            return request_pps(m_pdo_active, voltage, max_current);
+        }
+
+        /**
+         * Adjust current on the active profile (PPS or fixed)
+         * @param current_ma current limit in milliamps (clamped to max)
+         * @return true if request was sent, false on I2C error
+         */
+        [[nodiscard]]
+        bool set_current(int current_ma) {
+
+            int max_current = get_pdo_max_current(m_pdo_active);
+            int clamped_ma = clamp(current_ma, 0, max_current);
+
+            if (is_index_pps(m_pdo_active)) {
+                return request_pps(
+                    m_pdo_active, m_pps_voltage_20mv * PPS_RDO_VOLTAGE_LSB, clamped_ma
+                );
+            }
+
+            return request_fixed(m_pdo_active, clamped_ma);
+        }
+
+        // ── Live readings
+
+        /**
+         * Read VBUS voltage from the AP33772
+         * @return voltage in millivolts (LSB = 80 mV), -1 on I2C error
+         */
+        int read_voltage() const {
+            uint8_t buf = 0;
+            if (!m_i2c.read(reg::VOLTAGE, &buf, 1)) {
+                return -1;
+            }
+            return buf * VOLTAGE_LSB;
+        }
+
+        /**
+         * Read VBUS current from the AP33772
+         * @return current in milliamps (LSB = 24 mA), -1 on I2C error
+         */
+        int read_current() const {
+            uint8_t buf = 0;
+            if (!m_i2c.read(reg::CURRENT, &buf, 1)) {
+                return -1;
+            }
+            return buf * CURRENT_LSB;
+        }
+
+        /**
+         * Read NTC temperature from the AP33772
+         * @return temperature in degrees Celsius, -1 on I2C error
+         */
+        int read_temp() const {
+            uint8_t buf = 0;
+            if (!m_i2c.read(reg::TEMP, &buf, 1)) {
+                return -1;
+            }
+            return buf;
+        }
+
+        /**
+         * Read the STATUS register (read-clear)
+         * @return status_reg_t with named bit fields
+         */
+        status_reg_t read_status() const {
+            status_reg_t status = {0};
+            m_i2c.read(reg::STATUS, &status.raw, 1);
+            return status;
+        }
+
+        /**
+         * Find a PPS profile that can deliver the requested V/I
+         * @param voltage_mv target voltage in millivolts
+         * @param current_ma target current in milliamps
+         * @return zero-based PDO index, or -1 if no suitable PPS found
+         */
+        int find_pps_index_by_voltage_current(int voltage_mv, int current_ma) const {
+            for (int i = 0; i < m_pdo_count; i++) {
+                if (!is_index_pps(i)) {
+                    continue;
+                }
+
+                if (voltage_mv >= m_pdo_list.at(i).min_voltage_mv() &&
+                    voltage_mv <= m_pdo_list.at(i).max_voltage_mv() &&
+                    current_ma <= m_pdo_list.at(i).max_current_ma()) {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /**
+         * Check if a PDO index is valid
+         */
+        bool is_index_valid(int index) const {
+            return index >= 0 && index < m_pdo_count;
+        }
+
+        /**
+         * Check if a PDO index is a PPS APDO
+         */
+        bool is_index_pps(int index) const {
+            return is_index_valid(index) && ((m_pps_mask >> index) & 1);
+        }
+
+        /**
+         * Check if a PDO index is a fixed-supply PDO
+         */
+        bool is_index_fixed(int index) const {
+            return is_index_valid(index) && m_pdo_list.at(index).is_fixed();
+        }
+
+        /**
+         * Get PDO voltage (fixed: nominal, PPS: max)
+         * @param index zero-based PDO index
+         * @return voltage in millivolts, -1 if invalid index
+         */
+        int get_pdo_max_voltage(int index) const {
+            return is_index_valid(index) ? m_pdo_list.at(index).max_voltage_mv() : -1;
+        }
+
+        /**
+         * Get PDO minimum voltage (fixed: same as nominal, PPS: min)
+         * @param index zero-based PDO index
+         * @return voltage in millivolts, -1 if invalid index
+         */
+        int get_pdo_min_voltage(int index) const {
+            return is_index_valid(index) ? m_pdo_list.at(index).min_voltage_mv() : -1;
+        }
+
+        /**
+         * Get PDO maximum current
+         * @param index zero-based PDO index
+         * @return current in milliamps, -1 if invalid index
+         */
+        int get_pdo_max_current(int index) const {
+            return is_index_valid(index) ? m_pdo_list.at(index).max_current_ma() : -1;
+        }
+
+        // ── Protection thresholds
+
+        /**
+         * Set over-current protection threshold
+         * @param current_ma threshold in milliamps (LSB = 50 mA, range 0..12750)
+         * @return false if out of range or I2C error
+         */
+        [[nodiscard]]
+        bool set_ocp_threshold(int current_ma) const {
+            if (current_ma < 0 || current_ma > 255 * OCP_LSB) {
+                return false;
+            }
+            const uint8_t val = current_ma / OCP_LSB;
+            return m_i2c.write(reg::OCPTHR, &val, 1);
+        }
+
+        /**
+         * Set over-temperature protection threshold
+         * @param temp_c threshold in degrees Celsius (range 0..255, default 120 °C)
+         * @return false if out of range or I2C error
+         */
+        [[nodiscard]]
+        bool set_otp_threshold(int temp_c) const {
+            if (temp_c < 0 || temp_c > 255) {
+                return false;
+            }
+            const uint8_t val = temp_c;
+            return m_i2c.write(reg::OTPTHR, &val, 1);
+        }
+
+        /**
+         * Set thermal derating threshold
+         * @param temp_c threshold in degrees Celsius (range 0..255, default 120 °C)
+         * @return false if out of range or I2C error
+         */
+        [[nodiscard]]
+        bool set_derating_threshold(int temp_c) const {
+            if (temp_c < 0 || temp_c > 255) {
+                return false;
+            }
+            const uint8_t val = temp_c;
+            return m_i2c.write(reg::DRTHR, &val, 1);
+        }
+
+        // ── NTC configuration
+
+        /**
+         * Set NTC thermistor resistance at four temperature points
+         * @param tr25  resistance at 25 °C in ohms  (default 10000)
+         * @param tr50  resistance at 50 °C in ohms  (default 4161)
+         * @param tr75  resistance at 75 °C in ohms  (default 1928)
+         * @param tr100 resistance at 100 °C in ohms (default 974)
+         */
+        [[nodiscard]]
+        bool set_ntc(int tr25, int tr50, int tr75, int tr100) const {
+            bool success = true;
+            success &= write_ntc_register(reg::TR25, tr25);
+            m_delay(5);
+            success &= write_ntc_register(reg::TR50, tr50);
+            m_delay(5);
+            success &= write_ntc_register(reg::TR75, tr75);
+            m_delay(5);
+            success &= write_ntc_register(reg::TR100, tr100);
+            return success;
+        }
+
+        // ── Interrupt mask
+
+        /**
+         * Read the current interrupt mask register
+         * @return mask_reg_t with named bit fields
+         */
+        mask_reg_t read_mask() const {
+            mask_reg_t mask = {0};
+            m_i2c.read(reg::MASK, &mask.raw, 1);
+            return mask;
+        }
+
+        /**
+         * Write the interrupt mask register
+         * @param mask mask_reg_t with desired bits set
+         */
+        [[nodiscard]]
+        bool write_mask(const mask_reg_t mask) const {
+            return m_i2c.write(reg::MASK, &mask.raw, 1);
+        }
+
+        // ── Utility
+
+        /**
+         * Hard reset the AP33772 and PD source
+         *
+         * Sends all-zero RDO which triggers a hard reset. Both AP33772 and
+         * PD source return to default states. Output NMOS is turned off.
+         */
+        [[nodiscard]]
+        bool reset() const {
+            std::array<uint8_t, 4> buffer{0};
+            return m_i2c.write(reg::RDO, buffer.data(), buffer.size());
+        }
+
+    };
+
+} // namespace ap33772

--- a/lib/AP33772/AP33772_debug.h
+++ b/lib/AP33772/AP33772_debug.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <cstddef>
+#include <cstdio>
+
+#include "AP33772.h"
+
+namespace ap33772 {
+
+    /**
+     * Format all source PDOs into `out` as null-terminated multi-line text.
+     *
+     * Hardware-agnostic: caller forwards bytes to Serial, Logger, file,
+     * ring buffer, or any other sink.
+     *
+     * @return Bytes written (excluding null terminator). Output is truncated to cap-1 if the buffer
+     * is too small.
+     */
+    inline size_t format_pdo(const AP33772& ap, char* out, size_t cap) {
+        if (cap == 0) {
+            return 0;
+        }
+
+        size_t total = 0;
+        auto append = [&](const char* fmt, auto... args) {
+            if (total + 1 >= cap) {
+                return;
+            }
+
+            const int n = snprintf(&out[total], cap - total, fmt, args...);
+            if (n > 0) {
+                total += static_cast<size_t>(n);
+                if (total >= cap) {
+                    total = cap - 1;
+                }
+            }
+        };
+
+        append("Source PDO Number = %d\n", ap.get_count_pdo());
+        append("PPS Profiles = %d\n", ap.get_count_pps());
+
+        for (int i = 0; i < ap.get_count_pdo(); i++) {
+            if (ap.is_index_pps(i)) {
+                append(
+                    "PDO[%d] - PPS : %.1fV~%.1fV @ %.1fA\n", i + 1,
+                    ap.get_pdo_min_voltage(i) / 1000.0, ap.get_pdo_max_voltage(i) / 1000.0,
+                    ap.get_pdo_max_current(i) / 1000.0
+                );
+            } else {
+                append(
+                    "PDO[%d] - Fixed : %.1fV @ %.1fA\n", i + 1, ap.get_pdo_max_voltage(i) / 1000.0,
+                    ap.get_pdo_max_current(i) / 1000.0
+                );
+            }
+        }
+
+        append("===============================================\n");
+        return total;
+    }
+
+} // namespace ap33772

--- a/lib/AP33772/ArduinoTwoWireDevice.h
+++ b/lib/AP33772/ArduinoTwoWireDevice.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <Arduino.h>
+#include <Wire.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "I2CDevice.h"
+
+/**
+ * @brief Concrete I2C device using Arduino TwoWire
+ */
+class ArduinoTwoWireDevice : public I2CDevice {
+private:
+    TwoWire& m_wire;
+    const uint8_t m_address;
+
+public:
+    /**
+     * Construct TwoWire-backed I2C device
+     * @param wire    TwoWire bus instance
+     * @param address 7-bit I2C slave address
+     */
+    ArduinoTwoWireDevice(TwoWire& wire, const uint8_t address) : m_wire(wire), m_address(address) {}
+
+protected:
+    bool read_bytes(uint8_t reg, uint8_t* const buf, size_t len) const override {
+        m_wire.beginTransmission(m_address);
+        m_wire.write(reg);
+        if (m_wire.endTransmission() != 0) {
+            return false;
+        }
+
+        if (m_wire.requestFrom(m_address, len) < len) {
+            return false;
+        }
+
+        for (size_t i = 0; i < len && m_wire.available(); i++) {
+            buf[i] = m_wire.read();
+        }
+
+        return true;
+    }
+
+    bool write_bytes(uint8_t reg, const uint8_t* const buf, size_t len) const override {
+        m_wire.beginTransmission(m_address);
+        m_wire.write(reg);
+        for (size_t i = 0; i < len; i++) {
+            m_wire.write(buf[i]);
+        }
+
+        return m_wire.endTransmission() == 0;
+    }
+};

--- a/lib/AP33772/I2CDevice.h
+++ b/lib/AP33772/I2CDevice.h
@@ -1,0 +1,54 @@
+#pragma once
+/**
+ * @file I2CDevice.h
+ * I2C device abstraction (header-only)
+ *
+ * Abstract interface for I2C register read/write.
+ * Concrete implementations live in separate headers
+ * (see ArduinoTwoWireDevice.h for an Arduino TwoWire backend).
+ */
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * Abstract I2C device interface
+ *
+ * Provides register-level read/write contract.
+ * Decouples drivers from specific I2C implementation.
+ */
+class I2CDevice {
+public:
+    virtual ~I2CDevice() = default;
+
+    /**
+     * Read len bytes from register into buf (non-virtual; calls do_read).
+     * @return true on success, false on NACK or short read
+     */
+    bool read(uint8_t reg, uint8_t* const buf, size_t len) const {
+        return read_bytes(reg, buf, len);
+    }
+
+    template <size_t N>
+    constexpr bool read(uint8_t reg, std::array<uint8_t, N>& buf) const {
+        return read(reg, buf.data(), buf.size());
+    }
+
+    /**
+     * Write len bytes from buf to register (non-virtual; calls do_write).
+     * @return true on success, false on NACK
+     */
+    bool write(uint8_t reg, const uint8_t* const buf, size_t len) const {
+        return write_bytes(reg, buf, len);
+    }
+
+    template <size_t N>
+    constexpr bool write(uint8_t reg, const std::array<uint8_t, N>& buf) const {
+        return write(reg, buf.data(), buf.size());
+    }
+
+protected:
+    virtual bool read_bytes(uint8_t reg, uint8_t* const buf, size_t len) const = 0;
+    virtual bool write_bytes(uint8_t reg, const uint8_t* const buf, size_t len) const = 0;
+};

--- a/lib/AP33772/usb_pd_types.h
+++ b/lib/AP33772/usb_pd_types.h
@@ -1,0 +1,171 @@
+/**
+ * @file usb_pd_types.h
+ * USB PD 3.0 Power Delivery Object types and helper functions for use exclusively with AP33772 PD
+ * Sink Controller. Note that this may not be accurate for other controllers.
+ *
+ * Struct layouts and scale factors from AP33772 Sink Controller EVB User Guide.
+ * ref: https://www.diodes.com/assets/Evaluation-Boards/AP33772-Sink-Controller-EVB-User-Guide.pdf
+ */
+#ifndef USB_PD_TYPES_H
+#define USB_PD_TYPES_H
+
+#include <cstdint>
+
+// ── PDO field scale factors
+#define FIXED_PDO_VOLTAGE_LSB 50  // mV per LSB  B[19:10]
+#define FIXED_PDO_CURRENT_LSB 10  // mA per LSB  B[9:0]
+#define PPS_PDO_VOLTAGE_LSB   100 // mV per LSB  B[24:17], B[15:8]
+#define PPS_PDO_CURRENT_LSB   50  // mA per LSB  B[6:0]
+
+// ── RDO field scale factors
+#define FIXED_RDO_CURRENT_LSB 10 // mA per LSB  B[19:10], B[9:0]
+#define PPS_RDO_VOLTAGE_LSB   20 // mV per LSB  B[19:9]
+#define PPS_RDO_CURRENT_LSB   50 // mA per LSB  B[6:0]
+
+/**
+ * Source Power Data Object
+ *
+ * Fixed Supply PDO:
+ *   B[31:30] = 00  Fixed supply
+ *   B[29:20]       Reserved
+ *   B[19:10]       Voltage in 50 mV units
+ *   B[9:0]         Maximum current in 10 mA units
+ *
+ * PPS APDO:
+ *   B[31:30] = 11  Augmented PDO
+ *   B[29:28] = 00  Programmable Power Supply
+ *   B[27:25]       Reserved
+ *   B[24:17]       Max voltage in 100 mV units
+ *   B[16]          Reserved
+ *   B[15:8]        Min voltage in 100 mV units
+ *   B[7]           Reserved
+ *   B[6:0]         Max current in 50 mA units
+ */
+struct pdo_t {
+
+    // clang-format off
+    union {
+        struct {
+            uint32_t max_current : 10;
+            uint32_t voltage     : 10;
+            uint32_t             : 10;
+            uint32_t type        : 2;
+        } fixed;
+        struct {
+            uint32_t max_current : 7;
+            uint32_t             : 1;
+            uint32_t min_voltage : 8;
+            uint32_t             : 1;
+            uint32_t max_voltage : 8;
+            uint32_t             : 3;
+            uint32_t apdo_type   : 2;
+            uint32_t type        : 2;
+        } pps;
+        uint32_t raw;
+    };
+    // clang-format on
+
+    // —— Spec type codes (B[31:30]) and APDO sub-type (B[29:28])
+    static constexpr uint32_t TYPE_FIXED = 0b00;
+    static constexpr uint32_t TYPE_AUGMENTED = 0b11;
+    static constexpr uint32_t APDO_PPS = 0b00;
+
+    enum pdo_type_t : uint8_t { FIXED, PPS, UNKNOWN };
+
+    pdo_type_t pdo_type() const {
+        switch (fixed.type) {
+        case TYPE_FIXED:
+            return FIXED;
+        case TYPE_AUGMENTED:
+            return pps.apdo_type == APDO_PPS ? PPS : UNKNOWN;
+        default:
+            return UNKNOWN;
+        }
+    }
+
+    bool is_fixed() const {
+        return pdo_type() == FIXED;
+    }
+    bool is_pps() const {
+        return pdo_type() == PPS;
+    }
+
+    int max_voltage_mv() const {
+        switch (pdo_type()) {
+        case FIXED:
+            return fixed.voltage * FIXED_PDO_VOLTAGE_LSB;
+        case PPS:
+            return pps.max_voltage * PPS_PDO_VOLTAGE_LSB;
+        default:
+            return -1;
+        }
+    }
+
+    int min_voltage_mv() const {
+        switch (pdo_type()) {
+        case FIXED:
+            return fixed.voltage * FIXED_PDO_VOLTAGE_LSB;
+        case PPS:
+            return pps.min_voltage * PPS_PDO_VOLTAGE_LSB;
+        default:
+            return -1;
+        }
+    }
+
+    int max_current_ma() const {
+        switch (pdo_type()) {
+        case FIXED:
+            return fixed.max_current * FIXED_PDO_CURRENT_LSB;
+        case PPS:
+            return pps.max_current * PPS_PDO_CURRENT_LSB;
+        default:
+            return -1;
+        }
+    }
+};
+
+static_assert(sizeof(pdo_t) == 4, "pdo_t must be 4 bytes");
+
+/**
+ * Request Data Object
+ * ```
+ * Fixed RDO:
+ *   B[9:0]         Max operating current in 10 mA units
+ *   B[19:10]       Operating current in 10 mA units
+ *   B[27:20]       Reserved (0)
+ *   B[30:28]       Object position (1-based, 000 reserved)
+ *   B[31]          Reserved (0)
+ *
+ * Programmable RDO:
+ *   B[6:0]         Operating current in 50 mA units
+ *   B[8:7]         Reserved (0)
+ *   B[19:9]        Output voltage in 20 mV units
+ *   B[27:20]       Reserved (0)
+ *   B[30:28]       Object position (1-based, 000 reserved)
+ *   B[31]          Reserved (0)
+ * ```
+ */
+struct rdo_t {
+    union {
+        struct {
+            uint32_t max_current : 10;
+            uint32_t op_current : 10;
+            uint32_t : 8;
+            uint32_t obj_position : 3;
+            uint32_t : 1;
+        } fixed;
+        struct {
+            uint32_t op_current : 7;
+            uint32_t : 2;
+            uint32_t voltage : 11;
+            uint32_t : 8;
+            uint32_t obj_position : 3;
+            uint32_t : 1;
+        } pps;
+        uint32_t raw;
+    };
+};
+
+static_assert(sizeof(rdo_t::raw) == 4, "rdo_t size is not 4 bytes");
+
+#endif // USB_PD_TYPES_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = HW1_1_V2
+default_envs = HW1_3, HW1_3_V2
 
 [pico_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
@@ -23,7 +23,6 @@ debug_speed = 5000
 monitor_speed = 115200
 monitor_port = /dev/cu.usbmodem1201
 monitor_filters = direct
-
 lib_deps =
 	tempo
 	olikraus/U8g2@^2.35.19
@@ -41,11 +40,11 @@ build_src_filter =
 	+<main.cpp> 
 	+<v1/**/*.cpp>
 
-[env:HW1_1_V2]
+[env:HW1_3_V2]
 extends = pico_base
 extra_scripts = post:scripts/compiledb_inject_headers.py
 build_flags =
-	-DHW1_1_V2
+	-DHW1_3_V2
 	-DVERSION="\"2.0.0-dev\""
 build_src_filter =
 	-<*>
@@ -61,6 +60,7 @@ build_flags =
 	-DUNIT_TEST
 	-I include
 	-I test/mocks
+	-I lib/AP33772
 	-Wno-missing-template-arg-list-after-template-kw
 lib_deps =
 	tempo
@@ -78,6 +78,7 @@ build_flags =
 	-DUNIT_TEST
 	-I include
 	-I test/mocks
+	-I lib/AP33772
 	-Wno-missing-template-arg-list-after-template-kw
 lib_deps =
 	tempo

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 
 #include "tempo/diag/logger.h"
 
-#ifdef HW1_1_V2
+#ifdef HW1_3_V2
 #include <tempo/tempo.h>
 
 /**

--- a/test/mocks/MockI2CDevice.h
+++ b/test/mocks/MockI2CDevice.h
@@ -1,0 +1,14 @@
+#ifndef MOCK_I2C_DEVICE_H
+#define MOCK_I2C_DEVICE_H
+
+#include <gmock/gmock.h>
+
+#include "I2CDevice.h"
+
+class MockI2CDevice : public I2CDevice {
+public:
+    MOCK_METHOD(bool, read_bytes, (uint8_t reg, uint8_t* buf, size_t len), (const, override));
+    MOCK_METHOD(bool, write_bytes, (uint8_t reg, const uint8_t* buf, size_t len), (const, override));
+};
+
+#endif // MOCK_I2C_DEVICE_H

--- a/test/test_AP33772/test.cpp
+++ b/test/test_AP33772/test.cpp
@@ -1,0 +1,293 @@
+/**
+ * GoogleTest/GoogleMock suite for AP33772 driver.
+ *
+ * Runs on host (native env): pio test -e native
+ *
+ * Uses GMock MockI2CDevice (scripted reads + EXPECT_CALL assertions on writes)
+ * and a no-op delay function (no real sleep).
+ */
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <MockI2CDevice.h>
+#include <AP33772.h>
+
+using namespace ap33772;
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::ElementsAre;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::SetArrayArgument;
+
+/**
+ * @brief 5V @ 3A Fixed PDO.
+ *
+ * Bit layout:
+ * ```
+ *  00      0000000000  0001100100   0100101100
+ *  ^^      ^^^^^^^^^^  ^^^^^^^^^^   ^^^^^^^^^^
+ *  type    reserved    voltage      max_current
+ *  [31:30] [29:20]     [19:10]      [9:0]
+ *  Fixed               100×50mV=5V  300×10mA=3A
+ * ```
+ */
+static std::vector<uint8_t> fixed_pdo_5v_3a() {
+    const uint32_t raw = (0u << 30) | (100u << 10) | 300u;
+    return {
+        static_cast<uint8_t>(raw & 0xFF),
+        static_cast<uint8_t>((raw >> 8) & 0xFF),
+        static_cast<uint8_t>((raw >> 16) & 0xFF),
+        static_cast<uint8_t>((raw >> 24) & 0xFF),
+    };
+}
+
+/**
+ * @brief 3.3V–11V @ 3A PPS APDO.
+ *
+ * Bit layout:
+ * ```
+ *  11      00       000      01101110       0    00100001       0    0111100
+ *  ^^      ^^       ^^^      ^^^^^^^^       ^    ^^^^^^^^       ^    ^^^^^^^
+ *  type    apdo     rsv      max_voltage    rsv  min_voltage    rsv  max_current
+ *  [31:30] [29:28]  [27:25]  [24:17]        [16] [15:8]         [7]  [6:0]
+ *  APDO    PPS               110×100mV=11V       33×100mV=3.3V       60×50mA=3A
+ * ```
+ */
+static std::vector<uint8_t> pps_pdo_3v3_11v_3a() {
+    const uint32_t raw = (3u << 30) | (0u << 28) | (110u << 17) | (33u << 8) | 60u;
+    return {
+        static_cast<uint8_t>(raw & 0xFF),
+        static_cast<uint8_t>((raw >> 8) & 0xFF),
+        static_cast<uint8_t>((raw >> 16) & 0xFF),
+        static_cast<uint8_t>((raw >> 24) & 0xFF),
+    };
+}
+
+static std::vector<uint8_t> pack_srcpdo(std::vector<std::vector<uint8_t>> pdos) {
+    std::vector<uint8_t> out(28, 0);
+    size_t offset = 0;
+    for (const auto& p : pdos) {
+        for (auto b : p) {
+            if (offset >= out.size()) {
+                break;
+            }
+            out[offset++] = b;
+        }
+    }
+    return out;
+}
+
+// STATUS = ready + success + newpdo (bits 0,1,2 = 0x07).
+static constexpr uint8_t STATUS_OK = 0x07;
+static void noop_delay(unsigned long) {}
+
+class AP33772Test : public ::testing::Test {
+protected:
+    NiceMock<MockI2CDevice> m_i2c_device;
+
+    // Buffer storage for GMock SetArrayArgument (lifetimes must outlive expectations).
+    uint8_t m_status_byte = 0;
+    uint8_t m_count_byte = 0;
+    std::vector<uint8_t> m_srcpdo_buf;
+
+    // Script the standard "healthy PDO list" read sequence.
+    void scriptHealthyBus(std::vector<std::vector<uint8_t>> pdos) {
+        m_status_byte = STATUS_OK;
+        m_count_byte = static_cast<uint8_t>(pdos.size());
+        m_srcpdo_buf = pack_srcpdo(pdos);
+
+        ON_CALL(m_i2c_device, read_bytes(reg::STATUS, _, 1))
+            .WillByDefault(
+                DoAll(SetArrayArgument<1>(&m_status_byte, &m_status_byte + 1), Return(true))
+            );
+        ON_CALL(m_i2c_device, read_bytes(reg::PDONUM, _, 1))
+            .WillByDefault(
+                DoAll(SetArrayArgument<1>(&m_count_byte, &m_count_byte + 1), Return(true))
+            );
+        ON_CALL(m_i2c_device, read_bytes(reg::SRCPDO, _, 28))
+            .WillByDefault(DoAll(
+                SetArrayArgument<1>(m_srcpdo_buf.data(), m_srcpdo_buf.data() + 28), Return(true)
+            ));
+    }
+
+    // Script a single-byte read response (status, count, etc).
+    void scriptReadByte(uint8_t reg_addr, uint8_t value, uint8_t* storage) {
+        *storage = value;
+        ON_CALL(m_i2c_device, read_bytes(reg_addr, _, 1))
+            .WillByDefault(DoAll(SetArrayArgument<1>(storage, storage + 1), Return(true)));
+    }
+};
+
+// —— begin() behavior
+TEST_F(AP33772Test, BeginFailsWhenOVPActive) {
+    scriptReadByte(reg::STATUS, 0x10, &m_status_byte);
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_FALSE(ap.begin());
+}
+
+TEST_F(AP33772Test, BeginFailsWhenNotReady) {
+    scriptReadByte(reg::STATUS, 0x00, &m_status_byte);
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_FALSE(ap.begin());
+}
+
+TEST_F(AP33772Test, BeginLoadsPDOsOnSuccess) {
+    scriptHealthyBus({fixed_pdo_5v_3a(), pps_pdo_3v3_11v_3a()});
+    AP33772 ap(m_i2c_device, noop_delay);
+
+    ASSERT_TRUE(ap.begin());
+    EXPECT_EQ(2, ap.get_count_pdo());
+    EXPECT_EQ(1, ap.get_count_pps());
+    EXPECT_TRUE(ap.has_pps_profile());
+}
+
+// —— PDO decode
+TEST_F(AP33772Test, FixedPDODecode) {
+    scriptHealthyBus({fixed_pdo_5v_3a()});
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+
+    EXPECT_EQ(5000, ap.get_pdo_max_voltage(0));
+    EXPECT_EQ(5000, ap.get_pdo_min_voltage(0));
+    EXPECT_EQ(3000, ap.get_pdo_max_current(0));
+    EXPECT_FALSE(ap.is_index_pps(0));
+}
+
+TEST_F(AP33772Test, PPSPDODecode) {
+    scriptHealthyBus({pps_pdo_3v3_11v_3a()});
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+
+    EXPECT_TRUE(ap.is_index_pps(0));
+    EXPECT_EQ(3300, ap.get_pdo_min_voltage(0));
+    EXPECT_EQ(11000, ap.get_pdo_max_voltage(0));
+    EXPECT_EQ(3000, ap.get_pdo_max_current(0));
+}
+
+// —— Bounds
+TEST_F(AP33772Test, OutOfRangeIndexReturnsMinusOne) {
+    scriptHealthyBus({fixed_pdo_5v_3a()});
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+
+    EXPECT_EQ(-1, ap.get_pdo_max_voltage(99));
+    EXPECT_EQ(-1, ap.get_pdo_max_voltage(-1));
+    EXPECT_FALSE(ap.is_index_pps(-1));
+    EXPECT_FALSE(ap.is_index_pps(99));
+}
+
+// —— Request paths
+TEST_F(AP33772Test, SetPPSPDORejectsNonPPSIndex) {
+    scriptHealthyBus({fixed_pdo_5v_3a()});
+
+    // RDO write must NOT be called.
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::RDO, _, _)).Times(0);
+
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+    EXPECT_FALSE(ap.set_pps_pdo(0, 5000, 1000));
+}
+
+TEST_F(AP33772Test, SetPDOWritesRDO) {
+    scriptHealthyBus({fixed_pdo_5v_3a()});
+
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::RDO, _, 4)).WillOnce(Return(true));
+
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+    EXPECT_TRUE(ap.set_pdo(0));
+}
+
+TEST_F(AP33772Test, FindPPSMatch) {
+    scriptHealthyBus({fixed_pdo_5v_3a(), pps_pdo_3v3_11v_3a()});
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+
+    EXPECT_EQ(1, ap.find_pps_index_by_voltage_current(5000, 1000));
+    EXPECT_EQ(-1, ap.find_pps_index_by_voltage_current(20000, 1000)); // out of range
+    EXPECT_EQ(-1, ap.find_pps_index_by_voltage_current(5000, 5000));  // too much current
+}
+
+TEST_F(AP33772Test, SetPDORejectsPPSIndex) {
+    scriptHealthyBus({fixed_pdo_5v_3a(), pps_pdo_3v3_11v_3a()});
+
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::RDO, _, _)).Times(0);
+
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+    EXPECT_FALSE(ap.set_pdo(1)); // PPS index — must reject
+}
+
+TEST_F(AP33772Test, FailedPPSRequestDoesNotMutateActiveState) {
+    scriptHealthyBus({fixed_pdo_5v_3a(), pps_pdo_3v3_11v_3a()});
+
+    // First write: fixed RDO succeeds (set_pdo).
+    // Second write: PPS RDO fails. State must stay on PDO 0 / fixed.
+    // Third write: set_current rebuilds for active=PDO 0 (fixed RDO).
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::RDO, _, 4))
+        .WillOnce(Return(true))   // set_pdo(0)
+        .WillOnce(Return(false))  // set_pps_pdo(1, ...) fails
+        .WillOnce(Return(true));  // set_current(...) — must use fixed path
+
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.begin());
+    EXPECT_TRUE(ap.set_pdo(0));
+    EXPECT_EQ(0, ap.get_active_pdo());
+
+    EXPECT_FALSE(ap.set_pps_pdo(1, 5000, 1000));
+    EXPECT_EQ(0, ap.get_active_pdo()); // unchanged on failure
+
+    EXPECT_TRUE(ap.set_current(1500));
+}
+
+// —— Protection thresholds
+TEST_F(AP33772Test, SetOcpThresholdAcceptsBoundary) {
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::OCPTHR, _, 1)).WillOnce(Return(true));
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.set_ocp_threshold(255 * OCP_LSB)); // 12750 mA — max
+}
+
+TEST_F(AP33772Test, SetOcpThresholdRejectsOutOfRange) {
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::OCPTHR, _, _)).Times(0);
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_FALSE(ap.set_ocp_threshold(-1));
+    EXPECT_FALSE(ap.set_ocp_threshold(255 * OCP_LSB + 1));
+}
+
+TEST_F(AP33772Test, SetOtpThresholdRejectsOutOfRange) {
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::OTPTHR, _, _)).Times(0);
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_FALSE(ap.set_otp_threshold(-1));
+    EXPECT_FALSE(ap.set_otp_threshold(256));
+}
+
+TEST_F(AP33772Test, SetDeratingThresholdRejectsOutOfRange) {
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::DRTHR, _, _)).Times(0);
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_FALSE(ap.set_derating_threshold(-1));
+    EXPECT_FALSE(ap.set_derating_threshold(256));
+}
+
+// —— reset
+TEST_F(AP33772Test, ResetWritesZeroRDO) {
+    std::vector<uint8_t> captured;
+    EXPECT_CALL(m_i2c_device, write_bytes(reg::RDO, _, 4))
+        .WillOnce(DoAll(
+            Invoke([&](uint8_t, const uint8_t* p, size_t n) { captured.assign(p, p + n); }),
+            Return(true)
+        ));
+
+    AP33772 ap(m_i2c_device, noop_delay);
+    EXPECT_TRUE(ap.reset());
+
+    EXPECT_THAT(captured, ElementsAre(0, 0, 0, 0));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleMock(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

New v2 AP33772 driver replacing v1 `AP33772_PocketPD`. Hardware-agnostic by design:

- Abstract `I2CDevice` interface — no Arduino types in the contract.
- `ArduinoTwoWireDevice` concrete backend in a separate header so non-firmware contexts (host tests) don't pull `<Arduino.h>` / `<Wire.h>`.
- Sink-agnostic `format_pdo` debug helper — caller picks Serial / Logger / file / ring buffer.
- Host tests use `MockI2CDevice` (gmock) with scripted reads + `EXPECT_CALL` assertions on writes; 16 cases covering begin / PDO decode / RDO writes / threshold validation / reset.

Bundled tooling tweaks:
- `platformio.ini` + `main.cpp`: rename `HW1_1_V2` env to `HW1_3_V2` to match HW revision; `-I lib/AP33772` added to native test envs.
- `.clang-tidy`: disable `cppcoreguidelines-pro-type-union-access` for the tagged unions in `usb_pd_types.h`.
- `.clangd`: force `-xc++` on `.h`/`.hpp` so headers opened via a case-mismatched URI on macOS still parse as C++ when the compile DB lookup misses.