### PR TITLE
feat(tempo+v2): UsePublisher mixin for event publishing

### DIFF
--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -32,20 +32,20 @@
 
 namespace pocketpd {
 
-    class ObtainStage : public App::Stage, public tempo::UseLog<ObtainStage> {
+    class ObtainStage : public App::Stage,
+                        public tempo::UseLog<ObtainStage>,
+                        public App::UsePublisher<ObtainStage> {
     private:
         PdSinkController& m_pd_sink;
         bool m_pd_ready = false;
 
-        tempo::Publisher<Event>& m_publisher;
         tempo::IntervalTimer m_dump_timer{3000};
         tempo::TimeoutTimer m_timeout;
 
     public:
         static constexpr const char* LOG_TAG = "Obtain";
 
-        ObtainStage(PdSinkController& pd_sink, tempo::Publisher<Event>& publisher)
-            : m_pd_sink(pd_sink), m_publisher(publisher) {}
+        explicit ObtainStage(PdSinkController& pd_sink) : m_pd_sink(pd_sink) {}
 
         const char* name() const override {
             return "OBTAIN";
@@ -63,7 +63,7 @@ namespace pocketpd {
             m_pd_ready = true;
             const auto pdo_n = static_cast<uint8_t>(m_pd_sink.pdo_count());
             const auto pps_n = static_cast<uint8_t>(m_pd_sink.pps_count());
-            m_publisher.publish(PdReadyEvent{pdo_n, pps_n});
+            publish(PdReadyEvent{pdo_n, pps_n});
 
             log.info("PD ready: %u PDO (%u PPS)", pdo_n, pps_n);
         }

--- a/include/v2/tasks/button_task.h
+++ b/include/v2/tasks/button_task.h
@@ -18,7 +18,9 @@
 
 namespace pocketpd {
 
-    class ButtonTask : public App::BackgroundTask, public tempo::UseLog<ButtonTask> {
+    class ButtonTask : public App::BackgroundTask,
+                       public tempo::UseLog<ButtonTask>,
+                       public App::UsePublisher<ButtonTask> {
     private:
         struct DetectorRef {
             ButtonId id;
@@ -28,7 +30,6 @@ namespace pocketpd {
             DetectorRef() = delete;
         };
 
-        tempo::Publisher<Event>& m_publisher;
         std::array<DetectorRef, 3> m_detectors;
 
         static constexpr uint32_t POLL_PERIOD_MS = 5;
@@ -37,14 +38,12 @@ namespace pocketpd {
         static constexpr const char* LOG_TAG = "ButtonTask";
 
         ButtonTask(
-            tempo::Publisher<Event>& publisher,
             tempo::ButtonInput& btn_encoder,
             tempo::ButtonInput& btn_vi_selector,
             tempo::ButtonInput& btn_output,
             ButtonGestureConfig gesture_config = {}
         )
             : App::BackgroundTask(POLL_PERIOD_MS),
-              m_publisher(publisher),
               m_detectors{
                   DetectorRef{
                       ButtonId::ENCODER,
@@ -92,7 +91,7 @@ namespace pocketpd {
                         button_name(ref.id),
                         gesture.value() == Gesture::SHORT ? "SHORT" : "LONG"
                     );
-                    m_publisher.publish(ButtonEvent{ref.id, gesture.value()});
+                    publish(ButtonEvent{ref.id, gesture.value()});
                 }
             }
         }

--- a/include/v2/tasks/encoder_task.h
+++ b/include/v2/tasks/encoder_task.h
@@ -14,10 +14,11 @@
 
 namespace pocketpd {
 
-    class EncoderTask : public App::BackgroundTask, public tempo::UseLog<EncoderTask> {
+    class EncoderTask : public App::BackgroundTask,
+                        public tempo::UseLog<EncoderTask>,
+                        public App::UsePublisher<EncoderTask> {
     private:
         tempo::EncoderInput& m_input;
-        tempo::Publisher<Event>& m_publisher;
         int m_last_position = 0;
 
         static constexpr int POLL_PERIOD_MS = 5;
@@ -25,8 +26,8 @@ namespace pocketpd {
     public:
         static constexpr const char* LOG_TAG = "EncoderTask";
 
-        EncoderTask(tempo::EncoderInput& input, tempo::Publisher<Event>& publisher)
-            : App::BackgroundTask(POLL_PERIOD_MS), m_input(input), m_publisher(publisher) {}
+        explicit EncoderTask(tempo::EncoderInput& input)
+            : App::BackgroundTask(POLL_PERIOD_MS), m_input(input) {}
 
         const char* name() const override {
             return "EncoderTask";
@@ -40,7 +41,7 @@ namespace pocketpd {
             const int pos = m_input.position();
             const int delta = pos - m_last_position;
             if (delta != 0) {
-                m_publisher.publish(EncoderEvent{delta});
+                publish(EncoderEvent{delta});
                 m_last_position = pos;
             }
         }

--- a/lib/tempo/include/tempo/app/application.h
+++ b/lib/tempo/include/tempo/app/application.h
@@ -37,12 +37,17 @@ namespace tempo {
      * @tparam Event An event type of std::variant<...>.
      * @tparam Stages The compile-time list of Stage types.
      */
-    template <typename Event, typename... Stages>
-    class Application : public UseLog<Application<Event, Stages...>> {
+    template <typename TEvent, typename... Stages>
+    class Application : public UseLog<Application<TEvent, Stages...>> {
     public:
         // clang-format off
         static constexpr size_t MaxTasks           = DEFAULT_MAX_TASKS;
         static constexpr size_t EventQueueCapacity = DEFAULT_EVENT_QUEUE_CAP;
+
+        using Event           = TEvent;
+        using Scheduler       = tempo::CooperativeScheduler<Event, MaxTasks, Stages...>;
+        using Queue           = tempo::EventQueue<Event, EventQueueCapacity>;
+        using Publisher       = tempo::QueuePublisher<Event, EventQueueCapacity>;
 
         using Conductor       = tempo::Conductor<Event, Stages...>;
         using Stage           = tempo::Stage<Event, Stages...>;
@@ -53,9 +58,8 @@ namespace tempo {
         using BackgroundTask  = tempo::BackgroundTask<Event, Stages...>;
         using StageScopedTask = tempo::StageScopedTask<Event, Stages...>;
 
-        using Scheduler       = tempo::CooperativeScheduler<Event, MaxTasks, Stages...>;
-        using Queue           = tempo::EventQueue<Event, EventQueueCapacity>;
-        using Publisher       = tempo::QueuePublisher<Event, EventQueueCapacity>;
+        template <typename Derived>
+        using UsePublisher    = tempo::UsePublisher<Derived, Event>;
 
         using UseLog<Application>::log;
         // clang-format on
@@ -74,7 +78,7 @@ namespace tempo {
 
         Queue m_task_queue;
         Queue m_isr_queue;
-        
+
         Publisher m_task_publisher;
         Publisher m_isr_publisher;
 
@@ -114,6 +118,11 @@ namespace tempo {
                 use_log._uselog_wiring.attach_log(m_clock, m_stream_writer);
             }
 
+            if constexpr (std::is_base_of_v<tempo::UsePublisher<T, Event>, T>) {
+                auto& usepublisher = static_cast<tempo::UsePublisher<T, Event>&>(task);
+                usepublisher.m_publisher_slot.attach(m_task_publisher);
+            }
+
             return m_scheduler.add(task);
         }
 
@@ -122,6 +131,11 @@ namespace tempo {
             if constexpr (std::is_base_of_v<UseLog<S>, S>) {
                 auto& use_log = static_cast<UseLog<S>&>(stage);
                 use_log._uselog_wiring.attach_log(m_clock, m_stream_writer);
+            }
+
+            if constexpr (std::is_base_of_v<tempo::UsePublisher<S, Event>, S>) {
+                auto& usepublisher = static_cast<tempo::UsePublisher<S, Event>&>(stage);
+                usepublisher.m_publisher_slot.attach(m_task_publisher);
             }
 
             m_conductor.register_stage(stage);

--- a/lib/tempo/include/tempo/bus/publisher.h
+++ b/lib/tempo/include/tempo/bus/publisher.h
@@ -14,13 +14,15 @@ namespace tempo {
     class Publisher {
     public:
         virtual ~Publisher() = default;
-
-        // Publish an event. Returns true iff every backing queue accepted
-        // the event. False indicates at least one queue was full; the
-        // producer should decide whether to retry, drop, or panic. In
-        // dual-core fan-out, partial success is possible: the event may
-        // have landed in some queues but not others. The framework deliberately
-        // does not roll back; the consumer side filters via std::get_if anyway.
+        /**
+         * @brief Publish an event. Returns true iff every backing queue accepted the event. False
+         * indicates at least one queue was full; the producer should decide whether to retry, drop,
+         * or panic. In dual-core fan-out, partial success is possible: the event may have landed in
+         * some queues but not others. The implementation should not deliberately roll back.
+         *
+         * @param e The event to publish.
+         * @return true if the event was published to all queues successfully, false otherwise.
+         */
         virtual bool publish(const Event& e) = 0;
 
     protected:
@@ -38,6 +40,86 @@ namespace tempo {
 
         bool publish(const Event& event) override {
             return m_queue.push(event);
+        }
+    };
+
+    template <typename Event, typename... Stages>
+    class Application;
+
+    template <typename Derived, typename Event>
+    class UsePublisher;
+
+    namespace detail {
+
+        /**
+         * @brief Storage layer for UsePublisher. Holds the PublisherSlot. Split out so that
+         * Derived (friend of UsePublisher for CRTP) does not gain access to the slot. Derived
+         * reaches the publish path through `publish()` exposed by UsePublisher.
+         */
+        template <typename Derived, typename Event>
+        class UsePublisherStorage {
+            class PublisherSlot {
+                Publisher<Event>* m_publisher = nullptr;
+
+                void attach(Publisher<Event>& publisher) {
+                    m_publisher = &publisher;
+                }
+
+                template <typename E, typename... Stages>
+                friend class tempo::Application;
+                friend class UsePublisherStorage<Derived, Event>;
+            };
+
+            PublisherSlot m_publisher_slot;
+
+            template <typename E, typename... Stages>
+            friend class tempo::Application;
+            friend class tempo::UsePublisher<Derived, Event>;
+
+        protected:
+            UsePublisherStorage() = default;
+
+            bool publish(const Event& event) {
+                if (m_publisher_slot.m_publisher == nullptr) {
+                    return false;
+                }
+                return m_publisher_slot.m_publisher->publish(event);
+            }
+
+            void attach_publisher(Publisher<Event>& publisher) {
+                m_publisher_slot.attach(publisher);
+            }
+        };
+
+    } // namespace detail
+
+    /**
+     * @brief CRTP mixin that injects a Publisher<Event> into Tasks and Stages registered with an
+     * Application.
+     *
+     * Derived classes call `publish(event)` to emit.
+     *
+     * @tparam Derived  The host class (CRTP).
+     * @tparam Event    The Application's event variant type.
+     */
+    template <typename Derived, typename Event>
+    class UsePublisher : public detail::UsePublisherStorage<Derived, Event> {
+        UsePublisher() = default;
+
+        template <typename E, typename... Stages>
+        friend class Application;
+        friend Derived;
+
+    public:
+        /**
+         * @brief DO NOT USE in production. Test-only seam for unit tests that construct a
+         * Stage or Task directly, without an Application. Calling this method manually is undefined
+         * behavior.
+         *
+         * @param publisher The publisher to attach.
+         */
+        void attach_publisher_INTERNAL_DO_NOT_USE(Publisher<Event>& publisher) {
+            this->attach_publisher(publisher);
         }
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,15 +42,14 @@ namespace {
     // —— Stages
 
     pocketpd::BootStage boot_stage(u8g2_display);
-    pocketpd::ObtainStage obtain_stage(pd_sink, app.task_publisher());
+    pocketpd::ObtainStage obtain_stage(pd_sink);
     pocketpd::PdoPickerStage pdo_picker_stage(u8g2_display, pd_sink);
     pocketpd::NormalStage normal_stage;
 
     // —— Tasks
 
-    pocketpd::ButtonTask
-        button_task(app.task_publisher(), encoder_button, select_vi_button, output_button);
-    pocketpd::EncoderTask encoder_task(encoder, app.task_publisher());
+    pocketpd::ButtonTask button_task(encoder_button, select_vi_button, output_button);
+    pocketpd::EncoderTask encoder_task(encoder);
 
 } // namespace
 

--- a/test/test_v2_inputs/test.cpp
+++ b/test/test_v2_inputs/test.cpp
@@ -86,7 +86,8 @@ TEST(ButtonTask, ShortGestureOnQuickRelease) {
     FakeButtonInput encoder, vi_selector, output;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(pub, encoder, vi_selector, output);
+    ButtonTask task(encoder, vi_selector, output);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
     encoder.set_held(true);
     task.poll(0);
@@ -103,7 +104,8 @@ TEST(ButtonTask, LongGestureFiresWhileHeldAndSilencesRelease) {
     FakeButtonInput encoder, vi_selector, output;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(pub, encoder, vi_selector, output);
+    ButtonTask task(encoder, vi_selector, output);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
     encoder.set_held(true);
     task.poll(0);
@@ -125,7 +127,8 @@ TEST(ButtonTask, OutputButtonShortGestureRoutesToOutputToggle) {
     FakeButtonInput encoder, vi_selector, output;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(pub, encoder, vi_selector, output);
+    ButtonTask task(encoder, vi_selector, output);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
     output.set_held(true);
     task.poll(0);
@@ -142,7 +145,8 @@ TEST(ButtonTask, SelectViLongPress) {
     FakeButtonInput encoder, vi_selector, output;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(pub, encoder, vi_selector, output);
+    ButtonTask task(encoder, vi_selector, output);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
     vi_selector.set_held(true);
     task.poll(0);
@@ -160,7 +164,8 @@ TEST(EncoderTask, OnStartLatchesBaselineWithoutEvent) {
     FakeEncoderInput enc;
     TestQueue q;
     TestPublisher pub(q);
-    EncoderTask task(enc, pub);
+    EncoderTask task(enc);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
     enc.set_position(42);
     task.on_start();
@@ -174,7 +179,8 @@ TEST(EncoderTask, NonZeroDeltaPublishes) {
     FakeEncoderInput enc;
     TestQueue q;
     TestPublisher pub(q);
-    EncoderTask task(enc, pub);
+    EncoderTask task(enc);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
     task.on_start();
 
     enc.set_position(3);
@@ -189,7 +195,8 @@ TEST(EncoderTask, NoChangeMeansNoEvent) {
     FakeEncoderInput enc;
     TestQueue q;
     TestPublisher pub(q);
-    EncoderTask task(enc, pub);
+    EncoderTask task(enc);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
     task.on_start();
     task.poll();
 
@@ -201,7 +208,8 @@ TEST(EncoderTask, NegativeDelta) {
     FakeEncoderInput enc;
     TestQueue q;
     TestPublisher pub(q);
-    EncoderTask task(enc, pub);
+    EncoderTask task(enc);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
     enc.set_position(5);
     task.on_start();
     enc.set_position(2);

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -54,7 +54,8 @@ TEST(ObtainStage, OnEnterCallsBeginAndPublishesCount) {
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>();
@@ -73,7 +74,8 @@ TEST(ObtainStage, MultiPpsChargerReportsBothPps) {
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(5));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(2));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>();
@@ -90,7 +92,8 @@ TEST(ObtainStage, BeginFailureSuppressesPdReady) {
 
     EXPECT_CALL(sink, begin()).WillOnce(Return(false));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>();
@@ -111,7 +114,8 @@ TEST(ObtainStage, OnEnterIssuesNoRdoRequest) {
     EXPECT_CALL(sink, set_pdo).Times(0);
     EXPECT_CALL(sink, set_pps_pdo).Times(0);
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>();
@@ -125,7 +129,8 @@ TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -148,7 +153,8 @@ TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -169,7 +175,8 @@ TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {
     TestPublisher publisher(queue);
     EXPECT_CALL(sink, begin()).WillOnce(Return(false));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>();
@@ -186,7 +193,8 @@ TEST(ObtainStage, EncoderRotationJumpsToPdoPickerInSelectMode) {
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NiceMock<MockDisplay> picker_display;
     PdoPickerStage picker(picker_display, sink);
     TestConductor conductor;
@@ -210,7 +218,8 @@ TEST(ObtainStage, TimeoutTransitionsToPdoPickerInReviewMode) {
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
-    ObtainStage stage(sink, publisher);
+    ObtainStage stage(sink);
+    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NiceMock<MockDisplay> picker_display;
     PdoPickerStage picker(picker_display, sink);
     TestConductor conductor;
@@ -240,7 +249,8 @@ TEST(BootStage, RequestsObtainAfterTimeout) {
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
     BootStage boot(display);
-    ObtainStage obtain(sink, publisher);
+    ObtainStage obtain(sink);
+    obtain.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     TestConductor conductor;
     conductor.register_stage(boot);
     conductor.register_stage(obtain);


### PR DESCRIPTION
## Summary
Adds `tempo::UsePublisher`, a CRTP mixin parallel to `UseLog` that auto-attaches the Application's task-side `Publisher<Event>` to any registered Task or Stage. ObtainStage, ButtonTask, and EncoderTask now inherit `App::UsePublisher` and emit through the inherited `publish()` method, replacing the `Publisher<Event>&` constructor argument they each took before.

## Linked issues

## Hardware tested
- [ ] HW1_3
- [x] None (no hardware change)

How tested:
`pio test -e native` (51 cases) and `make test-tempo` (23 cases) green; `pio run -e HW1_3_V2` builds at 4.4% Flash.

## Breaking change / migration
- [x] Public lib API (`lib/*` headers)

Details:
`tempo::UsePublisher<Derived, Event>` is new public surface. Stages or Tasks that previously took a `Publisher<Event>&` constructor argument can keep that pattern or migrate to inherit `App::UsePublisher<Derived>` and call `publish()`. Tests that construct types directly (without an Application) wire a publisher via `attach_publisher_INTERNAL_DO_NOT_USE`.

## Notes
Stacked on `feature/v2-button-input-and-task` (lands `tempo::ButtonInput` + `pocketpd::ButtonTask`); that base needs to merge first. Base itself stacks on `refactor/v2-encoder-tempo-interface` (PR #63).