### PR TITLE
feat(v2): render PD capabilities in PdoPickerStage

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,6 +15,7 @@ DerivePointerAlignment: false
 SpaceAfterCStyleCast: true
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
+BinPackArguments: false
 BinPackParameters: OnePerLine
 PackConstructorInitializers: NextLine
 ReflowComments: true

--- a/include/v2/hal/u8g2_display.h
+++ b/include/v2/hal/u8g2_display.h
@@ -21,7 +21,7 @@ namespace pocketpd {
     public:
         void begin() {
             m_u8g2.begin();
-            m_u8g2.setFont(u8g2_font_profont12_tr);
+            m_u8g2.setFont(u8g2_font_profont11_tr);
         }
 
         void clear() override {

--- a/include/v2/stages/pdo_picker_stage.h
+++ b/include/v2/stages/pdo_picker_stage.h
@@ -1,29 +1,41 @@
 /**
  * @file pdo_picker_stage.h
- * @brief Stub stage; transition target for ObtainStage. Picker UI lands in F4.
+ * @brief PDO picker / capability list stage. Two modes via tempo
+ * payload-passing transition: REVIEW renders the source PDO list and
+ * waits for input; SELECT will host cursor + commit logic in a later PR.
  *
- * Carries the `Mode` enum so callers can already pass it via
- * `Conductor::request<PdoPickerStage>(Mode)`. Today `prepare(Mode)` stashes
- * the value and `on_enter` logs it; nothing is rendered and no events are
- * handled.
+ * REVIEW renders once on entry — the PDO list is fixed for the lifetime
+ * of the negotiation. No on_tick, no input handling yet; transitions out
+ * land with F3b.
  */
 #pragma once
 
+#include <tempo/hardware/display.h>
+
 #include <cstdint>
+#include <cstdio>
 
 #include "v2/app.h"
+#include "v2/hal/pd_sink_controller.h"
 
 namespace pocketpd {
+
+    void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink);
 
     class PdoPickerStage : public App::Stage, public tempo::UseLog<PdoPickerStage> {
     public:
         enum class Mode : uint8_t { REVIEW, SELECT };
 
     private:
+        tempo::Display& m_display;
+        PdSinkController& m_pd_sink;
         Mode m_pending_mode = Mode::REVIEW;
 
     public:
         static constexpr const char* LOG_TAG = "PdoPick";
+
+        PdoPickerStage(tempo::Display& display, PdSinkController& pd_sink)
+            : m_display(display), m_pd_sink(pd_sink) {}
 
         const char* name() const override {
             return "PDO_PICKER";
@@ -38,8 +50,57 @@ namespace pocketpd {
         }
 
         void on_enter(Conductor&) override {
-            log.info("entered mode=%u", static_cast<unsigned>(m_pending_mode));
+            if (m_pending_mode == Mode::REVIEW) {
+                render_pdo_list(m_display, m_pd_sink);
+            } else {
+                log.info("entered mode=SELECT");
+            }
         }
     };
+
+    inline void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink) {
+        display.clear();
+        const int count = pd_sink.pdo_count();
+        if (count == 0) {
+            display.draw_text(8, 34, "No Profile Detected");
+            display.flush();
+            return;
+        }
+
+        std::array<char, 32> buffer{};
+        for (int i = 0; i < count; ++i) {
+            const auto y = static_cast<uint8_t>(9 * (i + 1));
+            if (pd_sink.is_index_fixed(i)) {
+                const int v = pd_sink.pdo_max_voltage_mv(i) / 1000;
+                const int a = pd_sink.pdo_max_current_ma(i) / 1000;
+                std::snprintf(buffer.data(), buffer.size(), "PDO: %dV @ %dA", v, a);
+                display.draw_text(5, y, buffer.data());
+            } else if (pd_sink.is_index_pps(i)) {
+                const int min_mv = pd_sink.pdo_min_voltage_mv(i);
+                const int max_mv = pd_sink.pdo_max_voltage_mv(i);
+                
+                const int min_v = min_mv / 1000;
+                const int min_dv = (min_mv % 1000) / 100;
+                
+                const int max_v = max_mv / 1000;
+                const int max_dv = (max_mv % 1000) / 100;
+                
+                const int a = pd_sink.pdo_max_current_ma(i) / 1000;
+                std::snprintf(
+                    buffer.data(),
+                    buffer.size(),
+                    "PPS: %d.%dV~%d.%dV @ %dA",
+                    min_v,
+                    min_dv,
+                    max_v,
+                    max_dv,
+                    a
+                );
+                display.draw_text(5, y, buffer.data());
+            }
+        }
+
+        display.flush();
+    }
 
 } // namespace pocketpd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ namespace {
 
     pocketpd::BootStage boot_stage(u8g2_display);
     pocketpd::ObtainStage obtain_stage(pd_sink, app.task_publisher());
-    pocketpd::PdoPickerStage pdo_picker_stage;
+    pocketpd::PdoPickerStage pdo_picker_stage(u8g2_display, pd_sink);
     pocketpd::NormalStage normal_stage;
 
 } // namespace

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -187,7 +187,8 @@ TEST(ObtainStage, EncoderRotationJumpsToPdoPickerInSelectMode) {
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
     ObtainStage stage(sink, publisher);
-    PdoPickerStage picker;
+    NiceMock<MockDisplay> picker_display;
+    PdoPickerStage picker(picker_display, sink);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(picker);
@@ -210,7 +211,8 @@ TEST(ObtainStage, TimeoutTransitionsToPdoPickerInReviewMode) {
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
     ObtainStage stage(sink, publisher);
-    PdoPickerStage picker;
+    NiceMock<MockDisplay> picker_display;
+    PdoPickerStage picker(picker_display, sink);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(picker);

--- a/test/test_v2_pdopicker/test.cpp
+++ b/test/test_v2_pdopicker/test.cpp
@@ -1,0 +1,161 @@
+/**
+ * GoogleTest suite for PdoPickerStage REVIEW render.
+ *
+ * Drives the conductor with scripted MockPdSink + MockDisplay, asserts
+ * the draw_text call sequence matches the v1 PDO list layout.
+ */
+#define VERSION "\"test\""
+
+#include <MockDisplay.h>
+#include <MockPdSink.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/stage/conductor.h>
+
+#include "v2/app.h"
+#include "v2/stages/pdo_picker_stage.h"
+
+using namespace pocketpd;
+using ::testing::AnyNumber;
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::StrEq;
+
+using TestConductor = App::Conductor;
+
+TEST(PdoPickerStage, ReviewEmptyListRendersFallback) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(8, 34, StrEq("No Profile Detected"))).Times(1);
+    EXPECT_CALL(display, flush()).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::Ne(8), ::testing::_, ::testing::_)).Times(0);
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, ReviewRendersSingleFixedPdo) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A"))).Times(1);
+    EXPECT_CALL(display, flush()).Times(1);
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, ReviewRendersFixedAndPpsLines) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(9000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(2000));
+
+    EXPECT_CALL(sink, is_index_fixed(1)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(1)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(21000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
+
+    EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 9V @ 2A"))).Times(1);
+    EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 3A"))).Times(1);
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, ReviewRendersMultiplePpsLines) {
+    // issue #24: chargers can advertise multiple PPS APDOs; each must render.
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(0)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(11000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+
+    EXPECT_CALL(sink, is_index_fixed(1)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(1)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(21000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(5000));
+
+    EXPECT_CALL(display, draw_text(5, 9, StrEq("PPS: 3.3V~11.0V @ 3A"))).Times(1);
+    EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 5A"))).Times(1);
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, SelectEntryDoesNotDraw) {
+    // SELECT mode: render + cursor + output-disable land in F4. Today: log-only.
+    using ::testing::_;
+
+    MockDisplay display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(display, clear()).Times(0);
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(0);
+    EXPECT_CALL(display, flush()).Times(0);
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+
+    MockDisplay display;
+    {
+        InSequence seq;
+        EXPECT_CALL(display, clear());
+        EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A")));
+        EXPECT_CALL(display, flush());
+    }
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
`PdoPickerStage` REVIEW renders the source PDO list on the OLED, mirroring v1 `printProfile` CAPDISPLAY layout (`PDO: 5V @ 3A` for fixed supplies, `PPS: 3.3V~21.0V @ 3A` for APDOs, `No Profile Detected` empty fallback). Integer-only `snprintf` keeps newlib float-printf out of the RP2040 image.

SELECT-mode is currently a log stub for now — cursor, long-press commit, and output-disable arrive in the next PR. `U8g2Display` default font is adjusted to `profont11_tr` so 7 lines fit vertically.

## Linked issues
Refs #24

## Hardware tested
- [x] HW1_3

How tested:
`pio test -e native` — 44/44 pass, including 6 new `test_v2_pdopicker` cases (empty fallback, single fixed, mixed fixed+PPS, multi-PPS, SELECT no-render, clear/draw/flush sequence). `pio run -e HW1_3_V2` builds at RAM 4.3% / Flash 4.3%; `pio run -e HW1_3` regression-checks clean. Bench check on real hardware below:

<img width="3024" height="4032" alt="tempImagenJJNAd" src="https://github.com/user-attachments/assets/62615b0f-b67a-4397-8c46-caac7b37b24c" />

## Breaking change / migration
None.

## Notes
Render-only for now. Only REVIEW-mode is implemented here. Next PR adds button/encoder input wiring, ObtainStage early-exit.