### PR TITLE
feat(v2): PdoPicker + Normal stage transitions

### DIFF
--- a/include/v2/app.h
+++ b/include/v2/app.h
@@ -3,7 +3,7 @@
  * @brief PocketPD v2 application alias.
  *
  * Provides the `App = tempo::Application<Event, Stages...>` alias used as the
- * single source of truth for stage and task base types throughout v2. 
+ * single source of truth for stage and task base types throughout v2.
  */
 #pragma once
 
@@ -17,9 +17,11 @@ namespace pocketpd {
 
     class BootStage;
     class ObtainStage;
+    class PdoPickerStage;
+    class NormalStage;
 
     // —— Application alias
 
-    using App = tempo::Application<Event, BootStage, ObtainStage>;
+    using App = tempo::Application<Event, BootStage, ObtainStage, PdoPickerStage, NormalStage>;
 
 } // namespace pocketpd

--- a/include/v2/events.h
+++ b/include/v2/events.h
@@ -4,9 +4,11 @@
  */
 #pragma once
 
+#include <tempo/bus/event.h>
+
 #include <cstdint>
 
-#include <tempo/bus/event.h>
+#include "v2/state.h"
 
 namespace pocketpd {
 
@@ -22,6 +24,26 @@ namespace pocketpd {
         uint8_t pps_count = 0;
     };
 
-    using Event = tempo::Events<PdReadyEvent>;
+    /**
+     * @brief Published by ButtonTask on each detected gesture.
+     *
+     * SHORT fires once on release if the press was shorter than the long-press
+     * threshold; LONG fires once when the press duration crosses the threshold
+     * while still pressed (no release event in that case).
+     */
+    struct ButtonEvent {
+        ButtonId id = ButtonId::ENCODER;
+        Gesture gesture = Gesture::SHORT;
+    };
+
+    /**
+     * @brief Published by EncoderTask when the encoder position has changed.
+     * `delta` is the signed tick count since the previous sample.
+     */
+    struct EncoderEvent {
+        int16_t delta = 0;
+    };
+
+    using Event = tempo::Events<PdReadyEvent, ButtonEvent, EncoderEvent>;
 
 } // namespace pocketpd

