### PR TITLE
feat(tempo): payload-passing transitions + TimeoutTimer

### DIFF
--- a/lib/tempo/include/tempo/core/time.h
+++ b/lib/tempo/include/tempo/core/time.h
@@ -89,4 +89,67 @@ namespace tempo {
         }
     };
 
+    /**
+     * @brief One-shot timeout. Set once, ask if reached, set again to re-arm.
+     *
+     * Wraparound-safe: uses `time_reached` for all comparisons. Disarmed by default; `reached`
+     * returns false until armed via `set`.
+     *
+     * Pairs with `IntervalTimer` — that one re-arms automatically and is for periodic events,
+     * this one fires once and stays "reached" until disarmed or re-set, and is for stage
+     * timeouts and similar single-shot deadlines.
+     *
+     * Example:
+     * @code
+     *   class MyStage : public App::Stage {
+     *       tempo::TimeoutTimer m_timeout;
+     *
+     *       void on_enter(Conductor&) override {
+     *           m_timeout.disarm();
+     *       }
+     *
+     *       void on_tick(Conductor& c, uint32_t now_ms) override {
+     *           if (!m_timeout.armed()) {
+     *               m_timeout.set(now_ms, MY_TIMEOUT_MS);
+     *               return;
+     *           }
+     *           if (m_timeout.reached(now_ms)) {
+     *               c.request<NextStage>();
+     *           }
+     *       }
+     *   };
+     * @endcode
+     */
+    class TimeoutTimer {
+    private:
+        uint32_t m_due_ms = 0;
+        bool m_armed = false;
+
+    public:
+        /**
+         * @brief Arm the timeout relative to `now_ms`. Becomes "reached" once
+         * `now_ms + duration_ms` is observed. Calling `set` again replaces any prior arm.
+         */
+        void set(uint32_t now_ms, uint32_t duration_ms) {
+            m_due_ms = now_ms + duration_ms;
+            m_armed = true;
+        }
+
+        /**
+         * @brief True once the armed timeout is past, and stays true until `disarm` or a
+         * re-`set`. Returns false while disarmed.
+         */
+        bool reached(uint32_t now_ms) const {
+            return m_armed && time_reached(now_ms, m_due_ms);
+        }
+
+        void disarm() {
+            m_armed = false;
+        }
+
+        bool armed() const {
+            return m_armed;
+        }
+    };
+
 } // namespace tempo

--- a/lib/tempo/include/tempo/stage/conductor.h
+++ b/lib/tempo/include/tempo/stage/conductor.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 
 #include "tempo/core/type_list.h"
 #include "tempo/stage/null_stage.h"
