### PR TITLE
feat(v2): add PD obtain stage and sink HAL

### DIFF
--- a/include/v2/app.h
+++ b/include/v2/app.h
@@ -16,9 +16,10 @@ namespace pocketpd {
     // —— Stage forward declarations
 
     class BootStage;
+    class ObtainStage;
 
     // —— Application alias
 
-    using App = tempo::Application<Event, BootStage>;
+    using App = tempo::Application<Event, BootStage, ObtainStage>;
 
 } // namespace pocketpd

--- a/include/v2/events.h
+++ b/include/v2/events.h
@@ -1,14 +1,27 @@
 /**
  * @file events.h
  * @brief PocketPD v2 application event variant.
- *
  */
 #pragma once
+
+#include <cstdint>
 
 #include <tempo/bus/event.h>
 
 namespace pocketpd {
 
-    using Event = tempo::Events<>;
+    /**
+     * @brief Published once by ObtainStage after a successful PD negotiation.
+     *
+     * Carries enough info for downstream stages to decide whether the charger
+     * advertises any PPS APDOs (issue #24 multi-PPS) without re-querying the
+     * sink. Detailed PDO inspection still goes through `PdSinkController`.
+     */
+    struct PdReadyEvent {
+        uint8_t num_pdo = 0;
+        uint8_t pps_count = 0;
+    };
+
+    using Event = tempo::Events<PdReadyEvent>;
 
 } // namespace pocketpd

