### PR TITLE
feat(tempo): overloaded helper, drop StageChangedEvent

### DIFF
--- a/lib/tempo/include/tempo/bus/event.h
+++ b/lib/tempo/include/tempo/bus/event.h
@@ -1,15 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include <variant>
 
 namespace tempo {
 
-    struct StageChangedEvent {
-        uint8_t from = 0;
-        uint8_t to = 0;
-    };
-
     template <typename... UserEvents>
-    using Events = std::variant<std::monostate, StageChangedEvent, UserEvents...>;
+    using Events = std::variant<std::monostate, UserEvents...>;
+
 } // namespace tempo

--- a/lib/tempo/include/tempo/bus/visit.h
+++ b/lib/tempo/include/tempo/bus/visit.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace tempo {
+
+    /**
+     * @brief Aggregate of callable types whose `operator()`s overload one another.
+     * See reference: https://en.cppreference.com/cpp/utility/variant/visit2.
+     *
+     * Example:
+     * @code
+     *   std::visit(tempo::overloaded{
+     *       [&](const ButtonEvent& e) { handle_button(e); },
+     *       [&](const EncoderEvent& e) { handle_encoder(e); },
+     *       [](const auto&) {}, // ignore everything else
+     *   }, event);
+     * @endcode
+     *
+     * The catch-all `[](const auto&) {}` is required when the variant has alternatives the call
+     * site does not care about — `std::visit` requires exhaustive coverage. For a
+     * `tempo::Events<...>` variant in particular, `std::monostate` (the default-constructed
+     * sentinel) needs an explicit handler or the catch-all.
+     */
+    template <typename... Fs>
+    struct overloaded : Fs... {
+        using Fs::operator()...;
+    };
+
+    template <typename... Fs>
+    overloaded(Fs...) -> overloaded<Fs...>;
+
+} // namespace tempo

--- a/lib/tempo/include/tempo/tempo.h
+++ b/lib/tempo/include/tempo/tempo.h
@@ -17,6 +17,7 @@
 #include "tempo/bus/event_queue.h"
 #include "tempo/bus/event.h"
 #include "tempo/bus/publisher.h"
+#include "tempo/bus/visit.h"
 
 // stage
 #include "tempo/stage/stage.h"


### PR DESCRIPTION
## Summary
Add `tempo::overloaded` (lambda-pack helper for `std::visit`) and remove the unused `StageChangedEvent` variant alternative. Stage-change signal already flows via `Task::on_stage_changed` (sync callback in `cooperative_scheduler.h`); the event-bus alternative was scaffolding nothing published.

## Linked issues
None.

## Hardware tested
- [x] None (no hardware change)

How tested:
- `pio test -e native` — 25/25 across test_smoke, test_AP33772, test_v2_boot, test_v2_obtain.
- `pio test -e native -d lib/tempo` — 20/20 across test_tempo, test_tempo_intervaltimer, test_tempo_timeouttimer, test_tempo_request_payload.

## Breaking change / migration
- [x] Public lib API (\`lib/*\` headers)

Details: `tempo::Events<...>` no longer carries `StageChangedEvent`. Any downstream code that pattern-matched on it via `std::visit` should drop that and use the lifecycle function instead

## Notes
Companion PocketPD-side PR uses `tempo::overloaded` in ObtainStage's `on_event`; that PR depends on this one landing first.