@@ -88,17 +89,38 @@ namespace tempo {
         /**
          * @brief Request a transition to stage S. on_enter(Conductor&) is called when the
          * transition is applied.
+         *
+         * Optional payload-passing form: `request<S>(args...)` calls `S::prepare(args...)`
+         * on the target slot immediately, then schedules the transition. The target stage
+         * uses `prepare` to stash entry context that its subsequent `on_enter` consumes.
+         * Stages without a `prepare` overload accept only the zero-arg `request<S>()` form.
+         *
+         * No allocation: arguments are forwarded directly to `prepare`. The configured
+         * state persists on the stage instance until `on_enter` runs on the next tick.
          */
-        template <typename S>
-        void request() {
-            m_pending_idx = index_of<S>();
+        template <typename S, typename... Args>
+        void request(Args&&... args) {
+            constexpr size_t idx = index_of<S>();
+            m_pending_idx = idx;
             m_has_pending = true;
+
+            if constexpr (sizeof...(Args) > 0) {
+                if (auto* slot = m_slots[idx]) {
+                    static_cast<S*>(slot)->prepare(std::forward<Args>(args)...);
+                }
+            }
         }
 
         bool has_pending() const {
             return m_has_pending;
         }
 
+        /**
+         * @brief Apply a pending transition. Same-stage requests are honored: the active
+         * stage's `on_exit` runs, then `on_enter` runs again on the same instance. Pair with
+         * `request<S>(payload)` to re-enter a stage with new entry context (e.g. switching
+         * an internal mode) without inventing a separate code path for in-stage updates.
+         */
         bool apply_pending_transition() {
             if (!m_has_pending) {
                 return false;
@@ -106,10 +128,6 @@ namespace tempo {
 
             const size_t next_idx = m_pending_idx;
             m_has_pending = false;
-
-            if (next_idx == m_current_idx) {
-                return false;
-            }
 
             StageType* next = lookup(next_idx);
 

--- a/lib/tempo/include/tempo/stage/stage.h
+++ b/lib/tempo/include/tempo/stage/stage.h
@@ -14,10 +14,16 @@ namespace tempo {
      * the Stage is passed to every lifecycle callback so the Stage can request transitions
      * (`conductor.request<Other>()`) or read its current_index().
      *
+     * Optional protocol — payload-passing entry: a stage may define a non-virtual member
+     * `prepare(Args...)` to receive entry context from `Conductor::request<Self>(Args...)`. The
+     * conductor calls `prepare` immediately at request time, before the transition is applied;
+     * the subsequent `on_enter` reads whatever state `prepare` stashed. Not virtual because
+     * payload signatures vary per stage; see `Conductor::request` docs.
+     *
      * @tparam Conductor The concrete Conductor instantiation that owns this Stage. Forward
      * declaration is sufficient.
      */
-    template <typename ...Stages>
+    template <typename... Stages>
     class Stage {
     public:
         using Conductor = tempo::Conductor<Stages...>;

--- a/lib/tempo/test/test_tempo_request_payload/test.cpp
+++ b/lib/tempo/test/test_tempo_request_payload/test.cpp
@@ -1,0 +1,146 @@
+/**
+ * GoogleTest suite for `Conductor::request<S>(Args...)` payload-passing transitions.
+ *
+ * Verifies the payload form forwards arguments to `S::prepare(...)` immediately
+ * (before the transition is applied) and that stages without prepare still
+ * accept the zero-arg `request<S>()` form unchanged.
+ */
+#include <gtest/gtest.h>
+#include <tempo/stage/conductor.h>
+#include <tempo/stage/stage.h>
+
+namespace {
+
+    enum class Mode { REVIEW, SELECT };
+
+    class StageWithPayload;
+    class PlainStage;
+
+    using TestConductor = tempo::Conductor<StageWithPayload, PlainStage>;
+    using TestStage = tempo::Stage<StageWithPayload, PlainStage>;
+
+    class StageWithPayload : public TestStage {
+    public:
+        Mode last_prepared = Mode::REVIEW;
+        int prepare_call_count = 0;
+        Mode mode_seen_in_on_enter = Mode::REVIEW;
+        int on_enter_count = 0;
+
+        const char* name() const override {
+            return "WithPayload";
+        }
+
+        void prepare(Mode m) {
+            last_prepared = m;
+            ++prepare_call_count;
+        }
+
+        void on_enter(TestConductor::StageType::Conductor&) override {
+            mode_seen_in_on_enter = last_prepared;
+            ++on_enter_count;
+        }
+    };
+
+    class PlainStage : public TestStage {
+    public:
+        int on_enter_count = 0;
+
+        const char* name() const override {
+            return "Plain";
+        }
+
+        void on_enter(TestConductor::StageType::Conductor&) override {
+            ++on_enter_count;
+        }
+    };
+
+} // namespace
+
+TEST(RequestPayload, RequestWithoutArgsLeavesStageDefaults) {
+    StageWithPayload payload;
+    PlainStage plain;
+    TestConductor c;
+    c.register_stage(payload);
+    c.register_stage(plain);
+    c.start<PlainStage>();
+
+    c.request<StageWithPayload>();
+    EXPECT_EQ(payload.prepare_call_count, 0);
+
+    c.apply_pending_transition();
+    EXPECT_EQ(payload.on_enter_count, 1);
+    EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::REVIEW);
+}
+
+TEST(RequestPayload, RequestWithArgCallsPrepareImmediately) {
+    StageWithPayload payload;
+    PlainStage plain;
+    TestConductor c;
+    c.register_stage(payload);
+    c.register_stage(plain);
+    c.start<PlainStage>();
+
+    c.request<StageWithPayload>(Mode::SELECT);
+
+    // prepare runs at request time, before apply.
+    EXPECT_EQ(payload.prepare_call_count, 1);
+    EXPECT_EQ(payload.last_prepared, Mode::SELECT);
+    EXPECT_EQ(payload.on_enter_count, 0);
+
+    c.apply_pending_transition();
+    EXPECT_EQ(payload.on_enter_count, 1);
+    EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::SELECT);
+}
+
+TEST(RequestPayload, LatestRequestWins) {
+    StageWithPayload payload;
+    PlainStage plain;
+    TestConductor c;
+    c.register_stage(payload);
+    c.register_stage(plain);
+    c.start<PlainStage>();
+
+    c.request<StageWithPayload>(Mode::REVIEW);
+    c.request<StageWithPayload>(Mode::SELECT);
+    EXPECT_EQ(payload.prepare_call_count, 2);
+
+    c.apply_pending_transition();
+    EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::SELECT);
+}
+
+TEST(RequestPayload, PlainStageStillTransitions) {
+    StageWithPayload payload;
+    PlainStage plain;
+    TestConductor c;
+    c.register_stage(payload);
+    c.register_stage(plain);
+    c.start<StageWithPayload>();
+
+    c.request<PlainStage>();
+    c.apply_pending_transition();
+    EXPECT_EQ(plain.on_enter_count, 1);
+}
+
+TEST(RequestPayload, SameStageRequestReFiresLifecycleWithNewPayload) {
+    StageWithPayload payload;
+    PlainStage plain;
+    TestConductor c;
+    c.register_stage(payload);
+    c.register_stage(plain);
+
+    payload.prepare(Mode::REVIEW);
+    c.start<StageWithPayload>();
+    EXPECT_EQ(payload.on_enter_count, 1);
+    EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::REVIEW);
+
+    // Same-stage request with a different payload should re-fire on_enter.
+    c.request<StageWithPayload>(Mode::SELECT);
+    EXPECT_TRUE(c.apply_pending_transition());
+    EXPECT_EQ(payload.on_enter_count, 2);
+    EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::SELECT);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/tempo/test/test_tempo_timeouttimer/test.cpp
+++ b/lib/tempo/test/test_tempo_timeouttimer/test.cpp
@@ -1,0 +1,67 @@
+/**
+ * GoogleTest suite for tempo::TimeoutTimer.
+ */
+#include <gtest/gtest.h>
+#include <tempo/core/time.h>
+
+using tempo::TimeoutTimer;
+
+TEST(TimeoutTimer, DefaultIsDisarmed) {
+    TimeoutTimer d;
+    EXPECT_FALSE(d.armed());
+    EXPECT_FALSE(d.reached(0));
+    EXPECT_FALSE(d.reached(1'000'000));
+}
+
+TEST(TimeoutTimer, NotReachedBeforeDuration) {
+    TimeoutTimer d;
+    d.set(100, 50);
+    EXPECT_TRUE(d.armed());
+    EXPECT_FALSE(d.reached(100));
+    EXPECT_FALSE(d.reached(149));
+}
+
+TEST(TimeoutTimer, ReachedAtBoundaryAndStaysReached) {
+    TimeoutTimer d;
+    d.set(100, 50);
+    EXPECT_TRUE(d.reached(150));
+    EXPECT_TRUE(d.reached(151));
+    EXPECT_TRUE(d.reached(10'000));
+}
+
+TEST(TimeoutTimer, DisarmStopsReporting) {
+    TimeoutTimer d;
+    d.set(0, 100);
+    EXPECT_TRUE(d.reached(150));
+    d.disarm();
+    EXPECT_FALSE(d.armed());
+    EXPECT_FALSE(d.reached(150));
+}
+
+TEST(TimeoutTimer, ReSetReplacesPriorArm) {
+    TimeoutTimer d;
+    d.set(0, 100);
+    EXPECT_TRUE(d.reached(150));
+    d.set(150, 100);
+    EXPECT_FALSE(d.reached(200));
+    EXPECT_TRUE(d.reached(250));
+}
+
+TEST(TimeoutTimer, ZeroDurationIsImmediatelyReached) {
+    TimeoutTimer d;
+    d.set(500, 0);
+    EXPECT_TRUE(d.reached(500));
+}
+
+TEST(TimeoutTimer, HandlesUint32Wraparound) {
+    TimeoutTimer d;
+    constexpr uint32_t near_max = 0xFFFFFFFF - 50;
+    d.set(near_max, 100);
+    EXPECT_FALSE(d.reached(near_max + 49));
+    EXPECT_TRUE(d.reached(near_max + 100));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Two independent tempo additions, both header-only.

**TimeoutTimer** (`tempo/core/time.h`) — one-shot deadline counterpart to `IntervalTimer`. `set(now, duration)` arms; `reached(now)` returns true once past and stays true until `disarm()` or re-`set()`. Wraparound-safe via `time_reached`.

**Payload-passing transitions** (`tempo/stage/conductor.h`, `tempo/stage/stage.h`) — `Conductor::request<S>(Args...)` forwards `args` to `S::prepare(Args...)` at request time; `on_enter` then reads what `prepare` stashed. Zero allocation, no Stage base interface change. Stages opt in by defining a non-virtual `prepare` member of any signature. Same-stage requests now re-fire `on_exit + on_enter` so a stage can re-enter itself with new payload (e.g. an internal mode flip).

## Linked issues

None — independent framework features.

## Hardware tested
- [x] None (no hardware change)

How tested:
- `make test` — 20/20 tempo cases (intervaltimer + smoke + new request_payload + new timeouttimer)
- `pio test -e native` — 25/25 root cases unaffected

## Breaking change / migration

- [x] Public lib API (`lib/*` headers)

Details:
- `apply_pending_transition` no longer silently drops same-stage requests — callers that relied on the drop must guard at the call site.
- New `Conductor::request<S>(Args...)` overload is additive; existing zero-arg `request<S>()` unchanged.

## Notes

Designed as the bus for v2 stage merges (e.g. one `PdoPickerStage` with REVIEW/SELECT modes entered via `request<PdoPickerStage>(Mode)`). Consumer code lands in a separate v2 PR off this one.