--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -21,8 +21,7 @@ namespace pocketpd {
      *
      */
     constexpr uint32_t BOOT_TO_OBTAIN_MS = 500;
-    constexpr uint32_t OBTAIN_TO_CAPDISPLAY_MS = 1500;
-    constexpr uint32_t CAPDISPLAY_TO_NORMAL_MS = 3000;
+    constexpr uint32_t OBTAIN_TO_PDOPICKER_MS = 1500;
 
     /**
      * @brief Which PD protocol the active charger speaks.

--- a/include/v2/stage_event_forwarder.h
+++ b/include/v2/stage_event_forwarder.h
@@ -1,0 +1,37 @@
+/**
+ * @file stage_event_forwarder.h
+ * @brief Helper task to forward events to the owning stage. The stage must implement
+ * `on_event(const Event&, uint32_t now_ms)`. This allows the stage to react to events by passing
+ * the current limitation, as Tempo does not support stage-level event handling at this moment.
+ */
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#include "v2/app.h"
+
+namespace pocketpd {
+
+    template <typename OwnerStage>
+    class StageEventForwarder : public App::StageScopedTask {
+    private:
+        OwnerStage& m_owner;
+
+    public:
+        explicit StageEventForwarder(OwnerStage& owner)
+            : App::StageScopedTask(
+                  std::numeric_limits<uint32_t>::max(), App::StageMask::template of<OwnerStage>()
+              ),
+              m_owner(owner) {}
+
+        const char* name() const override {
+            return "StageEventForwarder";
+        }
+
+        void on_event(const Event& event, uint32_t now_ms) override {
+            m_owner.on_event(event, now_ms);
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/boot_stage.h
+++ b/include/v2/stages/boot_stage.h
@@ -5,10 +5,10 @@
  */
 #pragma once
 
-#include <cstdint>
-
 #include <tempo/core/time.h>
 #include <tempo/hardware/display.h>
+
+#include <cstdint>
 
 #include "v2/app.h"
 #include "v2/images.h"
@@ -19,8 +19,7 @@ namespace pocketpd {
     class BootStage : public App::Stage, public tempo::UseLog<BootStage> {
     private:
         tempo::Display& m_display;
-        uint32_t m_deadline_ms = 0;
-        bool m_armed = false;
+        tempo::TimeoutTimer m_timeout;
 
     public:
         static constexpr const char* LOG_TAG = "Boot";
@@ -32,6 +31,7 @@ namespace pocketpd {
         }
 
         void on_enter(Conductor&) override {
+            m_timeout.disarm();
             m_display.clear();
             m_display.draw_bitmap(0, 0, 128 / 8, 64, bitmap::LOGO.data());
             m_display.draw_text(67, 64, "FW: ");
@@ -40,12 +40,11 @@ namespace pocketpd {
         }
 
         void on_tick(Conductor& conductor, uint32_t now_ms) override {
-            if (!m_armed) {
-                m_deadline_ms = now_ms + BOOT_TO_OBTAIN_MS;
-                m_armed = true;
+            if (!m_timeout.armed()) {
+                m_timeout.set(now_ms, BOOT_TO_OBTAIN_MS);
                 return;
             }
-            if (tempo::time_reached(now_ms, m_deadline_ms)) {
+            if (m_timeout.reached(now_ms)) {
                 conductor.request<ObtainStage>();
             }
         }

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -1,0 +1,48 @@
+/**
+ * @file normal_stage.h
+ * @brief Live operating stage for both PPS and fixed PDO chargers.
+ *
+ * Profile (`PPS` vs `PDO`) is set at entry by the caller via
+ * `Conductor::request<NormalStage>(Profile)` which forwards to
+ * `prepare(Profile)`. The profile is locked for the duration of the stage —
+ * to switch profile, exit to PdoPicker SELECT and re-enter.
+ *
+ * Stub today: enters and logs the chosen profile. The full encoder edit
+ * (PPS-only), PDO/PPS RDO issuance, output toggle, autosave, sensor read,
+ * and energy accumulator land once those subsystems arrive.
+ */
+#pragma once
+
+#include "v2/app.h"
+#include "v2/pocketpd.h"
+
+namespace pocketpd {
+
+    class NormalStage : public App::Stage, public tempo::UseLog<NormalStage> {
+    private:
+        // Still don't know if we should use pending variable or not. TBD.
+        Profile m_pending_profile = Profile::PDO;
+        Profile m_profile = Profile::PDO;
+
+    public:
+        static constexpr const char* LOG_TAG = "Normal";
+
+        const char* name() const override {
+            return "NORMAL";
+        }
+
+        Profile profile() const {
+            return m_profile;
+        }
+
+        void prepare(Profile profile) {
+            m_pending_profile = profile;
+        }
+
+        void on_enter(Conductor&) override {
+            m_profile = m_pending_profile;
+            log.info("entered profile=%s", m_profile == Profile::PPS ? "PPS" : "PDO");
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -3,32 +3,46 @@
  * @brief Stage that runs PD negotiation, learns the source PDO list, and
  * announces the result to the rest of the app via `PdReadyEvent`.
  *
- * Issue #33: ObtainStage must NOT issue an RDO request. The first request runs
- * later (NormalPpsStage / NormalPdoStage) once EEPROM has been consulted. Until
- * then the AP33772 holds whatever default profile the source negotiated at
- * begin().
+ * After the announce, ObtainStage acts as a short window to handle user input:
+ *  1. a short button press resumes Normal operation immediately,
+ *  2. encoder rotation jumps to PdoPicker in SELECT mode, and
+ *  3. otherwise the stage times out into PdoPicker REVIEW so the PDO list can be reviewed.
+ *
+ * Issue #33: ObtainStage must NOT issue an RDO request. The first request runs later
+ * (NormalPpsStage / NormalPdoStage) once EEPROM has been consulted. Until then the AP33772 holds
+ * whatever default profile the source negotiated at begin().
  */
 #pragma once
-
-#include <array>
-#include <cstdint>
 
 #include <tempo/bus/publisher.h>
 #include <tempo/core/time.h>
 
-#include "AP33772_debug.h"
+#include <array>
+#include <cstdint>
+#include <variant>
 
+#include "AP33772_debug.h"
 #include "v2/app.h"
 #include "v2/events.h"
 #include "v2/hal/pd_sink_controller.h"
+#include "v2/pocketpd.h"
+#include "v2/stage_event_forwarder.h"
+#include "v2/stages/normal_stage.h"
+#include "v2/stages/pdo_picker_stage.h"
 
 namespace pocketpd {
 
     class ObtainStage : public App::Stage, public tempo::UseLog<ObtainStage> {
     private:
         PdSinkController& m_pd_sink;
+        bool m_pd_ready = false;
+
         tempo::Publisher<Event>& m_publisher;
-        tempo::IntervalTimer m_dump_timer{1000};
+        tempo::IntervalTimer m_dump_timer{3000};
+        tempo::TimeoutTimer m_timeout;
+
+        StageEventForwarder<ObtainStage> m_forwarder{*this};
+        Conductor* m_conductor = nullptr;
 
     public:
         static constexpr const char* LOG_TAG = "Obtain";
@@ -40,12 +54,22 @@ namespace pocketpd {
             return "OBTAIN";
         }
 
-        void on_enter(Conductor&) override {
+        // Probably should put this into tempo or provide first class support for it. TBD.
+        StageEventForwarder<ObtainStage>& forwarder() {
+            return m_forwarder;
+        }
+
+        void on_enter(Conductor& conductor) override {
+            m_conductor = &conductor;
+            m_timeout.disarm();
+            m_pd_ready = false;
+
             if (!m_pd_sink.begin()) {
                 log.error("PD negotiation failed");
                 return;
             }
 
+            m_pd_ready = true;
             const auto pdo_n = static_cast<uint8_t>(m_pd_sink.pdo_count());
             const auto pps_n = static_cast<uint8_t>(m_pd_sink.pps_count());
             m_publisher.publish(PdReadyEvent{pdo_n, pps_n});
@@ -53,13 +77,52 @@ namespace pocketpd {
             log.info("PD ready: %u PDO (%u PPS)", pdo_n, pps_n);
         }
 
-        void on_tick(Conductor&, uint32_t now_ms) override {
-            if (!m_dump_timer.tick(now_ms)) {
+        void on_tick(Conductor& conductor, uint32_t now_ms) override {
+            // Periodically dump the PDO list for debugging
+            if (m_dump_timer.tick(now_ms)) {
+                std::array<char, 2048> buffer{};
+                ap33772::format_pdo(m_pd_sink, buffer.data(), buffer.size());
+                log.info(buffer.data());
+            }
+
+            if (!m_timeout.armed()) {
+                m_timeout.set(now_ms, OBTAIN_TO_PDOPICKER_MS);
                 return;
             }
-            std::array<char, 2048> buffer{};
-            ap33772::format_pdo(m_pd_sink, buffer.data(), buffer.size());
-            log.info(buffer.data());
+
+            if (m_timeout.reached(now_ms)) {
+                conductor.request<PdoPickerStage>(PdoPickerStage::Mode::REVIEW);
+                return; // Should return after stage change request to avoid executing more code
+            }
+        }
+
+        void on_event(const Event& event, uint32_t) {
+            if (m_conductor == nullptr) {
+                return;
+            }
+
+            std::visit(
+                tempo::overloaded{
+                    [&](const ButtonEvent& evt) {
+                        if (evt.gesture == Gesture::SHORT && m_pd_ready) {
+                            const Profile profile =
+                                m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
+                            m_conductor->template request<NormalStage>(profile);
+                        }
+                    },
+                    [&](const EncoderEvent& evt) {
+                        if (evt.delta != 0) {
+                            m_conductor->template request<PdoPickerStage>(
+                                PdoPickerStage::Mode::SELECT
+                            );
+                        }
+                    },
+                    [](const auto&) {
+                        // handle std::monostate and any unrelated event variants
+                    },
+                },
+                event
+            );
         }
     };
 

--- a/include/v2/stages/pdo_picker_stage.h
+++ b/include/v2/stages/pdo_picker_stage.h
@@ -1,0 +1,45 @@
+/**
+ * @file pdo_picker_stage.h
+ * @brief Stub stage; transition target for ObtainStage. Picker UI lands in F4.
+ *
+ * Carries the `Mode` enum so callers can already pass it via
+ * `Conductor::request<PdoPickerStage>(Mode)`. Today `prepare(Mode)` stashes
+ * the value and `on_enter` logs it; nothing is rendered and no events are
+ * handled.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "v2/app.h"
+
+namespace pocketpd {
+
+    class PdoPickerStage : public App::Stage, public tempo::UseLog<PdoPickerStage> {
+    public:
+        enum class Mode : uint8_t { REVIEW, SELECT };
+
+    private:
+        Mode m_pending_mode = Mode::REVIEW;
+
+    public:
+        static constexpr const char* LOG_TAG = "PdoPick";
+
+        const char* name() const override {
+            return "PDO_PICKER";
+        }
+
+        Mode mode() const {
+            return m_pending_mode;
+        }
+
+        void prepare(Mode mode) {
+            m_pending_mode = mode;
+        }
+
+        void on_enter(Conductor&) override {
+            log.info("entered mode=%u", static_cast<unsigned>(m_pending_mode));
+        }
+    };
+
+} // namespace pocketpd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,36 +1,41 @@
 #include <Arduino.h>
 
 #ifdef HW1_3_V2
+#include <ArduinoTwoWireDevice.h>
 #include <PocketPDPinOut.h>
 #include <Wire.h>
 #include <tempo/tempo.h>
 
-#include <AP33772.h>
-#include <ArduinoTwoWireDevice.h>
-
 #include "v2/app.h"
+#include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/arduino_clock.h"
 #include "v2/hal/arduino_stream_writer.h"
-#include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/stages/boot_stage.h"
+#include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
+#include "v2/stages/pdo_picker_stage.h"
+#include <AP33772.h>
 
 namespace {
 
-    // Setup framework components
     pocketpd::ArduinoClock arduino_clock;
     pocketpd::ArduinoStreamWriter arduino_stream_writer;
     pocketpd::App app(arduino_clock, arduino_stream_writer);
 
-    // Setup hardware adapters
+    // —— Hardware adapters
+
     ArduinoTwoWireDevice ap33772_i2c{Wire, ap33772::ADDRESS};
     pocketpd::Ap33772PdSink pd_sink{ap33772_i2c, ::delay};
-    
-    // Setup stages
+
     pocketpd::U8g2Display u8g2_display;
+
+    // —— Stages
+
     pocketpd::BootStage boot_stage(u8g2_display);
     pocketpd::ObtainStage obtain_stage(pd_sink, app.task_publisher());
+    pocketpd::PdoPickerStage pdo_picker_stage;
+    pocketpd::NormalStage normal_stage;
 
 } // namespace
 
@@ -45,6 +50,9 @@ void setup() {
 
     app.register_stage(boot_stage);
     app.register_stage(obtain_stage);
+    app.register_stage(pdo_picker_stage);
+    app.register_stage(normal_stage);
+
     app.start<pocketpd::BootStage>();
 }
 

--- a/test/test_v2_boot/test.cpp
+++ b/test/test_v2_boot/test.cpp
@@ -11,11 +11,9 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
 #include <tempo/stage/conductor.h>
 
-#include <MockDisplay.h>
-
+#include "MockDisplay.h"
 #include "v2/app.h"
 #include "v2/stages/boot_stage.h"
 
@@ -25,7 +23,7 @@ using ::testing::InSequence;
 using ::testing::NiceMock;
 using ::testing::StrEq;
 
-using BootConductor = tempo::Conductor<BootStage, ObtainStage>;
+using BootConductor = App::Conductor;
 
 TEST(BootStage, OnEnterDrawsSplash) {
     MockDisplay display;

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -1,33 +1,35 @@
 /**
  * GoogleTest suite for ObtainStage.
  *
- * Drives Conductor<BootStage, ObtainStage> with scripted MockPdSink and a real
- * EventQueue / QueuePublisher so PdReadyEvent payload can be inspected after
- * on_enter runs. Boot→Obtain timeout transition is verified end-to-end here too.
+ * Drives Conductor<...> with scripted MockPdSink and a real EventQueue /
+ * QueuePublisher so PdReadyEvent payload can be inspected. Also covers the
+ * input-driven exits (short button → resume, encoder → PdoPicker SELECT,
+ * timeout → PdoPicker REVIEW).
  */
 #define VERSION "\"test\""
 
+#include <MockDisplay.h>
+#include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-#include <variant>
-
 #include <tempo/bus/event_queue.h>
 #include <tempo/bus/publisher.h>
 #include <tempo/stage/conductor.h>
 
-#include <MockDisplay.h>
-#include <MockPdSink.h>
+#include <variant>
 
+#include "v2/app.h"
 #include "v2/events.h"
 #include "v2/stages/boot_stage.h"
+#include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
+#include "v2/stages/pdo_picker_stage.h"
 
 using namespace pocketpd;
 using ::testing::NiceMock;
 using ::testing::Return;
 
-using TestConductor = tempo::Conductor<BootStage, ObtainStage>;
+using TestConductor = App::Conductor;
 using TestQueue = tempo::EventQueue<Event, 8>;
 using TestPublisher = tempo::QueuePublisher<Event, 8>;
 
@@ -113,6 +115,116 @@ TEST(ObtainStage, OnEnterIssuesNoRdoRequest) {
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>();
+}
+
+TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
+
+    ObtainStage stage(sink, publisher);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<ObtainStage>();
+
+    stage.on_event(ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PPS);
+}
+
+TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+
+    ObtainStage stage(sink, publisher);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<ObtainStage>();
+
+    stage.on_event(ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PDO);
+}
+
+TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    EXPECT_CALL(sink, begin()).WillOnce(Return(false));
+
+    ObtainStage stage(sink, publisher);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<ObtainStage>();
+
+    stage.on_event(ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+    EXPECT_FALSE(conductor.has_pending());
+}
+
+TEST(ObtainStage, EncoderRotationJumpsToPdoPickerInSelectMode) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+
+    ObtainStage stage(sink, publisher);
+    PdoPickerStage picker;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(picker);
+    conductor.start<ObtainStage>();
+
+    stage.on_event(EncoderEvent{-1}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<PdoPickerStage>());
+    EXPECT_EQ(picker.mode(), PdoPickerStage::Mode::SELECT);
+}
+
+TEST(ObtainStage, TimeoutTransitionsToPdoPickerInReviewMode) {
+    NiceMock<MockPdSink> sink;
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+
+    ObtainStage stage(sink, publisher);
+    PdoPickerStage picker;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(picker);
+    conductor.start<ObtainStage>();
+
+    conductor.tick(0);
+    conductor.tick(OBTAIN_TO_PDOPICKER_MS - 1);
+    EXPECT_FALSE(conductor.has_pending());
+
+    conductor.tick(OBTAIN_TO_PDOPICKER_MS);
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<PdoPickerStage>());
+    EXPECT_EQ(picker.mode(), PdoPickerStage::Mode::REVIEW);
 }
 
 TEST(BootStage, RequestsObtainAfterTimeout) {


### PR DESCRIPTION
## Summary
Add stage transitions for the rest of the user flow: `ObtainStage` → `PdoPickerStage(REVIEW)` (1500 ms timeout), plus `PdoPickerStage` and `NormalStage` stub stages with payload-passing entry (`Mode REVIEW/SELECT`, `Profile PPS/PDO` set via `prepare`).

Adds `ButtonEvent` + `EncoderEvent` to the `Event` variant and `StageEventForwarder<Owner>` glue task so stages can subscribe via a non-virtual `on_event`. ObtainStage uses `tempo::overloaded` over `std::visit` for its event handling.

`main.cpp` registers the new stages but does **not** wire any input source — input HAL + tasks land separately together with the OutputGate HAL + commit logic. ObtainStage owns its `forwarder()` so adding it back is a one-line diff.

In V1, PdoPickerStage is split into two stages: `CapDisplay` and `Menu`. In V2, this is now one stage with feature flag. Same with NormalPps and NormalPdo is now just `NormalStage` with feature flag

## Linked issues
Refs #33 (Obtain still issues no RDO; first request lands with NormalStage real impl in a later PR), #32 (output disable on profile commit ships with OutputGate HAL).

## Hardware tested
- [x] HW1_3

## Breaking change / migration
- [x] None

Details: stages are stubs (PdoPicker logs entered mode; Normal logs entered profile). On hardware: splash → 500 ms → Obtain (negotiate + dump) → 1500 ms → PdoPicker REVIEW. No user-visible interaction yet.

## Notes
- Depends on #56 (\`feat(tempo): overloaded helper, drop StageChangedEvent\`).
- Follow-up PR: input HAL (\`ButtonInput\` / \`EncoderInput\` interfaces + Arduino impls), \`ButtonTask\` / \`EncoderTask\`. 