--- a/include/v2/hal/ap33772_pd_sink.h
+++ b/include/v2/hal/ap33772_pd_sink.h
@@ -1,0 +1,56 @@
+/**
+ * @file ap33772_pd_sink.h
+ * @brief AP33772-backed implementation of `PdSinkController`.
+ *
+ * Owns an `ap33772::AP33772` driver instance and forwards `PdSinkController`
+ * calls to it. Borrows the I2C bus through an `I2CDevice` reference.
+ */
+#pragma once
+
+#include <AP33772.h>
+#include <I2CDevice.h>
+
+#include "v2/hal/pd_sink_controller.h"
+
+namespace pocketpd {
+
+    class Ap33772PdSink : public PdSinkController {
+    private:
+        ap33772::AP33772 m_driver;
+
+    public:
+        Ap33772PdSink(const I2CDevice& i2c, ap33772::delay_fn_t delay) : m_driver(i2c, delay) {}
+
+        bool begin() override {
+            return m_driver.begin();
+        }
+        int pdo_count() const override {
+            return m_driver.pdo_count();
+        }
+        int pps_count() const override {
+            return m_driver.pps_count();
+        }
+        bool is_index_pps(int index) const override {
+            return m_driver.is_index_pps(index);
+        }
+        bool is_index_fixed(int index) const override {
+            return m_driver.is_index_fixed(index);
+        }
+        int pdo_max_voltage_mv(int index) const override {
+            return m_driver.pdo_max_voltage_mv(index);
+        }
+        int pdo_min_voltage_mv(int index) const override {
+            return m_driver.pdo_min_voltage_mv(index);
+        }
+        int pdo_max_current_ma(int index) const override {
+            return m_driver.pdo_max_current_ma(index);
+        }
+        bool set_pdo(int index) override {
+            return m_driver.set_pdo(index);
+        }
+        bool set_pps_pdo(int index, int voltage_mv, int current_ma) override {
+            return m_driver.set_pps_pdo(index, voltage_mv, current_ma);
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/hal/pd_sink_controller.h
+++ b/include/v2/hal/pd_sink_controller.h
@@ -1,0 +1,58 @@
+/**
+ * @file pd_sink_controller.h
+ * @brief Abstract USB-PD sink HAL.
+ *
+ * Stages, tasks, and tests depend only on this interface. The Arduino-backed
+ * implementation lives in `ap33772_pd_sink.h`; mocks live in
+ * `test/mocks/MockPdSink.h`.
+ */
+#pragma once
+
+namespace pocketpd {
+
+    /**
+     * @brief Abstract USB-PD sink. Surface today covers negotiation and PDO
+     * summary; later stages add set_pdo / set_pps_pdo / live readings.
+     */
+    class PdSinkController {
+    public:
+        virtual ~PdSinkController() = default;
+
+        /**
+         * @brief Negotiate with the source and load PDO list.
+         * @return true if the controller reported READY+SUCCESS+NEWPDO and the
+         * SRCPDO block was read without I2C error.
+         */
+        [[nodiscard]] virtual bool begin() = 0;
+
+        /** @brief Number of valid source PDOs after a successful begin(). */
+        virtual int pdo_count() const = 0;
+
+        /** @brief Number of PPS APDOs in the PDO list (issue #24 multi-PPS). */
+        virtual int pps_count() const = 0;
+
+        /** @brief True if PDO at index is a PPS APDO. */
+        virtual bool is_index_pps(int index) const = 0;
+
+        /** @brief True if PDO at index is a fixed-supply PDO. */
+        virtual bool is_index_fixed(int index) const = 0;
+
+        /** @brief Max voltage in mV for a PDO; -1 if invalid index. */
+        virtual int pdo_max_voltage_mv(int index) const = 0;
+
+        /** @brief Min voltage in mV for a PDO (= max for fixed); -1 if invalid index. */
+        virtual int pdo_min_voltage_mv(int index) const = 0;
+
+        /** @brief Max current in mA for a PDO; -1 if invalid index. */
+        virtual int pdo_max_current_ma(int index) const = 0;
+
+        // —— Power requests
+
+        /** @brief Request a fixed PDO by index. */
+        [[nodiscard]] virtual bool set_pdo(int index) = 0;
+
+        /** @brief Request a PPS APDO with explicit voltage and current. */
+        [[nodiscard]] virtual bool set_pps_pdo(int index, int voltage_mv, int current_ma) = 0;
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/boot_stage.h
+++ b/include/v2/stages/boot_stage.h
@@ -1,12 +1,11 @@
 /**
  * @file boot_stage.h
  * @brief First stage at power-on. Renders the splash screen with the logo and firmware version,
- * then yields after BOOT_TO_OBTAIN_MS.
- *
- * In F1 the timeout simply flips an observable `boot_complete()` flag and logs a single info line;
- * F2 will replace that with `conductor.request<ObtainStage>()`.
+ * then requests `ObtainStage` after `BOOT_TO_OBTAIN_MS`.
  */
 #pragma once
+
+#include <cstdint>
 
 #include <tempo/core/time.h>
 #include <tempo/hardware/display.h>
@@ -22,7 +21,6 @@ namespace pocketpd {
         tempo::Display& m_display;
         uint32_t m_deadline_ms = 0;
         bool m_armed = false;
-        bool m_boot_complete = false;
 
     public:
         static constexpr const char* LOG_TAG = "Boot";
@@ -41,23 +39,15 @@ namespace pocketpd {
             m_display.flush();
         }
 
-        void on_tick(Conductor&, uint32_t now_ms) override {
+        void on_tick(Conductor& conductor, uint32_t now_ms) override {
             if (!m_armed) {
                 m_deadline_ms = now_ms + BOOT_TO_OBTAIN_MS;
                 m_armed = true;
                 return;
             }
-            if (m_boot_complete) {
-                return;
-            }
             if (tempo::time_reached(now_ms, m_deadline_ms)) {
-                m_boot_complete = true;
-                log.info("Boot splash complete");
+                conductor.request<ObtainStage>();
             }
-        }
-
-        bool boot_complete() const {
-            return m_boot_complete;
         }
     };
 

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -1,0 +1,66 @@
+/**
+ * @file obtain_stage.h
+ * @brief Stage that runs PD negotiation, learns the source PDO list, and
+ * announces the result to the rest of the app via `PdReadyEvent`.
+ *
+ * Issue #33: ObtainStage must NOT issue an RDO request. The first request runs
+ * later (NormalPpsStage / NormalPdoStage) once EEPROM has been consulted. Until
+ * then the AP33772 holds whatever default profile the source negotiated at
+ * begin().
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include <tempo/bus/publisher.h>
+#include <tempo/core/time.h>
+
+#include "AP33772_debug.h"
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/hal/pd_sink_controller.h"
+
+namespace pocketpd {
+
+    class ObtainStage : public App::Stage, public tempo::UseLog<ObtainStage> {
+    private:
+        PdSinkController& m_pd_sink;
+        tempo::Publisher<Event>& m_publisher;
+        tempo::IntervalTimer m_dump_timer{1000};
+
+    public:
+        static constexpr const char* LOG_TAG = "Obtain";
+
+        ObtainStage(PdSinkController& pd_sink, tempo::Publisher<Event>& publisher)
+            : m_pd_sink(pd_sink), m_publisher(publisher) {}
+
+        const char* name() const override {
+            return "OBTAIN";
+        }
+
+        void on_enter(Conductor&) override {
+            if (!m_pd_sink.begin()) {
+                log.error("PD negotiation failed");
+                return;
+            }
+
+            const auto pdo_n = static_cast<uint8_t>(m_pd_sink.pdo_count());
+            const auto pps_n = static_cast<uint8_t>(m_pd_sink.pps_count());
+            m_publisher.publish(PdReadyEvent{pdo_n, pps_n});
+
+            log.info("PD ready: %u PDO (%u PPS)", pdo_n, pps_n);
+        }
+
+        void on_tick(Conductor&, uint32_t now_ms) override {
+            if (!m_dump_timer.tick(now_ms)) {
+                return;
+            }
+            std::array<char, 2048> buffer{};
+            ap33772::format_pdo(m_pd_sink, buffer.data(), buffer.size());
+            log.info(buffer.data());
+        }
+    };
+
+} // namespace pocketpd

--- a/lib/AP33772/AP33772.h
+++ b/lib/AP33772/AP33772.h
@@ -199,15 +199,15 @@ namespace ap33772 {
          */
         AP33772(const I2CDevice& i2c, const delay_fn_t delay) : m_i2c(i2c), m_delay(delay) {}
 
-        int get_count_pdo() const {
+        int pdo_count() const {
             return m_pdo_count;
         }
 
-        int get_count_pps() const {
+        int pps_count() const {
             return m_pps_count;
         }
 
-        int get_active_pdo() const {
+        int active_pdo() const {
             return m_pdo_active;
         }
 
@@ -306,7 +306,7 @@ namespace ap33772 {
             }
 
             int voltage = clamp_voltage(m_pdo_active, voltage_mv);
-            int max_current = get_pdo_max_current(m_pdo_active);
+            int max_current = pdo_max_current_ma(m_pdo_active);
             return request_pps(m_pdo_active, voltage, max_current);
         }
 
@@ -318,7 +318,7 @@ namespace ap33772 {
         [[nodiscard]]
         bool set_current(int current_ma) {
 
-            int max_current = get_pdo_max_current(m_pdo_active);
+            int max_current = pdo_max_current_ma(m_pdo_active);
             int clamped_ma = clamp(current_ma, 0, max_current);
 
             if (is_index_pps(m_pdo_active)) {
@@ -426,7 +426,7 @@ namespace ap33772 {
          * @param index zero-based PDO index
          * @return voltage in millivolts, -1 if invalid index
          */
-        int get_pdo_max_voltage(int index) const {
+        int pdo_max_voltage_mv(int index) const {
             return is_index_valid(index) ? m_pdo_list.at(index).max_voltage_mv() : -1;
         }
 
@@ -435,7 +435,7 @@ namespace ap33772 {
          * @param index zero-based PDO index
          * @return voltage in millivolts, -1 if invalid index
          */
-        int get_pdo_min_voltage(int index) const {
+        int pdo_min_voltage_mv(int index) const {
             return is_index_valid(index) ? m_pdo_list.at(index).min_voltage_mv() : -1;
         }
 
@@ -444,7 +444,7 @@ namespace ap33772 {
          * @param index zero-based PDO index
          * @return current in milliamps, -1 if invalid index
          */
-        int get_pdo_max_current(int index) const {
+        int pdo_max_current_ma(int index) const {
             return is_index_valid(index) ? m_pdo_list.at(index).max_current_ma() : -1;
         }
 

--- a/lib/AP33772/AP33772_debug.h
+++ b/lib/AP33772/AP33772_debug.h
@@ -2,8 +2,6 @@
 #include <cstddef>
 #include <cstdio>
 
-#include "AP33772.h"
-
 namespace ap33772 {
 
     /**
@@ -12,10 +10,22 @@ namespace ap33772 {
      * Hardware-agnostic: caller forwards bytes to Serial, Logger, file,
      * ring buffer, or any other sink.
      *
+     * Templated on a duck-typed `Sink` so the same body serves the raw
+     * `ap33772::AP33772` driver and any consumer-side abstraction (e.g.
+     * `pocketpd::PdSinkController`). The Sink must expose:
+     *
+     *   int  pdo_count()                   const;
+     *   int  pps_count()                   const;
+     *   bool is_index_pps(int)             const;
+     *   int  pdo_min_voltage_mv(int)       const;
+     *   int  pdo_max_voltage_mv(int)       const;
+     *   int  pdo_max_current_ma(int)       const;
+     *
      * @return Bytes written (excluding null terminator). Output is truncated to cap-1 if the buffer
      * is too small.
      */
-    inline size_t format_pdo(const AP33772& ap, char* out, size_t cap) {
+    template <typename Sink>
+    inline size_t format_pdo(const Sink& s, char* out, size_t cap) {
         if (cap == 0) {
             return 0;
         }
@@ -35,20 +45,20 @@ namespace ap33772 {
             }
         };
 
-        append("Source PDO Number = %d\n", ap.get_count_pdo());
-        append("PPS Profiles = %d\n", ap.get_count_pps());
+        append("Source PDO Number = %d\n", s.pdo_count());
+        append("PPS Profiles = %d\n", s.pps_count());
 
-        for (int i = 0; i < ap.get_count_pdo(); i++) {
-            if (ap.is_index_pps(i)) {
+        for (int i = 0; i < s.pdo_count(); i++) {
+            if (s.is_index_pps(i)) {
                 append(
                     "PDO[%d] - PPS : %.1fV~%.1fV @ %.1fA\n", i + 1,
-                    ap.get_pdo_min_voltage(i) / 1000.0, ap.get_pdo_max_voltage(i) / 1000.0,
-                    ap.get_pdo_max_current(i) / 1000.0
+                    s.pdo_min_voltage_mv(i) / 1000.0, s.pdo_max_voltage_mv(i) / 1000.0,
+                    s.pdo_max_current_ma(i) / 1000.0
                 );
             } else {
                 append(
-                    "PDO[%d] - Fixed : %.1fV @ %.1fA\n", i + 1, ap.get_pdo_max_voltage(i) / 1000.0,
-                    ap.get_pdo_max_current(i) / 1000.0
+                    "PDO[%d] - Fixed : %.1fV @ %.1fA\n", i + 1, s.pdo_max_voltage_mv(i) / 1000.0,
+                    s.pdo_max_current_ma(i) / 1000.0
                 );
             }
         }

--- a/lib/tempo/include/tempo/core/time.h
+++ b/lib/tempo/include/tempo/core/time.h
@@ -18,12 +18,75 @@ namespace tempo {
 
     /**
      * @brief Implementation-agnostic Clock interface
-     * 
+     *
      */
     class Clock {
     public:
         virtual ~Clock() = default;
         virtual uint32_t now_ms() const = 0;
+    };
+
+    /**
+     * @brief Lightweight periodic gate for use inside a Stage's `on_tick` (or any caller that ticks
+     * faster than the desired cadence).
+     *
+     * Wraparound-safe: uses `time_reached` for all comparisons, so a 32-bit `now_ms` rollover is
+     * handled correctly.
+     *
+     * Example:
+     * @code
+     *   class MyStage : public App::Stage {
+     *       tempo::IntervalTimer m_heartbeat{500};
+     *
+     *       void on_tick(Conductor&, uint32_t now_ms) override {
+     *           if (m_heartbeat.tick(now_ms)) {
+     *               log.info("alive");
+     *           }
+     *       }
+     *   };
+     * @endcode
+     */
+    class IntervalTimer {
+    private:
+        uint32_t m_period_ms;
+        uint32_t m_due_ms = 0;
+        bool m_armed = false;
+
+    public:
+        explicit IntervalTimer(uint32_t period_ms) : m_period_ms(period_ms) {}
+
+        /**
+         * @brief Returns true once when the period elapses, false otherwise.
+         *
+         * The first call arms the timer relative to `now_ms` and returns false.
+         */
+        bool tick(uint32_t now_ms) {
+            if (!m_armed) {
+                m_due_ms = now_ms + m_period_ms;
+                m_armed = true;
+                return false;
+            }
+            if (time_reached(now_ms, m_due_ms)) {
+                m_due_ms = now_ms + m_period_ms;
+                return true;
+            }
+            return false;
+        }
+
+        /**
+         * @brief Re-arm relative to `now_ms`. Next fire is one period out.
+         *
+         * Use after handling a stage transition or any condition that should suppress the next
+         * scheduled fire.
+         */
+        void reset(uint32_t now_ms) {
+            m_due_ms = now_ms + m_period_ms;
+            m_armed = true;
+        }
+
+        uint32_t period_ms() const {
+            return m_period_ms;
+        }
     };
 
 } // namespace tempo

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,21 +5,32 @@
 #include <Wire.h>
 #include <tempo/tempo.h>
 
+#include <AP33772.h>
+#include <ArduinoTwoWireDevice.h>
+
 #include "v2/app.h"
 #include "v2/hal/arduino_clock.h"
 #include "v2/hal/arduino_stream_writer.h"
+#include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/stages/boot_stage.h"
+#include "v2/stages/obtain_stage.h"
 
 namespace {
 
+    // Setup framework components
     pocketpd::ArduinoClock arduino_clock;
     pocketpd::ArduinoStreamWriter arduino_stream_writer;
-
-    pocketpd::U8g2Display u8g2_display;
-
     pocketpd::App app(arduino_clock, arduino_stream_writer);
+
+    // Setup hardware adapters
+    ArduinoTwoWireDevice ap33772_i2c{Wire, ap33772::ADDRESS};
+    pocketpd::Ap33772PdSink pd_sink{ap33772_i2c, ::delay};
+    
+    // Setup stages
+    pocketpd::U8g2Display u8g2_display;
     pocketpd::BootStage boot_stage(u8g2_display);
+    pocketpd::ObtainStage obtain_stage(pd_sink, app.task_publisher());
 
 } // namespace
 
@@ -33,6 +44,7 @@ void setup() {
     u8g2_display.begin();
 
     app.register_stage(boot_stage);
+    app.register_stage(obtain_stage);
     app.start<pocketpd::BootStage>();
 }
 

--- a/test/mocks/MockPdSink.h
+++ b/test/mocks/MockPdSink.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "v2/hal/pd_sink_controller.h"
+
+namespace pocketpd {
+
+    class MockPdSink : public PdSinkController {
+    public:
+        MOCK_METHOD(bool, begin, (), (override));
+        MOCK_METHOD(int, pdo_count, (), (const, override));
+        MOCK_METHOD(int, pps_count, (), (const, override));
+        MOCK_METHOD(bool, is_index_pps, (int index), (const, override));
+        MOCK_METHOD(bool, is_index_fixed, (int index), (const, override));
+        MOCK_METHOD(int, pdo_max_voltage_mv, (int index), (const, override));
+        MOCK_METHOD(int, pdo_min_voltage_mv, (int index), (const, override));
+        MOCK_METHOD(int, pdo_max_current_ma, (int index), (const, override));
+        MOCK_METHOD(bool, set_pdo, (int index), (override));
+        MOCK_METHOD(bool, set_pps_pdo, (int index, int voltage_mv, int current_ma), (override));
+    };
+
+} // namespace pocketpd

--- a/test/test_AP33772/test.cpp
+++ b/test/test_AP33772/test.cpp
@@ -140,8 +140,8 @@ TEST_F(AP33772Test, BeginLoadsPDOsOnSuccess) {
     AP33772 ap(m_i2c_device, noop_delay);
 
     ASSERT_TRUE(ap.begin());
-    EXPECT_EQ(2, ap.get_count_pdo());
-    EXPECT_EQ(1, ap.get_count_pps());
+    EXPECT_EQ(2, ap.pdo_count());
+    EXPECT_EQ(1, ap.pps_count());
     EXPECT_TRUE(ap.has_pps_profile());
 }
 
@@ -151,9 +151,9 @@ TEST_F(AP33772Test, FixedPDODecode) {
     AP33772 ap(m_i2c_device, noop_delay);
     EXPECT_TRUE(ap.begin());
 
-    EXPECT_EQ(5000, ap.get_pdo_max_voltage(0));
-    EXPECT_EQ(5000, ap.get_pdo_min_voltage(0));
-    EXPECT_EQ(3000, ap.get_pdo_max_current(0));
+    EXPECT_EQ(5000, ap.pdo_max_voltage_mv(0));
+    EXPECT_EQ(5000, ap.pdo_min_voltage_mv(0));
+    EXPECT_EQ(3000, ap.pdo_max_current_ma(0));
     EXPECT_FALSE(ap.is_index_pps(0));
 }
 
@@ -163,9 +163,9 @@ TEST_F(AP33772Test, PPSPDODecode) {
     EXPECT_TRUE(ap.begin());
 
     EXPECT_TRUE(ap.is_index_pps(0));
-    EXPECT_EQ(3300, ap.get_pdo_min_voltage(0));
-    EXPECT_EQ(11000, ap.get_pdo_max_voltage(0));
-    EXPECT_EQ(3000, ap.get_pdo_max_current(0));
+    EXPECT_EQ(3300, ap.pdo_min_voltage_mv(0));
+    EXPECT_EQ(11000, ap.pdo_max_voltage_mv(0));
+    EXPECT_EQ(3000, ap.pdo_max_current_ma(0));
 }
 
 // —— Bounds
@@ -174,8 +174,8 @@ TEST_F(AP33772Test, OutOfRangeIndexReturnsMinusOne) {
     AP33772 ap(m_i2c_device, noop_delay);
     EXPECT_TRUE(ap.begin());
 
-    EXPECT_EQ(-1, ap.get_pdo_max_voltage(99));
-    EXPECT_EQ(-1, ap.get_pdo_max_voltage(-1));
+    EXPECT_EQ(-1, ap.pdo_max_voltage_mv(99));
+    EXPECT_EQ(-1, ap.pdo_max_voltage_mv(-1));
     EXPECT_FALSE(ap.is_index_pps(-1));
     EXPECT_FALSE(ap.is_index_pps(99));
 }
@@ -236,10 +236,10 @@ TEST_F(AP33772Test, FailedPPSRequestDoesNotMutateActiveState) {
     AP33772 ap(m_i2c_device, noop_delay);
     EXPECT_TRUE(ap.begin());
     EXPECT_TRUE(ap.set_pdo(0));
-    EXPECT_EQ(0, ap.get_active_pdo());
+    EXPECT_EQ(0, ap.active_pdo());
 
     EXPECT_FALSE(ap.set_pps_pdo(1, 5000, 1000));
-    EXPECT_EQ(0, ap.get_active_pdo()); // unchanged on failure
+    EXPECT_EQ(0, ap.active_pdo()); // unchanged on failure
 
     EXPECT_TRUE(ap.set_current(1500));
 }

--- a/test/test_v2_boot/test.cpp
+++ b/test/test_v2_boot/test.cpp
@@ -1,9 +1,11 @@
 /**
- * GoogleTest suite for BootStage (F1).
+ * GoogleTest suite for BootStage.
  *
  * Exercises splash render via MockDisplay and the BOOT_TO_OBTAIN_MS timeout
- * driving the observable `boot_complete()` flag. Conductor is constructed
- * directly (no full Application) since F1 has no event flow yet.
+ * driving a `request<ObtainStage>()` against the production `Conductor` type
+ * list. ObtainStage's slot is left unregistered; the conductor falls back to
+ * `NullStage` on apply, which is enough to verify the index transition.
+ * ObtainStage's own behaviour is exercised in test_v2_obtain.
  */
 #define VERSION "\"test\""
 
@@ -14,25 +16,25 @@
 
 #include <MockDisplay.h>
 
+#include "v2/app.h"
 #include "v2/stages/boot_stage.h"
 
 using namespace pocketpd;
-using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::InSequence;
 using ::testing::NiceMock;
 using ::testing::StrEq;
 
-using BootConductor = tempo::Conductor<BootStage>;
+using BootConductor = tempo::Conductor<BootStage, ObtainStage>;
 
 TEST(BootStage, OnEnterDrawsSplash) {
     MockDisplay display;
     {
         InSequence seq;
         EXPECT_CALL(display, clear());
-        EXPECT_CALL(display, draw_bitmap(0, 0, 16, 64, _));
+        EXPECT_CALL(display, draw_bitmap(0, 0, 16, 64, ::testing::_));
         EXPECT_CALL(display, draw_text(67, 64, StrEq("FW: ")));
-        EXPECT_CALL(display, draw_text(87, 64, _));
+        EXPECT_CALL(display, draw_text(87, 64, ::testing::_));
         EXPECT_CALL(display, flush());
     }
 
@@ -42,26 +44,26 @@ TEST(BootStage, OnEnterDrawsSplash) {
     conductor.start<BootStage>();
 }
 
-TEST(BootStage, CompletesAfterBootTimeout) {
+TEST(BootStage, RequestsObtainAfterBootTimeout) {
     NiceMock<MockDisplay> display;
     BootStage stage(display);
     BootConductor conductor;
     conductor.register_stage(stage);
     conductor.start<BootStage>();
 
-    EXPECT_FALSE(stage.boot_complete());
+    EXPECT_FALSE(conductor.has_pending());
 
     conductor.tick(0);
-    EXPECT_FALSE(stage.boot_complete());
+    EXPECT_FALSE(conductor.has_pending());
 
     conductor.tick(BOOT_TO_OBTAIN_MS - 1);
-    EXPECT_FALSE(stage.boot_complete());
+    EXPECT_FALSE(conductor.has_pending());
 
     conductor.tick(BOOT_TO_OBTAIN_MS);
-    EXPECT_TRUE(stage.boot_complete());
+    EXPECT_TRUE(conductor.has_pending());
 }
 
-TEST(BootStage, CompletesOnceAcrossMultipleTicks) {
+TEST(BootStage, TransitionsToObtainOnApply) {
     NiceMock<MockDisplay> display;
     BootStage stage(display);
     BootConductor conductor;
@@ -70,8 +72,9 @@ TEST(BootStage, CompletesOnceAcrossMultipleTicks) {
 
     conductor.tick(0);
     conductor.tick(BOOT_TO_OBTAIN_MS);
-    conductor.tick(BOOT_TO_OBTAIN_MS + 1000);
-    EXPECT_TRUE(stage.boot_complete());
+
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), BootConductor::index_of<ObtainStage>());
 }
 
 int main(int argc, char** argv) {

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -1,0 +1,151 @@
+/**
+ * GoogleTest suite for ObtainStage.
+ *
+ * Drives Conductor<BootStage, ObtainStage> with scripted MockPdSink and a real
+ * EventQueue / QueuePublisher so PdReadyEvent payload can be inspected after
+ * on_enter runs. Boot→Obtain timeout transition is verified end-to-end here too.
+ */
+#define VERSION "\"test\""
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <variant>
+
+#include <tempo/bus/event_queue.h>
+#include <tempo/bus/publisher.h>
+#include <tempo/stage/conductor.h>
+
+#include <MockDisplay.h>
+#include <MockPdSink.h>
+
+#include "v2/events.h"
+#include "v2/stages/boot_stage.h"
+#include "v2/stages/obtain_stage.h"
+
+using namespace pocketpd;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+using TestConductor = tempo::Conductor<BootStage, ObtainStage>;
+using TestQueue = tempo::EventQueue<Event, 8>;
+using TestPublisher = tempo::QueuePublisher<Event, 8>;
+
+namespace {
+
+    PdReadyEvent expect_pd_ready(TestQueue& q) {
+        Event e;
+        EXPECT_TRUE(q.pop(e));
+        const auto* ready = std::get_if<PdReadyEvent>(&e);
+        EXPECT_NE(ready, nullptr);
+        return ready ? *ready : PdReadyEvent{};
+    }
+
+} // namespace
+
+TEST(ObtainStage, OnEnterCallsBeginAndPublishesCount) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
+
+    ObtainStage stage(sink, publisher);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<ObtainStage>();
+
+    const auto ready = expect_pd_ready(queue);
+    EXPECT_EQ(ready.num_pdo, 3);
+    EXPECT_EQ(ready.pps_count, 1);
+}
+
+TEST(ObtainStage, MultiPpsChargerReportsBothPps) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(5));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(2));
+
+    ObtainStage stage(sink, publisher);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<ObtainStage>();
+
+    const auto ready = expect_pd_ready(queue);
+    EXPECT_EQ(ready.num_pdo, 5);
+    EXPECT_EQ(ready.pps_count, 2);
+}
+
+TEST(ObtainStage, BeginFailureSuppressesPdReady) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+
+    EXPECT_CALL(sink, begin()).WillOnce(Return(false));
+
+    ObtainStage stage(sink, publisher);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<ObtainStage>();
+
+    Event e;
+    EXPECT_FALSE(queue.pop(e));
+}
+
+TEST(ObtainStage, OnEnterIssuesNoRdoRequest) {
+    // Issue #33: charger-dependent default voltage. Obtain must not pick a PDO.
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+    EXPECT_CALL(sink, set_pdo).Times(0);
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+
+    ObtainStage stage(sink, publisher);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<ObtainStage>();
+}
+
+TEST(BootStage, RequestsObtainAfterTimeout) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+
+    BootStage boot(display);
+    ObtainStage obtain(sink, publisher);
+    TestConductor conductor;
+    conductor.register_stage(boot);
+    conductor.register_stage(obtain);
+    conductor.start<BootStage>();
+
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<BootStage>());
+
+    conductor.tick(0);
+    conductor.tick(BOOT_TO_OBTAIN_MS - 1);
+    EXPECT_FALSE(conductor.has_pending());
+
+    conductor.tick(BOOT_TO_OBTAIN_MS);
+    EXPECT_TRUE(conductor.has_pending());
+
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ObtainStage>());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_v2_util/test.cpp
+++ b/test/test_v2_util/test.cpp
@@ -1,0 +1,63 @@
+/**
+ * GoogleTest suite for tempo time helpers.
+ */
+#include <gtest/gtest.h>
+
+#include <tempo/core/time.h>
+
+using tempo::IntervalTimer;
+
+TEST(IntervalTimer, FirstTickArmsAndReturnsFalse) {
+    IntervalTimer timer(100);
+    EXPECT_FALSE(timer.tick(0));
+}
+
+TEST(IntervalTimer, DoesNotFireBeforePeriodElapses) {
+    IntervalTimer timer(100);
+    timer.tick(0);
+    EXPECT_FALSE(timer.tick(50));
+    EXPECT_FALSE(timer.tick(99));
+}
+
+TEST(IntervalTimer, FiresAtPeriodBoundary) {
+    IntervalTimer timer(100);
+    timer.tick(0);
+    EXPECT_TRUE(timer.tick(100));
+}
+
+TEST(IntervalTimer, RearmsAfterFiring) {
+    IntervalTimer timer(100);
+    timer.tick(0);
+    timer.tick(100);
+    EXPECT_FALSE(timer.tick(150));
+    EXPECT_TRUE(timer.tick(200));
+}
+
+TEST(IntervalTimer, FiresOnceAcrossMultipleTicksPastDue) {
+    IntervalTimer timer(100);
+    timer.tick(0);
+    EXPECT_TRUE(timer.tick(250));
+    EXPECT_FALSE(timer.tick(300));
+    EXPECT_TRUE(timer.tick(350));
+}
+
+TEST(IntervalTimer, ResetReArms) {
+    IntervalTimer timer(100);
+    timer.tick(0);
+    timer.tick(100);
+    timer.reset(500);
+    EXPECT_FALSE(timer.tick(550));
+    EXPECT_TRUE(timer.tick(600));
+}
+
+TEST(IntervalTimer, HandlesUint32Wraparound) {
+    IntervalTimer timer(100);
+    constexpr uint32_t near_max = 0xFFFFFFFF - 50;
+    timer.tick(near_max);
+    EXPECT_TRUE(timer.tick(near_max + 100));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
Two commits:

1. **`feat(tempo): add IntervalTimer helper`** — periodic gate for use inside a Stage's `on_tick` (or any caller that ticks faster than the desired cadence). Header-only, wraparound-safe via existing `time_reached`.
2. **`feat(v2): add PD obtain stage and sink HAL`** — BootStage now requests `ObtainStage` on splash timeout. ObtainStage runs PD negotiation through a new `PdSinkController` HAL and publishes `PdReadyEvent` so later stages can decide on PPS vs fixed without re-querying the sink. PDO request deliberately deferred — first RDO runs after EEPROM resolves the resume profile (issue #33).

`PdSinkController` is split into a pure-virtual interface (`include/v2/hal/pd_sink_controller.h`) and an AP33772-backed impl (`include/v2/hal/ap33772_pd_sink.h`) so stages depend only on the abstract surface; AP33772 / I2CDevice headers stay scoped to `main.cpp` and driver-level tests.

AP33772 accessors renamed to align with the controller-level vocabulary so the layers share names: `pdo_count`, `pps_count`, `pdo_max_voltage_mv`, `pdo_min_voltage_mv`, `pdo_max_current_ma`, `active_pdo`. As a result, `format_pdo` in `lib/AP33772/AP33772_debug.h` is now a template over a duck-typed `Sink` — one body serves both the raw driver and any `PdSinkController`, no duplication.

## Linked issues
Refs #33, Refs #24

## Hardware tested
- [x] HW1_3

[
<img width="399" height="561" alt="Screenshot 2026-05-01 at 4 51 41 PM" src="https://github.com/user-attachments/assets/c73543e2-ab43-48db-8e9d-052ff0cfe7ca" />
](url)

How tested:
- `pio test -e native` — 32/32 PASSED (test_smoke, test_AP33772, test_v2_boot, test_v2_obtain, test_v2_util).
- `pio run -e HW1_3_V2` — RAM 4.2 %, Flash 4.2 %.
- Bench verification deferred to a later phase.

## Breaking change / migration
- `lib/AP33772/` accessor rename. Consumers must rename `get_count_pdo` → `pdo_count`, `get_count_pps` → `pps_count`, `get_active_pdo` → `active_pdo`, `get_pdo_max_voltage` → `pdo_max_voltage_mv`, `get_pdo_min_voltage` → `pdo_min_voltage_mv`, `get_pdo_max_current` → `pdo_max_current_ma`.

## Notes
- 5 new test cases for ObtainStage: success path publishes counts, multi-PPS surfaces both APDOs, `begin()` failure suppresses the event, no `set_pdo`/`set_pps_pdo` call from ObtainStage, boot→obtain timeout end-to-end.
- 7 new test cases for `tempo::IntervalTimer`: period boundary, re-arm, past-due single-fire, reset, uint32 wraparound.
- `test_v2_boot` updated: dropped the `boot_complete()` flag; now asserts pending transition + apply.
- Surface for later stages already declared on the interface (`set_pdo`, `set_pps_pdo`, voltage/current accessors) so MockPdSink can assert non-call from ObtainStage.
