### PR TITLE
refactor(tempo+v2): hide UseLog slot and add App::UseLog alias

### DIFF
--- a/include/v2/stages/boot_stage.h
+++ b/include/v2/stages/boot_stage.h
@@ -16,7 +16,7 @@
 
 namespace pocketpd {
 
-    class BootStage : public App::Stage, public tempo::UseLog<BootStage> {
+    class BootStage : public App::Stage, public App::UseLog<BootStage> {
     private:
         tempo::Display& m_display;
         tempo::TimeoutTimer m_timeout;

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -18,7 +18,7 @@
 
 namespace pocketpd {
 
-    class NormalStage : public App::Stage, public tempo::UseLog<NormalStage> {
+    class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
         // Still don't know if we should use pending variable or not. TBD.
         Profile m_pending_profile = Profile::PDO;

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -33,7 +33,7 @@
 namespace pocketpd {
 
     class ObtainStage : public App::Stage,
-                        public tempo::UseLog<ObtainStage>,
+                        public App::UseLog<ObtainStage>,
                         public App::UsePublisher<ObtainStage> {
     private:
         PdSinkController& m_pd_sink;

--- a/include/v2/stages/pdo_picker_stage.h
+++ b/include/v2/stages/pdo_picker_stage.h
@@ -28,7 +28,7 @@ namespace pocketpd {
 
     void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor = -1);
 
-    class PdoPickerStage : public App::Stage, public tempo::UseLog<PdoPickerStage> {
+    class PdoPickerStage : public App::Stage, public App::UseLog<PdoPickerStage> {
     public:
         enum class Mode : uint8_t { REVIEW, SELECT };
 

--- a/include/v2/tasks/button_task.h
+++ b/include/v2/tasks/button_task.h
@@ -19,7 +19,7 @@
 namespace pocketpd {
 
     class ButtonTask : public App::BackgroundTask,
-                       public tempo::UseLog<ButtonTask>,
+                       public App::UseLog<ButtonTask>,
                        public App::UsePublisher<ButtonTask> {
     private:
         struct DetectorRef {

--- a/include/v2/tasks/encoder_task.h
+++ b/include/v2/tasks/encoder_task.h
@@ -15,7 +15,7 @@
 namespace pocketpd {
 
     class EncoderTask : public App::BackgroundTask,
-                        public tempo::UseLog<EncoderTask>,
+                        public App::UseLog<EncoderTask>,
                         public App::UsePublisher<EncoderTask> {
     private:
         tempo::EncoderInput& m_input;

--- a/lib/tempo/include/tempo/app/application.h
+++ b/lib/tempo/include/tempo/app/application.h
@@ -59,9 +59,11 @@ namespace tempo {
         using StageScopedTask = tempo::StageScopedTask<Event, Stages...>;
 
         template <typename Derived>
+        using UseLog          = tempo::UseLog<Derived>;
+        template <typename Derived>
         using UsePublisher    = tempo::UsePublisher<Derived, Event>;
 
-        using UseLog<Application>::log;
+        using tempo::UseLog<Application>::log;
         // clang-format on
 
     private:
@@ -113,8 +115,8 @@ namespace tempo {
         // ---- Registration (before start) ----
         template <typename T>
         bool add_task(T& task) {
-            if constexpr (std::is_base_of_v<UseLog<T>, T>) {
-                auto& uselog = static_cast<UseLog<T>&>(task);
+            if constexpr (std::is_base_of_v<tempo::UseLog<T>, T>) {
+                auto& uselog = static_cast<tempo::UseLog<T>&>(task);
                 uselog.m_log_slot.attach(m_clock, m_stream_writer);
             }
 
@@ -128,8 +130,8 @@ namespace tempo {
 
         template <typename S>
         void register_stage(S& stage) {
-            if constexpr (std::is_base_of_v<UseLog<S>, S>) {
-                auto& uselog = static_cast<UseLog<S>&>(stage);
+            if constexpr (std::is_base_of_v<tempo::UseLog<S>, S>) {
+                auto& uselog = static_cast<tempo::UseLog<S>&>(stage);
                 uselog.m_log_slot.attach(m_clock, m_stream_writer);
             }
 

--- a/lib/tempo/include/tempo/app/application.h
+++ b/lib/tempo/include/tempo/app/application.h
@@ -105,7 +105,7 @@ namespace tempo {
             TEMPO_CHECK(instance == nullptr, "Only one Application may exist per build");
             instance = this;
 
-            this->_uselog_wiring.attach_log(m_clock, m_stream_writer);
+            this->m_log_slot.attach(m_clock, m_stream_writer);
         }
 
         ~Application() = default;
@@ -114,8 +114,8 @@ namespace tempo {
         template <typename T>
         bool add_task(T& task) {
             if constexpr (std::is_base_of_v<UseLog<T>, T>) {
-                auto& use_log = static_cast<UseLog<T>&>(task);
-                use_log._uselog_wiring.attach_log(m_clock, m_stream_writer);
+                auto& uselog = static_cast<UseLog<T>&>(task);
+                uselog.m_log_slot.attach(m_clock, m_stream_writer);
             }
 
             if constexpr (std::is_base_of_v<tempo::UsePublisher<T, Event>, T>) {
@@ -129,8 +129,8 @@ namespace tempo {
         template <typename S>
         void register_stage(S& stage) {
             if constexpr (std::is_base_of_v<UseLog<S>, S>) {
-                auto& use_log = static_cast<UseLog<S>&>(stage);
-                use_log._uselog_wiring.attach_log(m_clock, m_stream_writer);
+                auto& uselog = static_cast<UseLog<S>&>(stage);
+                uselog.m_log_slot.attach(m_clock, m_stream_writer);
             }
 
             if constexpr (std::is_base_of_v<tempo::UsePublisher<S, Event>, S>) {

--- a/lib/tempo/include/tempo/diag/logger.h
+++ b/lib/tempo/include/tempo/diag/logger.h
@@ -240,51 +240,72 @@ namespace tempo {
     template <typename T>
     struct has_log_tag<T, std::void_t<decltype(T::LOG_TAG)>> : std::true_type {};
 
-    /**
-     * @brief Allows only the derived class to use this mixin while Application-framework layers
-     * have full access to underlying wiring functions
-     *
-     * @tparam Derived
-     */
+    template <typename Event, typename... Stages>
+    class Application;
+
     template <typename Derived>
-    class UseLog {
-        static constexpr const char* resolve_tag() {
-            if constexpr (has_log_tag<Derived>::value) {
-                return Derived::LOG_TAG;
-            } else {
-                return "<Unnamed>";
-            }
-        }
+    class UseLog;
 
-        class uselog_wiring {
-            Logger m_log;
-            void set_log_clock(const Clock& clock) {
-                m_log.set_clock(clock);
+    namespace detail {
+
+        /**
+         * @brief Storage layer for UseLog. Owns the LogSlot and exposes `log` to the outer
+         * mixin. Split out of UseLog so that Derived — friend of UseLog for CRTP enforcement —
+         * does not also gain access to `m_log_slot`.
+         *
+         * @tparam Derived
+         */
+        template <typename Derived>
+        class UseLogStorage {
+            static constexpr const char* resolve_tag() {
+                if constexpr (has_log_tag<Derived>::value) {
+                    return Derived::LOG_TAG;
+                } else {
+                    return "<Unnamed>";
+                }
             }
 
-            void set_log_stream_writer(StreamWriter& writer) {
-                m_log.set_stream_writer(writer);
-            }
+            class LogSlot {
+                Logger m_log;
 
-            void attach_log(const Clock& clock, StreamWriter& stream_writer) {
-                m_log.set_clock(clock);
-                m_log.set_stream_writer(stream_writer);
-                m_log.set_tag(UseLog::resolve_tag());
-            }
+                void attach(const Clock& clock, StreamWriter& stream_writer) {
+                    m_log.set_clock(clock);
+                    m_log.set_stream_writer(stream_writer);
+                    m_log.set_tag(UseLogStorage<Derived>::resolve_tag());
+                }
+
+                template <typename Event, typename... Stages>
+                friend class tempo::Application;
+                friend class UseLogStorage<Derived>;
+            };
+
+            LogSlot m_log_slot;
 
             template <typename Event, typename... Stages>
-            friend class Application;
-            friend class UseLog<Derived>;
+            friend class tempo::Application;
+            friend class tempo::UseLog<Derived>;
+
+        protected:
+            UseLogStorage() = default;
+            const Logger& log = m_log_slot.m_log;
         };
 
-        uselog_wiring _uselog_wiring;
-        const Logger& log = _uselog_wiring.m_log;
+    } // namespace detail
 
+    /**
+     * @brief CRTP mixin that injects a Logger into Tasks and Stages registered with an
+     * Application.
+     *
+     * Derived class get access to logging functions via `log` member reference.
+     *
+     * @tparam Derived The host class (CRTP).
+     */
+    template <typename Derived>
+    class UseLog : public detail::UseLogStorage<Derived> {
         UseLog() = default;
 
         template <typename Event, typename... Stages>
         friend class Application;
-        friend class uselog_wiring;
         friend Derived;
     };
 


### PR DESCRIPTION
## Summary
Splits `tempo::UseLog` into a privately-friended `detail::UseLogStorage` base plus a thin outer mixin so that Derived (CRTP-friended for ctor enforcement) can no longer see `m_log_slot`. Adds an `App::UseLog<Derived>` nested alias that mirrors `App::UsePublisher` and migrates the six v2 stages and tasks onto it.

## Linked issues

## Hardware tested
- [x] None (no hardware change)

How tested:
`pio test -e native` (51 cases) and `make test-tempo` (23 cases) green; `pio run -e HW1_3_V2` builds at 4.4% Flash.

## Breaking change / migration
- [x] Public lib API (`lib/*` headers)

Details:
`tempo::UseLog`'s storage is now in `detail::UseLogStorage`; downstream code that reached into `_uselog_wiring` would need to switch to the new `m_log_slot` (only Application is friended for either). The new `App::UseLog<X>` alias is additive — existing `tempo::UseLog<X>` usage keeps working.

## Notes
Stacked on PR #65 (`feature/v2-use-publisher`). That base PR needs to merge first.