### PR TITLE
refactor(tempo+v2): retarget EncoderTask onto tempo::EncoderInput

### DIFF
--- a/include/v2/events.h
+++ b/include/v2/events.h
@@ -41,7 +41,7 @@ namespace pocketpd {
      * `delta` is the signed tick count since the previous sample.
      */
     struct EncoderEvent {
-        int16_t delta = 0;
+        int delta = 0;
     };
 
     using Event = tempo::Events<PdReadyEvent, ButtonEvent, EncoderEvent>;

--- a/include/v2/hal/rotary_encoder_input.h
+++ b/include/v2/hal/rotary_encoder_input.h
@@ -1,31 +1,22 @@
 /**
- * @file encoder_input.h
- * @brief Pure-virtual rotary encoder HAL. Arduino impl wraps `RotaryEncoder`; pin ISR uses a
- * static instance pointer because `attachInterrupt` only takes free functions.
+ * @file rotary_encoder_input.h
+ * @brief `RotaryEncoder`-backed implementation of `EncoderInput`.
+ *
+ * Owns a `RotaryEncoder` instance. The pin ISR uses a static instance pointer
+ * because `attachInterrupt` only takes free functions; only one `RotaryEncoderInput` may be active
+ * at a time.
  */
 #pragma once
+
+#include <Arduino.h>
+#include <RotaryEncoder.h>
+#include <tempo/hardware/encoder_input.h>
 
 #include <cstdint>
 
 namespace pocketpd {
 
-    class EncoderInput {
-    public:
-        virtual ~EncoderInput() = default;
-
-        /// Accumulated tick position, signed.
-        virtual int32_t position() const = 0;
-    };
-
-} // namespace pocketpd
-
-#ifdef ARDUINO
-#include <Arduino.h>
-#include <RotaryEncoder.h>
-
-namespace pocketpd {
-
-    class RotaryEncoderInput : public EncoderInput {
+    class RotaryEncoderInput : public tempo::EncoderInput {
     private:
         static inline RotaryEncoderInput* s_instance = nullptr;
         mutable RotaryEncoder m_encoder;
@@ -47,7 +38,7 @@ namespace pocketpd {
             s_instance = this;
         }
 
-        /// Wire the pin ISRs. Call once from `setup()`. Only one instance may be active.
+        /// Wire the pin ISRs
         void begin() {
             attachInterrupt(digitalPinToInterrupt(m_pin_a), isr_handler, CHANGE);
             attachInterrupt(digitalPinToInterrupt(m_pin_b), isr_handler, CHANGE);
@@ -59,4 +50,3 @@ namespace pocketpd {
     };
 
 } // namespace pocketpd
-#endif

--- a/include/v2/tasks/encoder_task.h
+++ b/include/v2/tasks/encoder_task.h
@@ -1,50 +1,46 @@
 /**
  * @file encoder_task.h
- * @brief Samples encoder at 5 ms; publishes signed delta on change. First poll arms the baseline
- * silently. `poll()` is public so native tests drive the task directly.
+ * @brief Samples encoder at 5 ms; publishes signed delta on change. `on_start()` latches the
+ * baseline once the scheduler goes live. `poll()` is public so native tests drive the task
+ * directly.
  */
 #pragma once
 
 #include <tempo/bus/publisher.h>
-
-#include <cstdint>
+#include <tempo/hardware/encoder_input.h>
 
 #include "v2/app.h"
 #include "v2/events.h"
-#include "v2/hal/encoder_input.h"
 
 namespace pocketpd {
 
     class EncoderTask : public App::BackgroundTask, public tempo::UseLog<EncoderTask> {
+    private:
+        tempo::EncoderInput& m_input;
+        tempo::Publisher<Event>& m_publisher;
+        int m_last_position = 0;
+
+        static constexpr int POLL_PERIOD_MS = 5;
+
     public:
-        static constexpr uint32_t POLL_PERIOD_MS = 5;
         static constexpr const char* LOG_TAG = "EncoderTask";
 
-    private:
-        EncoderInput& m_input;
-        tempo::Publisher<Event>& m_publisher;
-        int32_t m_last_position = 0;
-        bool m_armed = false;
-
-    public:
-        EncoderTask(EncoderInput& input, tempo::Publisher<Event>& publisher)
+        EncoderTask(tempo::EncoderInput& input, tempo::Publisher<Event>& publisher)
             : App::BackgroundTask(POLL_PERIOD_MS), m_input(input), m_publisher(publisher) {}
 
         const char* name() const override {
             return "EncoderTask";
         }
 
+        void on_start() override {
+            m_last_position = m_input.position();
+        }
+
         void poll() {
-            const auto pos = m_input.position();
-            log.debug("%d", pos);
-            if (!m_armed) {
-                m_last_position = pos;
-                m_armed = true;
-                return;
-            }
-            const auto delta = pos - m_last_position;
+            const int pos = m_input.position();
+            const int delta = pos - m_last_position;
             if (delta != 0) {
-                m_publisher.publish(EncoderEvent{static_cast<int16_t>(delta)});
+                m_publisher.publish(EncoderEvent{delta});
                 m_last_position = pos;
             }
         }

--- a/lib/tempo/include/tempo/hardware/encoder_input.h
+++ b/lib/tempo/include/tempo/hardware/encoder_input.h
@@ -1,0 +1,21 @@
+/**
+ * @file encoder_input.h
+ * @brief Abstract rotary encoder input.
+ *
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace tempo {
+
+    /**
+     * @brief Abstract rotary encoder.
+     */
+    class EncoderInput {
+    public:
+        virtual ~EncoderInput() = default;
+        virtual int32_t position() const = 0;
+    };
+
+} // namespace tempo

--- a/lib/tempo/include/tempo/tempo.h
+++ b/lib/tempo/include/tempo/tempo.h
@@ -10,6 +10,7 @@
 #include "tempo/core/time.h"
 
 // hardware (interfaces)
+#include "tempo/hardware/encoder_input.h"
 #include "tempo/hardware/display.h"
 #include "tempo/hardware/stream.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@
 #include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/arduino_clock.h"
 #include "v2/hal/arduino_stream_writer.h"
-#include "v2/hal/encoder_input.h"
+#include "v2/hal/rotary_encoder_input.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/stages/boot_stage.h"
 #include "v2/stages/normal_stage.h"

--- a/test/mocks/MockEncoderInput.h
+++ b/test/mocks/MockEncoderInput.h
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <gmock/gmock.h>
+#include <tempo/hardware/encoder_input.h>
 
 #include <cstdint>
 
-#include "v2/hal/encoder_input.h"
-
 namespace pocketpd {
 
-    class MockEncoderInput : public EncoderInput {
+    class MockEncoderInput : public tempo::EncoderInput {
     public:
         MOCK_METHOD(int32_t, position, (), (const, override));
     };
@@ -17,7 +16,7 @@ namespace pocketpd {
      * @brief Scripted EncoderInput for tests that just need to set the next
      * position value.
      */
-    class FakeEncoderInput : public EncoderInput {
+    class FakeEncoderInput : public tempo::EncoderInput {
     private:
         int32_t m_position = 0;
 

--- a/test/test_v2_inputs/test.cpp
+++ b/test/test_v2_inputs/test.cpp
@@ -1,0 +1,98 @@
+/**
+ * GoogleTest suite for EncoderTask.
+ *
+ * Drives the task's public `poll()` directly with a scripted FakeEncoderInput plus a real
+ * EventQueue, then inspects what was published.
+ */
+#define VERSION "\"test\""
+
+#include <MockEncoderInput.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/bus/event_queue.h>
+#include <tempo/bus/publisher.h>
+
+#include <variant>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/tasks/encoder_task.h"
+
+using namespace pocketpd;
+
+using TestQueue = tempo::EventQueue<Event, 8>;
+using TestPublisher = tempo::QueuePublisher<Event, 8>;
+
+namespace {
+
+    template <typename T>
+    const T* pop_as(TestQueue& q) {
+        static Event last;
+        if (!q.pop(last)) {
+            return nullptr;
+        }
+        return std::get_if<T>(&last);
+    }
+
+} // namespace
+
+TEST(EncoderTask, OnStartLatchesBaselineWithoutEvent) {
+    FakeEncoderInput enc;
+    TestQueue q;
+    TestPublisher pub(q);
+    EncoderTask task(enc, pub);
+
+    enc.set_position(42);
+    task.on_start();
+    task.poll();
+
+    Event tmp;
+    EXPECT_FALSE(q.pop(tmp));
+}
+
+TEST(EncoderTask, NonZeroDeltaPublishes) {
+    FakeEncoderInput enc;
+    TestQueue q;
+    TestPublisher pub(q);
+    EncoderTask task(enc, pub);
+    task.on_start();
+
+    enc.set_position(3);
+    task.poll();
+
+    const auto* ev = pop_as<EncoderEvent>(q);
+    ASSERT_NE(ev, nullptr);
+    EXPECT_EQ(ev->delta, 3);
+}
+
+TEST(EncoderTask, NoChangeMeansNoEvent) {
+    FakeEncoderInput enc;
+    TestQueue q;
+    TestPublisher pub(q);
+    EncoderTask task(enc, pub);
+    task.on_start();
+    task.poll();
+
+    Event tmp;
+    EXPECT_FALSE(q.pop(tmp));
+}
+
+TEST(EncoderTask, NegativeDelta) {
+    FakeEncoderInput enc;
+    TestQueue q;
+    TestPublisher pub(q);
+    EncoderTask task(enc, pub);
+    enc.set_position(5);
+    task.on_start();
+    enc.set_position(2);
+    task.poll();
+
+    const auto* ev = pop_as<EncoderEvent>(q);
+    ASSERT_NE(ev, nullptr);
+    EXPECT_EQ(ev->delta, -3);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
Lifts the EncoderInput abstract interface into `tempo/hardware` (matching Display and Stream), then retargets EncoderTask onto it. The Arduino-backed concrete impl is renamed to `rotary_encoder_input.h`. EncoderTask seeds its baseline in `on_start` instead of the prior first-poll arming flag.

## Linked issues

## Hardware tested
- [x] None (no hardware change)

How tested:
Native `pio test -e native` (44 cases pass) and `pio run -e HW1_3_V2` build green. No firmware flashed.

## Breaking change / migration

Details:

## Notes
EncoderTask's first-poll arming flag is removed; native tests call `task.on_start()` before `task.poll()` to seed the baseline.