### PR TITLE
feat(tempo+v2): button HAL + gesture detector + ButtonTask

### DIFF
--- a/include/v2/hal/ez_button_input.h
+++ b/include/v2/hal/ez_button_input.h
@@ -1,0 +1,34 @@
+/**
+ * @file ez_button_input.h
+ * @brief `ezButton`-backed implementation of `ButtonInput`.
+ *
+ * Owns an `ezButton` instance and forwards `ButtonInput` calls to it. Active-low wiring
+ * (held = `LOW`) matches the PocketPD board.
+ */
+#pragma once
+
+#include <Arduino.h>
+#include <ezButton.h>
+#include <tempo/hardware/button_input.h>
+
+namespace pocketpd {
+
+    class EzButtonInput : public tempo::ButtonInput {
+    private:
+        mutable ezButton m_button;
+
+    public:
+        explicit EzButtonInput(int pin, unsigned long debounce_ms = 50) : m_button(pin) {
+            m_button.setDebounceTime(debounce_ms);
+        }
+
+        void update() override {
+            m_button.loop();
+        }
+
+        bool is_held() const override {
+            return m_button.getState() == LOW;
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/input/button_gesture.h
+++ b/include/v2/input/button_gesture.h
@@ -1,0 +1,91 @@
+/**
+ * @file button_gesture.h
+ * @brief Pure state machine that turns a (held, now_ms) sample stream into SHORT / LONG gestures.
+ * Owned per-button by ButtonTask. No publisher, no hardware — fully unit testable.
+ */
+#pragma once
+
+#include <tempo/core/time.h>
+
+#include <cstdint>
+#include <optional>
+
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    struct ButtonGestureConfig {
+        uint32_t long_press_ms = 1500;
+    };
+
+    class ButtonGestureDetector {
+    private:
+        enum class State : uint8_t {
+            IDLE,
+            PRESSED,  
+            POST_LONG,
+        };
+        
+        State m_state = State::IDLE;
+
+        ButtonGestureConfig m_config;
+        tempo::TimeoutTimer m_long_timeout;
+
+    public:
+        explicit ButtonGestureDetector(ButtonGestureConfig config = {}) : m_config(config) {}
+
+        /**
+         * @brief Feed one sample. Returns a gesture on the tick it is recognized, otherwise
+         * `std::nullopt`.
+         *
+         * SHORT fires on release if the press did not cross the long-press threshold. LONG fires
+         * once at the threshold while still held; the eventual release produces no event.
+         *
+         * State diagram:
+         * @verbatim
+         *     ┌──────┐  hold / arm timer   ┌─────────┐  reached / LONG    ┌───────────┐
+         *     │ IDLE │ ───────────────────▶│ PRESSED │ ──────────────────▶│ POST_LONG │
+         *     └──────┘                     └────┬────┘                    └─────┬─────┘
+         *         ▲                             │                               │
+         *         │       release / SHORT       │            release            │
+         *         └─────────────────────────────┴───────────────────────────────┘
+         * @endverbatim
+         */
+        std::optional<Gesture> update(bool is_holding, uint32_t now_ms) {
+            switch (m_state) {
+            case State::IDLE:
+                if (is_holding) {
+                    m_state = State::PRESSED;
+                    m_long_timeout.set(now_ms, m_config.long_press_ms);
+                }
+
+                return std::nullopt;
+
+            case State::PRESSED:
+                if (!is_holding) {
+                    m_state = State::IDLE;
+                    m_long_timeout.disarm();
+                    return Gesture::SHORT;
+                }
+
+                if (m_long_timeout.reached(now_ms)) {
+                    m_state = State::POST_LONG;
+                    m_long_timeout.disarm();
+                    return Gesture::LONG;
+                }
+
+                return std::nullopt;
+
+            case State::POST_LONG:
+                if (!is_holding) {
+                    m_state = State::IDLE;
+                }
+
+                return std::nullopt;
+            }
+
+            return std::nullopt;
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/tasks/button_task.h
+++ b/include/v2/tasks/button_task.h
@@ -1,0 +1,106 @@
+/**
+ * @file button_task.h
+ * @brief Polls 3 buttons at 5 ms and feeds each into its own ButtonGestureDetector. Publishes a
+ * `ButtonEvent` whenever a detector recognizes a SHORT or LONG gesture. `poll(now_ms)`
+ * is public so native tests drive the task directly.
+ */
+#pragma once
+
+#include <tempo/bus/publisher.h>
+#include <tempo/hardware/button_input.h>
+
+#include <cstdint>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/input/button_gesture.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    class ButtonTask : public App::BackgroundTask, public tempo::UseLog<ButtonTask> {
+    private:
+        struct DetectorRef {
+            ButtonId id;
+            tempo::ButtonInput* input;
+            ButtonGestureDetector detector;
+
+            DetectorRef() = delete;
+        };
+
+        tempo::Publisher<Event>& m_publisher;
+        std::array<DetectorRef, 3> m_detectors;
+
+        static constexpr uint32_t POLL_PERIOD_MS = 5;
+
+    public:
+        static constexpr const char* LOG_TAG = "ButtonTask";
+
+        ButtonTask(
+            tempo::Publisher<Event>& publisher,
+            tempo::ButtonInput& btn_encoder,
+            tempo::ButtonInput& btn_vi_selector,
+            tempo::ButtonInput& btn_output,
+            ButtonGestureConfig gesture_config = {}
+        )
+            : App::BackgroundTask(POLL_PERIOD_MS),
+              m_publisher(publisher),
+              m_detectors{
+                  DetectorRef{
+                      ButtonId::ENCODER,
+                      &btn_encoder,
+                      ButtonGestureDetector{gesture_config},
+                  },
+                  DetectorRef{
+                      ButtonId::SELECT_VI,
+                      &btn_vi_selector,
+                      ButtonGestureDetector{gesture_config},
+                  },
+                  DetectorRef{
+                      ButtonId::OUTPUT_TOGGLE,
+                      &btn_output,
+                      ButtonGestureDetector{gesture_config},
+                  },
+              } {}
+
+        const char* name() const override {
+            return "ButtonTask";
+        }
+
+        const char* button_name(ButtonId id) {
+            switch (id) {
+            case ButtonId::ENCODER:
+                return "ENCODER";
+            case ButtonId::SELECT_VI:
+                return "SELECT_VI";
+            case ButtonId::OUTPUT_TOGGLE:
+                return "OUTPUT_TOGGLE";
+            default:
+                return "UNKNOWN";
+            }
+        }
+
+        void poll(uint32_t now_ms) {
+            for (DetectorRef& ref : m_detectors) {
+                ref.input->update();
+
+                const bool is_held = ref.input->is_held();
+                const std::optional<Gesture> gesture = ref.detector.update(is_held, now_ms);
+                if (gesture.has_value()) {
+                    log.debug(
+                        "button=%s detected gesture=%s",
+                        button_name(ref.id),
+                        gesture.value() == Gesture::SHORT ? "SHORT" : "LONG"
+                    );
+                    m_publisher.publish(ButtonEvent{ref.id, gesture.value()});
+                }
+            }
+        }
+
+    protected:
+        void on_tick(uint32_t now_ms) override {
+            poll(now_ms);
+        }
+    };
+
+} // namespace pocketpd

--- a/lib/tempo/include/tempo/hardware/button_input.h
+++ b/lib/tempo/include/tempo/hardware/button_input.h
@@ -1,0 +1,19 @@
+/**
+ * @file button_input.h
+ * @brief Abstract momentary-button input.
+ *
+ */
+#pragma once
+
+namespace tempo {
+
+    class ButtonInput {
+    public:
+        virtual ~ButtonInput() = default;
+
+        /// Drive debounce state. Call once per task tick.
+        virtual void update() = 0;
+        virtual bool is_held() const = 0;
+    };
+
+} // namespace tempo

--- a/lib/tempo/include/tempo/tempo.h
+++ b/lib/tempo/include/tempo/tempo.h
@@ -10,6 +10,7 @@
 #include "tempo/core/time.h"
 
 // hardware (interfaces)
+#include "tempo/hardware/button_input.h"
 #include "tempo/hardware/encoder_input.h"
 #include "tempo/hardware/display.h"
 #include "tempo/hardware/stream.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,12 +10,14 @@
 #include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/arduino_clock.h"
 #include "v2/hal/arduino_stream_writer.h"
+#include "v2/hal/ez_button_input.h"
 #include "v2/hal/rotary_encoder_input.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/stages/boot_stage.h"
 #include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
 #include "v2/stages/pdo_picker_stage.h"
+#include "v2/tasks/button_task.h"
 #include "v2/tasks/encoder_task.h"
 #include <AP33772.h>
 
@@ -32,6 +34,9 @@ namespace {
 
     pocketpd::U8g2Display u8g2_display;
 
+    pocketpd::EzButtonInput encoder_button{pin_encoder_SW};
+    pocketpd::EzButtonInput output_button{pin_button_outputSW};
+    pocketpd::EzButtonInput select_vi_button{pin_button_selectVI};
     pocketpd::RotaryEncoderInput encoder{pin_encoder_A, pin_encoder_B};
 
     // —— Stages
@@ -43,6 +48,8 @@ namespace {
 
     // —— Tasks
 
+    pocketpd::ButtonTask
+        button_task(app.task_publisher(), encoder_button, select_vi_button, output_button);
     pocketpd::EncoderTask encoder_task(encoder, app.task_publisher());
 
 } // namespace
@@ -62,6 +69,7 @@ void setup() {
     app.register_stage(pdo_picker_stage);
     app.register_stage(normal_stage);
 
+    app.add_task(button_task);
     app.add_task(encoder_task);
 
     app.start<pocketpd::BootStage>();

--- a/test/mocks/MockButtonInput.h
+++ b/test/mocks/MockButtonInput.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <tempo/hardware/button_input.h>
+
+namespace pocketpd {
+
+    class MockButtonInput : public tempo::ButtonInput {
+    public:
+        MOCK_METHOD(void, update, (), (override));
+        MOCK_METHOD(bool, is_held, (), (const, override));
+    };
+
+    /**
+     * @brief Scripted ButtonInput for tests that just need to flip held state.
+     */
+    class FakeButtonInput : public tempo::ButtonInput {
+    private:
+        bool m_held = false;
+
+    public:
+        void set_held(bool held) {
+            m_held = held;
+        }
+
+        void update() override {}
+
+        bool is_held() const override {
+            return m_held;
+        }
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_inputs/test.cpp
+++ b/test/test_v2_inputs/test.cpp
@@ -1,11 +1,13 @@
 /**
- * GoogleTest suite for EncoderTask.
+ * GoogleTest suite for ButtonGestureDetector, ButtonTask, EncoderTask.
  *
- * Drives the task's public `poll()` directly with a scripted FakeEncoderInput plus a real
- * EventQueue, then inspects what was published.
+ * Detector is exercised in isolation since it is pure logic. ButtonTask tests cover the wiring:
+ * three FakeButtonInputs feed three detectors, gestures land on the EventQueue tagged with the
+ * right ButtonId.
  */
 #define VERSION "\"test\""
 
+#include <MockButtonInput.h>
 #include <MockEncoderInput.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -16,6 +18,9 @@
 
 #include "v2/app.h"
 #include "v2/events.h"
+#include "v2/input/button_gesture.h"
+#include "v2/state.h"
+#include "v2/tasks/button_task.h"
 #include "v2/tasks/encoder_task.h"
 
 using namespace pocketpd;
@@ -34,7 +39,122 @@ namespace {
         return std::get_if<T>(&last);
     }
 
+    constexpr ButtonGestureConfig kDefaultCfg{};
+
 } // namespace
+
+// —— ButtonGestureDetector
+
+TEST(ButtonGestureDetector, ShortFiresOnRelease) {
+    ButtonGestureDetector d;
+    EXPECT_FALSE(d.update(true, 0).has_value());
+
+    auto g = d.update(false, 50);
+    ASSERT_TRUE(g.has_value());
+    EXPECT_EQ(*g, Gesture::SHORT);
+}
+
+TEST(ButtonGestureDetector, LongFiresAtThresholdWhileHeld) {
+    ButtonGestureDetector d;
+    EXPECT_FALSE(d.update(true, 0).has_value());
+    EXPECT_FALSE(d.update(true, kDefaultCfg.long_press_ms - 1).has_value());
+
+    auto g = d.update(true, kDefaultCfg.long_press_ms);
+    ASSERT_TRUE(g.has_value());
+    EXPECT_EQ(*g, Gesture::LONG);
+
+    EXPECT_FALSE(d.update(true, kDefaultCfg.long_press_ms + 500).has_value());
+    EXPECT_FALSE(d.update(false, kDefaultCfg.long_press_ms + 600).has_value());
+}
+
+TEST(ButtonGestureDetector, ConsecutivePressesEachEmitShort) {
+    ButtonGestureDetector d;
+    d.update(true, 0);
+    auto first = d.update(false, 30);
+    ASSERT_TRUE(first.has_value());
+    EXPECT_EQ(*first, Gesture::SHORT);
+
+    d.update(true, 100);
+    auto second = d.update(false, 130);
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(*second, Gesture::SHORT);
+}
+
+// —— ButtonTask
+
+TEST(ButtonTask, ShortGestureOnQuickRelease) {
+    FakeButtonInput encoder, vi_selector, output;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(pub, encoder, vi_selector, output);
+
+    encoder.set_held(true);
+    task.poll(0);
+    encoder.set_held(false);
+    task.poll(100);
+
+    const auto* btn = pop_as<ButtonEvent>(q);
+    ASSERT_NE(btn, nullptr);
+    EXPECT_EQ(btn->id, ButtonId::ENCODER);
+    EXPECT_EQ(btn->gesture, Gesture::SHORT);
+}
+
+TEST(ButtonTask, LongGestureFiresWhileHeldAndSilencesRelease) {
+    FakeButtonInput encoder, vi_selector, output;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(pub, encoder, vi_selector, output);
+
+    encoder.set_held(true);
+    task.poll(0);
+    task.poll(kDefaultCfg.long_press_ms - 1);
+    Event tmp;
+    EXPECT_FALSE(q.pop(tmp));
+
+    task.poll(kDefaultCfg.long_press_ms);
+    const auto* btn = pop_as<ButtonEvent>(q);
+    ASSERT_NE(btn, nullptr);
+    EXPECT_EQ(btn->gesture, Gesture::LONG);
+
+    encoder.set_held(false);
+    task.poll(kDefaultCfg.long_press_ms + 100);
+    EXPECT_FALSE(q.pop(tmp));
+}
+
+TEST(ButtonTask, OutputButtonShortGestureRoutesToOutputToggle) {
+    FakeButtonInput encoder, vi_selector, output;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(pub, encoder, vi_selector, output);
+
+    output.set_held(true);
+    task.poll(0);
+    output.set_held(false);
+    task.poll(50);
+
+    const auto* btn = pop_as<ButtonEvent>(q);
+    ASSERT_NE(btn, nullptr);
+    EXPECT_EQ(btn->id, ButtonId::OUTPUT_TOGGLE);
+    EXPECT_EQ(btn->gesture, Gesture::SHORT);
+}
+
+TEST(ButtonTask, SelectViLongPress) {
+    FakeButtonInput encoder, vi_selector, output;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(pub, encoder, vi_selector, output);
+
+    vi_selector.set_held(true);
+    task.poll(0);
+    task.poll(kDefaultCfg.long_press_ms);
+
+    const auto* btn = pop_as<ButtonEvent>(q);
+    ASSERT_NE(btn, nullptr);
+    EXPECT_EQ(btn->id, ButtonId::SELECT_VI);
+    EXPECT_EQ(btn->gesture, Gesture::LONG);
+}
+
+// —— EncoderTask
 
 TEST(EncoderTask, OnStartLatchesBaselineWithoutEvent) {
     FakeEncoderInput enc;


### PR DESCRIPTION
## Summary
Adds the button input pipeline. `tempo::ButtonInput` is a new abstract interface in `tempo/hardware`; `EzButtonInput` wraps the ezButton library behind it. `ButtonGestureDetector` is a pure 3-state machine that turns `(held, now_ms)` samples into SHORT or LONG gestures. `ButtonTask` polls three buttons at 5 ms and publishes a `ButtonEvent` tagged with `ButtonId` on each recognized gesture.

Stacked on #63 (encoder tempo interface PR). Rebases onto main once that merges.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested:
Native `pio test -e native` (51 cases pass — 7 new gesture/task cases). `pio run -e HW1_3_V2` build green. Confirmed on real hardware: encoder, output, and SELECT_VI button presses log via the publish path.

## Breaking change / migration

Details:

## Notes
No stage consumes `ButtonEvent` from these new buttons yet beyond ObtainStage's existing SHORT-press transition. PdoPicker and NormalStage handlers come in a follow-up PR alongside the PD-sink commit path.

<img width="1070" height="181" alt="Screenshot 2026-05-04 at 1 18 36 AM" src="https://github.com/user-attachments/assets/5f55a933-0c4d-4b29-9563-c2c79ca9f936" />
