### PR TITLE
feat(v2): encoder HAL + PDO picker SELECT cursor

### DIFF
--- a/include/v2/hal/encoder_input.h
+++ b/include/v2/hal/encoder_input.h
@@ -1,0 +1,62 @@
+/**
+ * @file encoder_input.h
+ * @brief Pure-virtual rotary encoder HAL. Arduino impl wraps `RotaryEncoder`; pin ISR uses a
+ * static instance pointer because `attachInterrupt` only takes free functions.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace pocketpd {
+
+    class EncoderInput {
+    public:
+        virtual ~EncoderInput() = default;
+
+        /// Accumulated tick position, signed.
+        virtual int32_t position() const = 0;
+    };
+
+} // namespace pocketpd
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#include <RotaryEncoder.h>
+
+namespace pocketpd {
+
+    class RotaryEncoderInput : public EncoderInput {
+    private:
+        static inline RotaryEncoderInput* s_instance = nullptr;
+        mutable RotaryEncoder m_encoder;
+        const int m_pin_a;
+        const int m_pin_b;
+
+        static void isr_handler() {
+            if (s_instance != nullptr) {
+                s_instance->m_encoder.tick();
+            }
+        }
+
+    public:
+        RotaryEncoderInput(int pin_a, int pin_b)
+            : m_encoder(pin_b, pin_a, RotaryEncoder::LatchMode::FOUR3),
+              m_pin_a(pin_a),
+              m_pin_b(pin_b) {
+
+            s_instance = this;
+        }
+
+        /// Wire the pin ISRs. Call once from `setup()`. Only one instance may be active.
+        void begin() {
+            attachInterrupt(digitalPinToInterrupt(m_pin_a), isr_handler, CHANGE);
+            attachInterrupt(digitalPinToInterrupt(m_pin_b), isr_handler, CHANGE);
+        }
+
+        int32_t position() const override {
+            return static_cast<int32_t>(m_encoder.getPosition());
+        }
+    };
+
+} // namespace pocketpd
+#endif

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -88,26 +88,26 @@ namespace pocketpd {
         }
 
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
-            std::visit(
-                tempo::overloaded{
-                    [&](const ButtonEvent& evt) {
-                        if (evt.gesture == Gesture::SHORT && m_pd_ready) {
-                            const Profile profile =
-                                m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
-                            conductor.request<NormalStage>(profile);
-                        }
-                    },
-                    [&](const EncoderEvent& evt) {
-                        if (evt.delta != 0) {
-                            conductor.request<PdoPickerStage>(PdoPickerStage::Mode::SELECT);
-                        }
-                    },
-                    [](const auto&) {
-                        // handle std::monostate and any unrelated event variants
-                    },
+            
+            auto handler = tempo::overloaded{
+                [&](const ButtonEvent& evt) {
+                    if (evt.gesture == Gesture::SHORT && m_pd_ready) {
+                        const Profile profile =
+                            m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
+                        conductor.request<NormalStage>(profile);
+                    }
                 },
-                event
-            );
+                [&](const EncoderEvent& evt) {
+                    if (evt.delta != 0) {
+                        conductor.request<PdoPickerStage>(PdoPickerStage::Mode::SELECT);
+                    }
+                },
+                [](const auto&) {
+                    // handle std::monostate and any unrelated event variants
+                },
+            };
+
+            std::visit(handler, event);
         }
     };
 

--- a/include/v2/stages/pdo_picker_stage.h
+++ b/include/v2/stages/pdo_picker_stage.h
@@ -1,26 +1,32 @@
 /**
  * @file pdo_picker_stage.h
- * @brief PDO picker / capability list stage. Two modes via tempo
- * payload-passing transition: REVIEW renders the source PDO list and
- * waits for input; SELECT will host cursor + commit logic in a later PR.
+ * @brief PDO picker / capability list stage. Two modes via tempo payload-passing transition:
+ * REVIEW renders the source PDO list and waits for input; SELECT renders the same list with an
+ * encoder-driven cursor.
  *
- * REVIEW renders once on entry — the PDO list is fixed for the lifetime
- * of the negotiation. No on_tick, no input handling yet; transitions out
- * land with F3b.
+ * REVIEW renders once on entry — the PDO list is fixed for the lifetime of the negotiation, so
+ * no on_tick redraw is needed. SELECT re-renders on each cursor move. Output gating on SELECT
+ * entry, REVIEW exit transitions, and long-press commit are not yet wired.
  */
 #pragma once
 
+#include <tempo/bus/publisher.h>
+#include <tempo/bus/visit.h>
 #include <tempo/hardware/display.h>
 
+#include <array>
 #include <cstdint>
 #include <cstdio>
+#include <variant>
+#include <algorithm>
 
 #include "v2/app.h"
+#include "v2/events.h"
 #include "v2/hal/pd_sink_controller.h"
 
 namespace pocketpd {
 
-    void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink);
+    void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor = -1);
 
     class PdoPickerStage : public App::Stage, public tempo::UseLog<PdoPickerStage> {
     public:
@@ -29,7 +35,8 @@ namespace pocketpd {
     private:
         tempo::Display& m_display;
         PdSinkController& m_pd_sink;
-        Mode m_pending_mode = Mode::REVIEW;
+        Mode m_mode = Mode::REVIEW;
+        int m_cursor = 0;
 
     public:
         static constexpr const char* LOG_TAG = "PdoPick";
@@ -42,24 +49,54 @@ namespace pocketpd {
         }
 
         Mode mode() const {
-            return m_pending_mode;
+            return m_mode;
         }
 
         void prepare(Mode mode) {
-            m_pending_mode = mode;
+            m_mode = mode;
         }
 
         void on_enter(Conductor&) override {
-            if (m_pending_mode == Mode::REVIEW) {
+            if (m_mode == Mode::REVIEW) {
                 render_pdo_list(m_display, m_pd_sink);
             } else {
-                log.info("entered mode=SELECT");
+                m_cursor = 0;
+                render_pdo_list(m_display, m_pd_sink, m_cursor);
             }
+        }
+
+        void on_event(Conductor&, const Event& event, uint32_t) override {
+            if (m_mode != Mode::SELECT) {
+                return;
+            }
+
+            auto handler = tempo::overloaded{
+                [&](const EncoderEvent& evt) {
+                    const int count = m_pd_sink.pdo_count();
+                    if (count <= 0 || evt.delta == 0) {
+                        return;
+                    }
+
+                    int next = std::clamp(m_cursor + evt.delta, 0, count - 1);
+                    if (next == m_cursor) {
+                        return;
+                    }
+
+                    m_cursor = next;
+                    render_pdo_list(m_display, m_pd_sink, m_cursor);
+                },
+                [](const auto&) {},
+            };
+
+            std::visit(handler, event);
         }
     };
 
-    inline void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink) {
+    inline void
+    render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor) {
+
         display.clear();
+
         const int count = pd_sink.pdo_count();
         if (count == 0) {
             display.draw_text(8, 34, "No Profile Detected");
@@ -68,24 +105,29 @@ namespace pocketpd {
         }
 
         std::array<char, 32> buffer{};
-        for (int i = 0; i < count; ++i) {
-            const auto y = static_cast<uint8_t>(9 * (i + 1));
-            if (pd_sink.is_index_fixed(i)) {
-                const int v = pd_sink.pdo_max_voltage_mv(i) / 1000;
-                const int a = pd_sink.pdo_max_current_ma(i) / 1000;
+        for (int row_index = 0; row_index < count; row_index++) {
+            const auto y = static_cast<uint8_t>(9 * (row_index + 1));
+            
+            if (row_index == cursor) {
+                display.draw_text(0, y, ">");
+            }
+            
+            if (pd_sink.is_index_fixed(row_index)) {
+                const int v = pd_sink.pdo_max_voltage_mv(row_index) / 1000;
+                const int a = pd_sink.pdo_max_current_ma(row_index) / 1000;
                 std::snprintf(buffer.data(), buffer.size(), "PDO: %dV @ %dA", v, a);
                 display.draw_text(5, y, buffer.data());
-            } else if (pd_sink.is_index_pps(i)) {
-                const int min_mv = pd_sink.pdo_min_voltage_mv(i);
-                const int max_mv = pd_sink.pdo_max_voltage_mv(i);
-                
+            } else if (pd_sink.is_index_pps(row_index)) {
+                const int min_mv = pd_sink.pdo_min_voltage_mv(row_index);
+                const int max_mv = pd_sink.pdo_max_voltage_mv(row_index);
+
                 const int min_v = min_mv / 1000;
                 const int min_dv = (min_mv % 1000) / 100;
-                
+
                 const int max_v = max_mv / 1000;
                 const int max_dv = (max_mv % 1000) / 100;
-                
-                const int a = pd_sink.pdo_max_current_ma(i) / 1000;
+
+                const int a = pd_sink.pdo_max_current_ma(row_index) / 1000;
                 std::snprintf(
                     buffer.data(),
                     buffer.size(),
@@ -96,6 +138,7 @@ namespace pocketpd {
                     max_dv,
                     a
                 );
+
                 display.draw_text(5, y, buffer.data());
             }
         }

--- a/include/v2/tasks/encoder_task.h
+++ b/include/v2/tasks/encoder_task.h
@@ -1,0 +1,58 @@
+/**
+ * @file encoder_task.h
+ * @brief Samples encoder at 5 ms; publishes signed delta on change. First poll arms the baseline
+ * silently. `poll()` is public so native tests drive the task directly.
+ */
+#pragma once
+
+#include <tempo/bus/publisher.h>
+
+#include <cstdint>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/hal/encoder_input.h"
+
+namespace pocketpd {
+
+    class EncoderTask : public App::BackgroundTask, public tempo::UseLog<EncoderTask> {
+    public:
+        static constexpr uint32_t POLL_PERIOD_MS = 5;
+        static constexpr const char* LOG_TAG = "EncoderTask";
+
+    private:
+        EncoderInput& m_input;
+        tempo::Publisher<Event>& m_publisher;
+        int32_t m_last_position = 0;
+        bool m_armed = false;
+
+    public:
+        EncoderTask(EncoderInput& input, tempo::Publisher<Event>& publisher)
+            : App::BackgroundTask(POLL_PERIOD_MS), m_input(input), m_publisher(publisher) {}
+
+        const char* name() const override {
+            return "EncoderTask";
+        }
+
+        void poll() {
+            const auto pos = m_input.position();
+            log.debug("%d", pos);
+            if (!m_armed) {
+                m_last_position = pos;
+                m_armed = true;
+                return;
+            }
+            const auto delta = pos - m_last_position;
+            if (delta != 0) {
+                m_publisher.publish(EncoderEvent{static_cast<int16_t>(delta)});
+                m_last_position = pos;
+            }
+        }
+
+    protected:
+        void on_tick(uint32_t) override {
+            poll();
+        }
+    };
+
+} // namespace pocketpd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,13 @@
 #include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/arduino_clock.h"
 #include "v2/hal/arduino_stream_writer.h"
+#include "v2/hal/encoder_input.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/stages/boot_stage.h"
 #include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
 #include "v2/stages/pdo_picker_stage.h"
+#include "v2/tasks/encoder_task.h"
 #include <AP33772.h>
 
 namespace {
@@ -30,12 +32,18 @@ namespace {
 
     pocketpd::U8g2Display u8g2_display;
 
+    pocketpd::RotaryEncoderInput encoder{pin_encoder_A, pin_encoder_B};
+
     // —— Stages
 
     pocketpd::BootStage boot_stage(u8g2_display);
     pocketpd::ObtainStage obtain_stage(pd_sink, app.task_publisher());
     pocketpd::PdoPickerStage pdo_picker_stage(u8g2_display, pd_sink);
     pocketpd::NormalStage normal_stage;
+
+    // —— Tasks
+
+    pocketpd::EncoderTask encoder_task(encoder, app.task_publisher());
 
 } // namespace
 
@@ -47,11 +55,14 @@ void setup() {
     Wire.begin();
 
     u8g2_display.begin();
+    encoder.begin();
 
     app.register_stage(boot_stage);
     app.register_stage(obtain_stage);
     app.register_stage(pdo_picker_stage);
     app.register_stage(normal_stage);
+
+    app.add_task(encoder_task);
 
     app.start<pocketpd::BootStage>();
 }

--- a/test/mocks/MockEncoderInput.h
+++ b/test/mocks/MockEncoderInput.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <cstdint>
+
+#include "v2/hal/encoder_input.h"
+
+namespace pocketpd {
+
+    class MockEncoderInput : public EncoderInput {
+    public:
+        MOCK_METHOD(int32_t, position, (), (const, override));
+    };
+
+    /**
+     * @brief Scripted EncoderInput for tests that just need to set the next
+     * position value.
+     */
+    class FakeEncoderInput : public EncoderInput {
+    private:
+        int32_t m_position = 0;
+
+    public:
+        void set_position(int32_t pos) {
+            m_position = pos;
+        }
+
+        int32_t position() const override {
+            return m_position;
+        }
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_pdopicker/test.cpp
+++ b/test/test_v2_pdopicker/test.cpp
@@ -1,8 +1,6 @@
 /**
- * GoogleTest suite for PdoPickerStage REVIEW render.
- *
- * Drives the conductor with scripted MockPdSink + MockDisplay, asserts
- * the draw_text call sequence matches the v1 PDO list layout.
+ * @file test.cpp
+ * @brief PdoPickerStage render + cursor tests, scripted MockPdSink + MockDisplay.
  */
 #define VERSION "\"test\""
 
@@ -13,6 +11,7 @@
 #include <tempo/stage/conductor.h>
 
 #include "v2/app.h"
+#include "v2/events.h"
 #include "v2/stages/pdo_picker_stage.h"
 
 using namespace pocketpd;
@@ -115,21 +114,146 @@ TEST(PdoPickerStage, ReviewRendersMultiplePpsLines) {
     conductor.start<PdoPickerStage>();
 }
 
-TEST(PdoPickerStage, SelectEntryDoesNotDraw) {
-    // SELECT mode: render + cursor + output-disable land in F4. Today: log-only.
-    using ::testing::_;
-
-    MockDisplay display;
+TEST(PdoPickerStage, SelectEntryDrawsCursorAtFirstRow) {
+    NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    EXPECT_CALL(display, clear()).Times(0);
-    EXPECT_CALL(display, draw_text(_, _, _)).Times(0);
-    EXPECT_CALL(display, flush()).Times(0);
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, is_index_fixed(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(9000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(2000));
+
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(0, 9, StrEq(">"))).Times(1);
+    EXPECT_CALL(display, draw_text(0, 18, StrEq(">"))).Times(0);
+    EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A"))).Times(1);
+    EXPECT_CALL(display, draw_text(5, 18, StrEq("PDO: 9V @ 2A"))).Times(1);
+    EXPECT_CALL(display, flush()).Times(1);
 
     PdoPickerStage stage(display, sink);
     stage.prepare(PdoPickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, SelectEncoderMovesCursorAndRerenders) {
+    using ::testing::_;
+    using ::testing::AnyNumber;
+
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
+        EXPECT_CALL(sink, is_index_pps(i)).WillRepeatedly(Return(false));
+        EXPECT_CALL(sink, pdo_max_voltage_mv(i)).WillRepeatedly(Return(5000));
+        EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
+    }
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+
+    ::testing::Mock::VerifyAndClearExpectations(&display);
+
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(5, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(0, 9, StrEq(">"))).Times(0);
+    EXPECT_CALL(display, draw_text(0, 18, StrEq(">"))).Times(1);
+    EXPECT_CALL(display, draw_text(0, 27, StrEq(">"))).Times(0);
+    EXPECT_CALL(display, flush()).Times(1);
+
+    stage.on_event(conductor, EncoderEvent{1}, 0);
+}
+
+TEST(PdoPickerStage, SelectEncoderClampsAtTopAndBottom) {
+    using ::testing::_;
+    using ::testing::AnyNumber;
+
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    for (int i = 0; i < 2; ++i) {
+        EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
+        EXPECT_CALL(sink, is_index_pps(i)).WillRepeatedly(Return(false));
+        EXPECT_CALL(sink, pdo_max_voltage_mv(i)).WillRepeatedly(Return(5000));
+        EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
+    }
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+    ::testing::Mock::VerifyAndClearExpectations(&display);
+
+    EXPECT_CALL(display, clear()).Times(0);
+    EXPECT_CALL(display, flush()).Times(0);
+    stage.on_event(conductor, EncoderEvent{-5}, 0);
+    ::testing::Mock::VerifyAndClearExpectations(&display);
+
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(5, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(0, 9, StrEq(">"))).Times(0);
+    EXPECT_CALL(display, draw_text(0, 18, StrEq(">"))).Times(1);
+    EXPECT_CALL(display, flush()).Times(1);
+    stage.on_event(conductor, EncoderEvent{10}, 0);
+    ::testing::Mock::VerifyAndClearExpectations(&display);
+
+    EXPECT_CALL(display, clear()).Times(0);
+    EXPECT_CALL(display, flush()).Times(0);
+    stage.on_event(conductor, EncoderEvent{4}, 0);
+}
+
+TEST(PdoPickerStage, SelectEmptyListIgnoresEncoder) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+    ::testing::Mock::VerifyAndClearExpectations(&display);
+
+    EXPECT_CALL(display, clear()).Times(0);
+    EXPECT_CALL(display, flush()).Times(0);
+    stage.on_event(conductor, EncoderEvent{1}, 0);
+}
+
+TEST(PdoPickerStage, ReviewIgnoresEncoderEvents) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, is_index_fixed(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(9000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(2000));
+
+    PdoPickerStage stage(display, sink);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+    ::testing::Mock::VerifyAndClearExpectations(&display);
+
+    // Cursor logic / re-render is SELECT-only. REVIEW must not redraw.
+    EXPECT_CALL(display, clear()).Times(0);
+    EXPECT_CALL(display, flush()).Times(0);
+    EXPECT_CALL(display, draw_text(0, ::testing::_, ::testing::_)).Times(0);
+    stage.on_event(conductor, EncoderEvent{1}, 0);
 }
 
 TEST(PdoPickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {


### PR DESCRIPTION
## Summary
Adds the encoder input layer (`EncoderInput` HAL + `RotaryEncoderInput` Arduino impl + `EncoderTask`) and wires it into `PdoPickerStage` SELECT mode. Selection now renders the PDO list with a `>` cursor that the encoder moves. Rotation is sampled as a `getPosition()` delta at 5 ms; v1 used `getDirection()`, which collapses any rotation between polls into a single ±1 and drops the rest (issue #11). Position-delta polling preserves magnitude.

## Linked issues
Refs #11

## Hardware tested
- [x] HW1_3

How tested: `pio test -e native` (40/40 pass), `pio run -e HW1_3_V2` (RAM 4.5%, Flash 4.4%). On bench: clockwise rotation produces positive position delta; SELECT mode draws `>` at the cursor row and moves it on each detent (see below photo).

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details: PdoPicker SELECT mode previously rendered nothing (log-only stub). It now draws the PDO list with a cursor when the encoder is rotated from OBTAIN. REVIEW mode is unchanged. No public lib API change; no EEPROM or PD-protocol change.

## Notes
Output gating on SELECT entry, REVIEW exit transitions (timeout / short-button → NormalStage, encoder → in-place flip to SELECT), and long-press commit are not wired here — they land with the OutputGate HAL in a follow-up.

<img width="3024" height="4032" alt="tempImageOQ0niT" src="https://github.com/user-attachments/assets/1b851cbb-4cc6-4484-abc5-04cbae831d4a" />
