### PR TITLE
feat(tempo): migrate Logger to fmtlib

### DIFF
--- a/benchmarks/platformio.ini
+++ b/benchmarks/platformio.ini
@@ -1,0 +1,54 @@
+; Standalone PlatformIO project for Logger benchmarks. Lives outside the main
+; project so default `pio test` and `pio run` runs do not pick it up.
+;
+; Run from the repo root:
+;   Device firmware:  pio run -d benchmarks -e bench_logger -t upload
+;   Capture serial:   pio device monitor -d benchmarks -e bench_logger
+;   Native bench:     pio test -d benchmarks -e native_bench
+
+[platformio]
+src_dir = src
+test_dir = test
+default_envs = bench_logger
+extra_configs = ../scripts/fmt_flags.ini
+
+[env:bench_logger]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = pico
+framework = arduino
+board_build.core = earlephilhower
+test_ignore = *
+debug_tool = cmsis-dap
+upload_protocol = cmsis-dap
+debug_speed = 5000
+monitor_speed = 115200
+monitor_port = /dev/cu.usbmodem1201
+monitor_filters = direct
+extra_scripts = pre:../scripts/configure_fmt_header_only.py
+build_flags =
+	${fmt_size_flags.build_flags}
+	-DBENCH_LOGGER
+	-O2
+build_src_filter =
+	-<*>
+	+<bench_logger.cpp>
+lib_extra_dirs = ../lib
+lib_deps =
+	tempo
+	fmt=https://github.com/fmtlib/fmt.git#11.2.0
+
+[env:native_bench]
+platform = native
+build_type = test
+test_framework = googletest
+extra_scripts = pre:../scripts/configure_fmt_header_only.py
+build_flags =
+	-std=gnu++17
+	-DUNIT_TEST
+	${fmt_size_flags.build_flags}
+	-Wno-missing-template-arg-list-after-template-kw
+lib_extra_dirs = ../lib
+lib_deps =
+	tempo
+	fmt=https://github.com/fmtlib/fmt.git#11.2.0
+	fabiobatsilva/ArduinoFake @ ^0.4.0

--- a/benchmarks/src/bench_logger.cpp
+++ b/benchmarks/src/bench_logger.cpp
@@ -1,0 +1,306 @@
+/**
+ * On-device snprintf vs fmt::format_to_n benchmark.
+ *
+ * Build/flash:
+ *   pio run -e bench_logger -t upload
+ *   pio device monitor -e bench_logger
+ *
+ * Runs N iterations of each format path into a stack buffer (no Serial in the
+ * timed region) for representative payloads, prints ns-per-op + ratio, then halts.
+ */
+#include <Arduino.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include <tempo/diag/stream_iterator.h>
+#include <tempo/hardware/stream.h>
+
+#pragma push_macro("F")
+#ifdef F
+#undef F
+#endif
+#include <fmt/format.h>
+#pragma pop_macro("F")
+
+namespace {
+
+    constexpr int N_ITERS = 5000;
+    constexpr size_t BUF_SIZE = 256;
+
+    inline void anti_optimize(const char* p) {
+        asm volatile("" : : "r"(p) : "memory");
+    }
+
+    class NullStreamWriter : public tempo::StreamWriter {
+    public:
+        size_t bytes = 0;
+        size_t calls = 0;
+        size_t write(const char* data, size_t len) override {
+            bytes += len;
+            ++calls;
+            anti_optimize(data);
+            return len;
+        }
+    };
+
+    template <typename Fn>
+    uint32_t time_us(Fn&& fn) {
+        const uint32_t t0 = micros();
+        fn();
+        return micros() - t0;
+    }
+
+    void report(const char* label, uint32_t snp_us, uint32_t fmt_us) {
+        const float snp_per = (snp_us * 1000.0f) / N_ITERS;
+        const float fmt_per = (fmt_us * 1000.0f) / N_ITERS;
+        const float ratio = fmt_per / snp_per;
+        char line[160];
+        std::snprintf(
+            line,
+            sizeof(line),
+            "  %-32s snprintf=%7.1f ns/op  fmt=%7.1f ns/op  ratio=%.2fx\r\n",
+            label,
+            static_cast<double>(snp_per),
+            static_cast<double>(fmt_per),
+            static_cast<double>(ratio)
+        );
+        Serial.write(line);
+    }
+
+    void bench_single_uint32() {
+        char buf[BUF_SIZE];
+        const uint32_t snp = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                std::snprintf(buf, BUF_SIZE, "v=%u", static_cast<unsigned>(i));
+                anti_optimize(buf);
+            }
+        });
+        const uint32_t fmtt = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                auto r = fmt::format_to_n(buf, BUF_SIZE, "v={}", i);
+                *r.out = '\0';
+                anti_optimize(buf);
+            }
+        });
+        report("single uint32", snp, fmtt);
+    }
+
+    void bench_multi_args() {
+        char buf[BUF_SIZE];
+        const uint32_t snp = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                std::snprintf(
+                    buf, BUF_SIZE, "PD ready: %u PDO (%u PPS) %s", 7u, 3u, "Anker"
+                );
+                anti_optimize(buf);
+            }
+        });
+        const uint32_t fmtt = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                auto r = fmt::format_to_n(
+                    buf, BUF_SIZE, "PD ready: {} PDO ({} PPS) {}", 7, 3, "Anker"
+                );
+                *r.out = '\0';
+                anti_optimize(buf);
+            }
+        });
+        report("multi-arg (2 int + str)", snp, fmtt);
+    }
+
+    void bench_logger_header() {
+        char buf[BUF_SIZE];
+        const uint32_t snp = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                std::snprintf(
+                    buf,
+                    BUF_SIZE,
+                    "%s[%02lu:%02lu:%02lu.%03lu][%c][%s] ",
+                    "\x1b[32m",
+                    1ul,
+                    2ul,
+                    3ul,
+                    456ul,
+                    'I',
+                    "TestTag"
+                );
+                anti_optimize(buf);
+            }
+        });
+        const uint32_t fmtt = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                auto r = fmt::format_to_n(
+                    buf,
+                    BUF_SIZE,
+                    "{}[{:02}:{:02}:{:02}.{:03}][{}][{}] ",
+                    "\x1b[32m",
+                    1u,
+                    2u,
+                    3u,
+                    456u,
+                    'I',
+                    "TestTag"
+                );
+                *r.out = '\0';
+                anti_optimize(buf);
+            }
+        });
+        report("logger header (7 args)", snp, fmtt);
+    }
+
+    void bench_hexdump_row() {
+        char buf[BUF_SIZE];
+        const uint8_t data[] = {0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0xff, 0x10};
+        const uint32_t snp = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                int n = std::snprintf(buf, BUF_SIZE, "%04x: ", static_cast<unsigned>(i));
+                for (size_t j = 0; j < sizeof(data); ++j) {
+                    n += std::snprintf(buf + n, BUF_SIZE - n, "%02x ", data[j]);
+                }
+                anti_optimize(buf);
+            }
+        });
+        const uint32_t fmtt = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                auto out = fmt::format_to_n(buf, BUF_SIZE, "{:04x}: ", i).out;
+                for (size_t j = 0; j < sizeof(data); ++j) {
+                    out = fmt::format_to_n(out, BUF_SIZE, "{:02x} ", data[j]).out;
+                }
+                anti_optimize(buf);
+            }
+        });
+        report("hexdump row (offset+8 bytes)", snp, fmtt);
+    }
+
+    void bench_long_body() {
+        char buf[512];
+        char body[201];
+        std::memset(body, 'x', 200);
+        body[200] = '\0';
+        const uint32_t snp = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                std::snprintf(buf, sizeof(buf), "%s", body);
+                anti_optimize(buf);
+            }
+        });
+        const uint32_t fmtt = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                auto r = fmt::format_to_n(buf, sizeof(buf), "{}", static_cast<const char*>(body));
+                *r.out = '\0';
+                anti_optimize(buf);
+            }
+        });
+        report("long body (200 chars)", snp, fmtt);
+    }
+
+    void bench_sink_short_line() {
+        NullStreamWriter sw;
+        const uint32_t t = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                tempo::BufferedStreamSink sink(sw);
+                fmt::format_to(
+                    sink.out(), "v={} ma={} idx={}", 5000u, 1000u, static_cast<uint32_t>(i)
+                );
+            }
+        });
+        char line[160];
+        std::snprintf(
+            line,
+            sizeof(line),
+            "  %-32s sink=%7.1f ns/op  bytes=%u  writes=%u  buf=%uB\r\n",
+            "sink short line (3 args)",
+            static_cast<double>((t * 1000.0f) / N_ITERS),
+            static_cast<unsigned>(sw.bytes),
+            static_cast<unsigned>(sw.calls),
+            static_cast<unsigned>(tempo::BufferedStreamSink::BUF_SIZE)
+        );
+        Serial.write(line);
+    }
+
+    void bench_sink_logger_header_like() {
+        NullStreamWriter sw;
+        const uint32_t t = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                tempo::BufferedStreamSink sink(sw);
+                fmt::format_to(
+                    sink.out(),
+                    "{}[{:02}:{:02}:{:02}.{:03}][{}][{}] body",
+                    "\x1b[32m",
+                    1u,
+                    2u,
+                    3u,
+                    456u,
+                    'I',
+                    "TestTag"
+                );
+            }
+        });
+        char line[160];
+        std::snprintf(
+            line,
+            sizeof(line),
+            "  %-32s sink=%7.1f ns/op  bytes=%u  writes=%u  buf=%uB\r\n",
+            "sink full log line (~38 ch)",
+            static_cast<double>((t * 1000.0f) / N_ITERS),
+            static_cast<unsigned>(sw.bytes),
+            static_cast<unsigned>(sw.calls),
+            static_cast<unsigned>(tempo::BufferedStreamSink::BUF_SIZE)
+        );
+        Serial.write(line);
+    }
+
+    void bench_sink_long_body() {
+        NullStreamWriter sw;
+        char body[201];
+        std::memset(body, 'x', 200);
+        body[200] = '\0';
+        const uint32_t t = time_us([&] {
+            for (int i = 0; i < N_ITERS; ++i) {
+                tempo::BufferedStreamSink sink(sw);
+                fmt::format_to(sink.out(), "{}", static_cast<const char*>(body));
+            }
+        });
+        char line[160];
+        std::snprintf(
+            line,
+            sizeof(line),
+            "  %-32s sink=%7.1f ns/op  bytes=%u  writes=%u  buf=%uB\r\n",
+            "sink long body (200 chars)",
+            static_cast<double>((t * 1000.0f) / N_ITERS),
+            static_cast<unsigned>(sw.bytes),
+            static_cast<unsigned>(sw.calls),
+            static_cast<unsigned>(tempo::BufferedStreamSink::BUF_SIZE)
+        );
+        Serial.write(line);
+    }
+
+} // namespace
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial) {
+        delay(10);
+    }
+    delay(2000); // give the host monitor time to attach
+}
+
+void loop() {
+    Serial.write("\r\n=== RP2040 snprintf vs fmt format-to-buffer benchmark ===\r\n");
+    char hdr[80];
+    std::snprintf(hdr, sizeof(hdr), "  N=%d, F_CPU=%lu Hz\r\n", N_ITERS, F_CPU);
+    Serial.write(hdr);
+
+    bench_single_uint32();
+    bench_multi_args();
+    bench_logger_header();
+    bench_hexdump_row();
+    bench_long_body();
+    bench_sink_short_line();
+    bench_sink_logger_header_like();
+    bench_sink_long_body();
+
+    Serial.write("=== bench done; sleeping 5s ===\r\n");
+    Serial.flush();
+    delay(5000);
+}

--- a/benchmarks/test/test_bench_logger/test.cpp
+++ b/benchmarks/test/test_bench_logger/test.cpp
@@ -1,0 +1,186 @@
+/**
+ * Native host benchmark: snprintf vs fmt::format_to_n.
+ *
+ * Purpose: relative-cost comparison for the format paths the Logger uses. Host CPU is
+ * not RP2040; absolute numbers do not transfer. Ratios usually do (within an order of
+ * magnitude); the on-device variant lives in `src/bench_logger.cpp` for true numbers.
+ *
+ * Run via: pio test -e native -f test_bench_logger
+ */
+#pragma GCC optimize("O3")
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#pragma push_macro("F")
+#ifdef F
+#undef F
+#endif
+#include <fmt/format.h>
+#pragma pop_macro("F")
+
+namespace {
+
+    constexpr int N_ITERS = 100'000;
+    constexpr size_t BUF_SIZE = 256;
+
+    using clock_t_ = std::chrono::steady_clock;
+
+    template <typename Fn>
+    uint64_t time_ns(Fn&& fn) {
+        auto t0 = clock_t_::now();
+        fn();
+        auto t1 = clock_t_::now();
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+    }
+
+    void anti_optimize(const char* p) {
+        asm volatile("" : : "r"(p) : "memory");
+    }
+
+    void report(const char* label, uint64_t snp_ns, uint64_t fmt_ns) {
+        const double snp_per = static_cast<double>(snp_ns) / N_ITERS;
+        const double fmt_per = static_cast<double>(fmt_ns) / N_ITERS;
+        const double ratio = fmt_per / snp_per;
+        std::printf(
+            "  %-32s snprintf=%7.1f ns/op  fmt=%7.1f ns/op  ratio=%4.2fx\n",
+            label,
+            snp_per,
+            fmt_per,
+            ratio
+        );
+    }
+
+} // namespace
+
+TEST(BenchLogger, SingleUint32) {
+    char buf[BUF_SIZE];
+    const uint32_t snp = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            std::snprintf(buf, BUF_SIZE, "v=%u", static_cast<unsigned>(i));
+            anti_optimize(buf);
+        }
+    });
+    const uint32_t fmtt = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            auto r = fmt::format_to_n(buf, BUF_SIZE, "v={}", i);
+            *r.out = '\0';
+            anti_optimize(buf);
+        }
+    });
+    report("single uint32", snp, fmtt);
+}
+
+TEST(BenchLogger, MultiArgsTwoIntsString) {
+    char buf[BUF_SIZE];
+    const uint32_t snp = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            std::snprintf(
+                buf, BUF_SIZE, "PD ready: %u PDO (%u PPS) %s", 7u, 3u, "Anker"
+            );
+            anti_optimize(buf);
+        }
+    });
+    const uint32_t fmtt = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            auto r = fmt::format_to_n(buf, BUF_SIZE, "PD ready: {} PDO ({} PPS) {}", 7, 3, "Anker");
+            *r.out = '\0';
+            anti_optimize(buf);
+        }
+    });
+    report("multi-arg (2 int + str)", snp, fmtt);
+}
+
+TEST(BenchLogger, TimestampHeader) {
+    char buf[BUF_SIZE];
+    const uint32_t snp = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            std::snprintf(
+                buf,
+                BUF_SIZE,
+                "%s[%02lu:%02lu:%02lu.%03lu][%c][%s] ",
+                "\x1b[32m",
+                1ul,
+                2ul,
+                3ul,
+                456ul,
+                'I',
+                "TestTag"
+            );
+            anti_optimize(buf);
+        }
+    });
+    const uint32_t fmtt = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            auto r = fmt::format_to_n(
+                buf,
+                BUF_SIZE,
+                "{}[{:02}:{:02}:{:02}.{:03}][{}][{}] ",
+                "\x1b[32m",
+                1u,
+                2u,
+                3u,
+                456u,
+                'I',
+                "TestTag"
+            );
+            *r.out = '\0';
+            anti_optimize(buf);
+        }
+    });
+    report("logger header (7 args)", snp, fmtt);
+}
+
+TEST(BenchLogger, Hex8Bytes) {
+    char buf[BUF_SIZE];
+    const uint8_t data[] = {0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0xff, 0x10};
+    const uint32_t snp = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            int n = std::snprintf(buf, BUF_SIZE, "%04x: ", static_cast<unsigned>(i));
+            for (size_t j = 0; j < sizeof(data); ++j) {
+                n += std::snprintf(buf + n, BUF_SIZE - n, "%02x ", data[j]);
+            }
+            anti_optimize(buf);
+        }
+    });
+    const uint32_t fmtt = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            auto out = fmt::format_to_n(buf, BUF_SIZE, "{:04x}: ", i).out;
+            for (size_t j = 0; j < sizeof(data); ++j) {
+                out = fmt::format_to_n(out, BUF_SIZE, "{:02x} ", data[j]).out;
+            }
+            anti_optimize(buf);
+        }
+    });
+    report("hexdump row (offset+8 bytes)", snp, fmtt);
+}
+
+TEST(BenchLogger, LongBody200Chars) {
+    char buf[512];
+    const std::string body(200, 'x');
+    const uint32_t snp = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            std::snprintf(buf, sizeof(buf), "%s", body.c_str());
+            anti_optimize(buf);
+        }
+    });
+    const uint32_t fmtt = time_ns([&] {
+        for (int i = 0; i < N_ITERS; ++i) {
+            auto r = fmt::format_to_n(buf, sizeof(buf), "{}", body);
+            *r.out = '\0';
+            anti_optimize(buf);
+        }
+    });
+    report("long body (200 chars)", snp, fmtt);
+}
+
+int main(int argc, char** argv) {
+    std::printf("\n=== snprintf vs fmt format-to-buffer benchmark (N=%d) ===\n", N_ITERS);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -41,7 +41,7 @@ namespace pocketpd {
 
         void on_enter(Conductor&) override {
             m_profile = m_pending_profile;
-            log.info("entered profile=%s", m_profile == Profile::PPS ? "PPS" : "PDO");
+            log.info("entered profile={}", m_profile == Profile::PPS ? "PPS" : "PDO");
         }
     };
 

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -65,7 +65,7 @@ namespace pocketpd {
             const auto pps_n = static_cast<uint8_t>(m_pd_sink.pps_count());
             publish(PdReadyEvent{pdo_n, pps_n});
 
-            log.info("PD ready: %u PDO (%u PPS)", pdo_n, pps_n);
+            log.info("PD ready: {} PDO ({} PPS)", pdo_n, pps_n);
         }
 
         void on_tick(Conductor& conductor, uint32_t now_ms) override {
@@ -73,7 +73,7 @@ namespace pocketpd {
             if (m_dump_timer.tick(now_ms)) {
                 std::array<char, 2048> buffer{};
                 ap33772::format_pdo(m_pd_sink, buffer.data(), buffer.size());
-                log.info(buffer.data());
+                log.info("{}", buffer.data());
             }
 
             if (!m_timeout.armed()) {

--- a/include/v2/tasks/button_task.h
+++ b/include/v2/tasks/button_task.h
@@ -87,7 +87,7 @@ namespace pocketpd {
                 const std::optional<Gesture> gesture = ref.detector.update(is_held, now_ms);
                 if (gesture.has_value()) {
                     log.debug(
-                        "button=%s detected gesture=%s",
+                        "button={} detected gesture={}",
                         button_name(ref.id),
                         gesture.value() == Gesture::SHORT ? "SHORT" : "LONG"
                     );

--- a/lib/tempo/include/tempo/app/application.h
+++ b/lib/tempo/include/tempo/app/application.h
@@ -159,7 +159,7 @@ namespace tempo {
             m_conductor.template start<InitialStage>();
 
             m_started = true;
-            log.info("tempo: started, Stage=%s", m_conductor.current_name());
+            log.info("tempo: started, Stage={}", m_conductor.current_name());
         }
 
         /**
@@ -177,7 +177,7 @@ namespace tempo {
             if (m_conductor.apply_pending_transition()) {
                 const size_t after = m_conductor.current_index();
                 m_scheduler.notify_stage_changed(before, after);
-                log.info("Stage %s -> %s", name_of_stage_at(before), name_of_stage_at(after));
+                log.info("Stage {} -> {}", name_of_stage_at(before), name_of_stage_at(after));
             }
 
             const size_t current = m_conductor.current_index();

--- a/lib/tempo/include/tempo/diag/logger.h
+++ b/lib/tempo/include/tempo/diag/logger.h
@@ -3,12 +3,21 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
-#include <cstring>
 #include <functional>
 #include <optional>
+#include <utility>
+
+// Arduino's `F()` macro collides with fmt's template parameter named `F`. Save and
+// restore around the fmt include so downstream Arduino code keeps the macro.
+#pragma push_macro("F")
+#ifdef F
+#undef F
+#endif
+#include <fmt/format.h>
+#pragma pop_macro("F")
 
 #include "tempo/core/time.h"
+#include "tempo/diag/stream_iterator.h"
 #include "tempo/hardware/stream.h"
 
 // 0=NONE 1=ERROR 2=WARN 3=INFO 4=DEBUG 5=VERBOSE
@@ -75,6 +84,7 @@ namespace tempo {
     }
 
     constexpr const char* COLOR_RESET = "\x1b[0m";
+    constexpr const char* COLOR_RESET_NEWLINE = "\x1b[0m\n";
 
     class Logger {
     private:
@@ -83,21 +93,8 @@ namespace tempo {
         std::optional<std::reference_wrapper<const Clock>> m_clock;
         std::optional<std::reference_wrapper<StreamWriter>> m_stream_writer;
 
-        template <size_t N, typename... Args>
-        int write(const char* format, Args... args) const {
-            std::array<char, N> buffer{0};
-            const int written = snprintf(buffer.data(), buffer.size(), format, args...);
-            if (written < 0) {
-                return written;
-            }
-            const size_t len =
-                (static_cast<size_t>(written) >= N) ? (N - 1) : static_cast<size_t>(written);
-            m_stream_writer->get().write(buffer.data(), len);
-            return written;
-        }
-
         template <LogLevel L, typename... Args>
-        void log(const char* fmt, Args... args) const {
+        void log(fmt::format_string<Args...> fs, Args&&... args) const {
             if constexpr (!compiledIn(L)) {
                 return;
             }
@@ -107,16 +104,13 @@ namespace tempo {
                 return;
             }
 
-            write_header(L);
-            if constexpr (sizeof...(Args) == 0) {
-                m_stream_writer->get().write(fmt, strlen(fmt));
-            } else {
-                write<192>(fmt, args...);
-            }
-            write_footer();
+            BufferedStreamSink sink(m_stream_writer->get());
+            write_header(sink, L);
+            fmt::format_to(sink.out(), fs, std::forward<Args>(args)...);
+            fmt::format_to(sink.out(), "{}", COLOR_RESET_NEWLINE);
         }
 
-        void write_header(LogLevel level) const {
+        void write_header(BufferedStreamSink& sink, LogLevel level) const {
             // clang-format off
             const uint32_t ms_total  = m_clock->get().now_ms();
             const uint32_t s_total   = ms_total / 1000;
@@ -126,45 +120,49 @@ namespace tempo {
             const uint32_t hr        = min_total / 60;
             const uint32_t min       = min_total - hr * 60;
             // clang-format on
-            write<64>(
-                "%s[%02lu:%02lu:%02lu.%03lu][%c][%s] ",
+            fmt::format_to(
+                sink.out(),
+                "{}[{:02}:{:02}:{:02}.{:03}][{}][{}] ",
                 level_color(level),
-                static_cast<unsigned long>(hr),
-                static_cast<unsigned long>(min),
-                static_cast<unsigned long>(sec),
-                static_cast<unsigned long>(ms),
+                hr,
+                min,
+                sec,
+                ms,
                 level_tag(level),
                 m_tag
             );
         }
 
-        void write_footer() const {
-            m_stream_writer->get().write("\x1b[0m\n");
-        }
-
         void hexdump_impl(const char* label, const uint8_t* data, size_t len) const {
-            write_header(LogLevel::DEBUG);
-            if (label) {
-                write<96>("%s (%u bytes):", label, static_cast<unsigned>(len));
+            StreamWriter& sw = m_stream_writer->get();
+            {
+                BufferedStreamSink sink(sw);
+                write_header(sink, LogLevel::DEBUG);
+                if (label) {
+                    fmt::format_to(sink.out(), "{} ({} bytes):", label, len);
+                }
+                fmt::format_to(sink.out(), "{}", COLOR_RESET_NEWLINE);
             }
-            write_footer();
 
             constexpr size_t ROW_WIDTH = 16;
             for (size_t i = 0; i < len; i += ROW_WIDTH) {
-                write<12>("  %04x: ", static_cast<unsigned>(i));
+                BufferedStreamSink sink(sw);
+                auto it = sink.out();
+                fmt::format_to(it, "  {:04x}: ", i);
                 for (size_t j = 0; j < ROW_WIDTH; ++j) {
                     if (i + j < len) {
-                        write<4>("%02x ", data[i + j]);
+                        fmt::format_to(it, "{:02x} ", data[i + j]);
                     } else {
-                        m_stream_writer->get().write("   ");
+                        fmt::format_to(it, "   ");
                     }
                 }
-                m_stream_writer->get().write(" ");
+                fmt::format_to(it, " ");
                 for (size_t j = 0; j < ROW_WIDTH && i + j < len; ++j) {
-                    uint8_t c = data[i + j];
-                    write<2>("%c", static_cast<char>((c >= 0x20 && c < 0x7f) ? c : '.'));
+                    const uint8_t c = data[i + j];
+                    const char printable = static_cast<char>((c >= 0x20 && c < 0x7f) ? c : '.');
+                    fmt::format_to(it, "{}", printable);
                 }
-                m_stream_writer->get().write("\n");
+                fmt::format_to(it, "\n");
             }
         }
 
@@ -194,24 +192,24 @@ namespace tempo {
         }
 
         template <typename... Args>
-        void error(const char* fmt, Args... args) const {
-            log<LogLevel::ERROR>(fmt, args...);
+        void error(fmt::format_string<Args...> fs, Args&&... args) const {
+            log<LogLevel::ERROR>(fs, std::forward<Args>(args)...);
         }
         template <typename... Args>
-        void warn(const char* fmt, Args... args) const {
-            log<LogLevel::WARN>(fmt, args...);
+        void warn(fmt::format_string<Args...> fs, Args&&... args) const {
+            log<LogLevel::WARN>(fs, std::forward<Args>(args)...);
         }
         template <typename... Args>
-        void info(const char* fmt, Args... args) const {
-            log<LogLevel::INFO>(fmt, args...);
+        void info(fmt::format_string<Args...> fs, Args&&... args) const {
+            log<LogLevel::INFO>(fs, std::forward<Args>(args)...);
         }
         template <typename... Args>
-        void debug(const char* fmt, Args... args) const {
-            log<LogLevel::DEBUG>(fmt, args...);
+        void debug(fmt::format_string<Args...> fs, Args&&... args) const {
+            log<LogLevel::DEBUG>(fs, std::forward<Args>(args)...);
         }
         template <typename... Args>
-        void verbose(const char* fmt, Args... args) const {
-            log<LogLevel::VERBOSE>(fmt, args...);
+        void verbose(fmt::format_string<Args...> fs, Args&&... args) const {
+            log<LogLevel::VERBOSE>(fs, std::forward<Args>(args)...);
         }
 
         void hexdump(const char* label, const void* data, size_t len) const {
@@ -227,9 +225,9 @@ namespace tempo {
         }
 
         template <typename... Args>
-        void check(bool cond, const char* fmt, Args... args) const {
+        void check(bool cond, fmt::format_string<Args...> fs, Args&&... args) const {
             if (!cond) {
-                error(fmt, args...);
+                error(fs, std::forward<Args>(args)...);
             }
         }
     };

--- a/lib/tempo/include/tempo/diag/stream_iterator.h
+++ b/lib/tempo/include/tempo/diag/stream_iterator.h
@@ -1,0 +1,96 @@
+/**
+ * @file stream_iterator.h
+ * @brief Buffered output sink that adapts a `tempo::StreamWriter` to fmt's output_iterator
+ * concept.
+ *
+ * Used by `tempo::Logger` to stream `fmt::format_to(...)` output through `StreamWriter::write`
+ * without per-character virtual dispatch. The sink owns a small stack buffer; characters
+ * accumulate until the buffer fills (auto-flush) or the sink destructs (final flush).
+ */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+
+#include "tempo/hardware/stream.h"
+
+namespace tempo {
+
+    /**
+     * @brief Small fixed-buffer sink writing into a `StreamWriter` in chunks.
+     *
+     * Iterator obtained via `out()` satisfies fmt's output_iterator requirements;
+     * `*it = c` calls `put(c)`. The sink owns the buffer; lifetime is one log call.
+     */
+    class BufferedStreamSink {
+    public:
+        // —— Tunables
+        static constexpr size_t BUF_SIZE = 64;
+
+    private:
+        StreamWriter& m_sw;
+        // Uninitialized: only bytes [0, m_n) are read by flush(); zero-init wastes cycles.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        std::array<char, BUF_SIZE> m_buf;
+        size_t m_n = 0;
+
+    public:
+        explicit BufferedStreamSink(StreamWriter& sw) : m_sw(sw) {}
+        ~BufferedStreamSink() {
+            flush();
+        }
+
+        BufferedStreamSink(const BufferedStreamSink&) = delete;
+        BufferedStreamSink& operator=(const BufferedStreamSink&) = delete;
+        BufferedStreamSink(BufferedStreamSink&&) = delete;
+        BufferedStreamSink& operator=(BufferedStreamSink&&) = delete;
+
+        void put(char c) {
+            if (m_n == BUF_SIZE) {
+                flush();
+            }
+            m_buf[m_n++] = c;
+        }
+
+        void flush() {
+            if (m_n != 0) {
+                m_sw.write(m_buf.data(), m_n);
+                m_n = 0;
+            }
+        }
+
+        class Iterator {
+            BufferedStreamSink* m_sink;
+
+        public:
+            using iterator_category = std::output_iterator_tag;
+            using value_type = char;
+            using difference_type = std::ptrdiff_t;
+            using pointer = void;
+            using reference = void;
+
+            explicit Iterator(BufferedStreamSink& sink) : m_sink(&sink) {}
+
+            Iterator& operator=(char c) {
+                m_sink->put(c);
+                return *this;
+            }
+
+            Iterator& operator*() {
+                return *this;
+            }
+            Iterator& operator++() {
+                return *this;
+            }
+            Iterator operator++(int) {
+                return *this;
+            }
+        };
+
+        Iterator out() {
+            return Iterator(*this);
+        }
+    };
+
+} // namespace tempo

--- a/lib/tempo/library.json
+++ b/lib/tempo/library.json
@@ -4,5 +4,8 @@
   "build": {
     "includeDir": "include",
     "srcFilter": "+<tempo.cpp>"
+  },
+  "dependencies": {
+    "fmt": "https://github.com/fmtlib/fmt.git#11.2.0"
   }
 }

--- a/lib/tempo/platformio.ini
+++ b/lib/tempo/platformio.ini
@@ -4,6 +4,7 @@
 
 [platformio]
 default_envs = pico, native
+extra_configs = ../../scripts/fmt_flags.ini
 
 [pico_common]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
@@ -11,9 +12,14 @@ board = pico
 framework = arduino
 board_build.core = earlephilhower
 test_ignore = *
+build_flags =
+	${fmt_size_flags.build_flags}
+lib_deps =
+	fmt=https://github.com/fmtlib/fmt.git#11.2.0
 
 [env:pico]
 extends = pico_common
+extra_scripts = pre:../../scripts/configure_fmt_header_only.py
 build_src_filter =
 	+<tempo.cpp>
 	+<main_pico.cpp>
@@ -22,12 +28,15 @@ build_src_filter =
 platform = native
 build_type = test
 test_framework = googletest
+extra_scripts = pre:../../scripts/configure_fmt_header_only.py
 build_src_filter = +<tempo.cpp>
 build_flags =
 	-std=gnu++17
 	-DUNIT_TEST
+	${fmt_size_flags.build_flags}
 	-I include
 	-Wno-missing-template-arg-list-after-template-kw
 lib_deps =
+	fmt=https://github.com/fmtlib/fmt.git#11.2.0
 	fabiobatsilva/ArduinoFake @ ^0.4.0
 	google/googletest @ ^1.17.0

--- a/lib/tempo/test/test_tempo_logger/test.cpp
+++ b/lib/tempo/test/test_tempo_logger/test.cpp
@@ -1,0 +1,114 @@
+/**
+ * GoogleTest suite for tempo Logger fmt-backed implementation.
+ *
+ * Asserts header byte sequence, body formatting, footer, level gating, hexdump output,
+ * and behavior when StreamWriter is unset. Inline mocks for Clock + StreamWriter.
+ */
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+#include <tempo/core/time.h>
+#include <tempo/diag/logger.h>
+#include <tempo/hardware/stream.h>
+
+namespace {
+
+    class FakeClock : public tempo::Clock {
+    public:
+        uint32_t now = 0;
+        uint32_t now_ms() const override {
+            return now;
+        }
+    };
+
+    class CapturingStream : public tempo::StreamWriter {
+    public:
+        std::string captured;
+        size_t write_calls = 0;
+
+        size_t write(const char* data, size_t len) override {
+            captured.append(data, len);
+            ++write_calls;
+            return len;
+        }
+    };
+
+} // namespace
+
+class LoggerTest : public ::testing::Test {
+protected:
+    FakeClock clock;
+    CapturingStream stream;
+    tempo::Logger logger{"TestTag", clock, stream};
+};
+
+TEST_F(LoggerTest, EmitsHeaderTagFooter) {
+    clock.now = 1234; // 00:00:01.234
+    logger.info("body");
+    EXPECT_EQ(stream.captured, "\x1b[32m[00:00:01.234][I][TestTag] body\x1b[0m\n");
+}
+
+TEST_F(LoggerTest, FormatsArgsWithBracePlaceholders) {
+    clock.now = 0;
+    logger.info("v={} ma={}", 5000, 1000);
+    EXPECT_NE(stream.captured.find("v=5000 ma=1000"), std::string::npos);
+}
+
+TEST_F(LoggerTest, AlwaysEndsWithColorResetAndNewline) {
+    logger.warn("anything");
+    EXPECT_EQ(stream.captured.substr(stream.captured.size() - 5), "\x1b[0m\n");
+}
+
+TEST_F(LoggerTest, LevelTagMatchesLevel) {
+    logger.error("e");
+    EXPECT_NE(stream.captured.find("[E]"), std::string::npos);
+    stream.captured.clear();
+
+    logger.warn("w");
+    EXPECT_NE(stream.captured.find("[W]"), std::string::npos);
+    stream.captured.clear();
+
+    logger.debug("d");
+    EXPECT_NE(stream.captured.find("[D]"), std::string::npos);
+}
+
+TEST_F(LoggerTest, EncodesTimestampZeroPadded) {
+    clock.now = 3'723'045; // 01:02:03.045
+    logger.info("");
+    EXPECT_NE(stream.captured.find("[01:02:03.045]"), std::string::npos);
+}
+
+TEST(LoggerDisabled, NoCrashWhenStreamUnset) {
+    tempo::Logger logger;
+    logger.info("body {}", 42); // must not crash, must write nothing
+    SUCCEED();
+}
+
+TEST_F(LoggerTest, HexdumpFormatsAddressBytesAscii) {
+    constexpr uint8_t data[] = {0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0xff, 0x10};
+    logger.hexdump("payload", data, sizeof(data));
+
+    EXPECT_NE(stream.captured.find("payload (8 bytes):"), std::string::npos);
+    EXPECT_NE(stream.captured.find("0000:"), std::string::npos);
+    EXPECT_NE(stream.captured.find("48 65 6c 6c 6f 00 ff 10"), std::string::npos);
+    EXPECT_NE(stream.captured.find("Hello"), std::string::npos); // ASCII column
+}
+
+TEST_F(LoggerTest, BufferedSinkChunksLongLineWithoutLoss) {
+    clock.now = 0;
+    // BufferedStreamSink::BUF_SIZE = 64. Header is ~30 bytes; body well over 64 forces flush.
+    const std::string long_body(200, 'x');
+    logger.info("{}", long_body);
+
+    // Body bytes survive intact across chunked writes.
+    EXPECT_NE(stream.captured.find(long_body), std::string::npos);
+    // More than one write call to the StreamWriter for header + chunked body + footer.
+    EXPECT_GT(stream.write_calls, 1u);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs = HW1_3, HW1_3_V2
+extra_configs = scripts/fmt_flags.ini
 
 [pico_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
@@ -23,8 +24,11 @@ debug_speed = 5000
 monitor_speed = 115200
 monitor_port = /dev/cu.usbmodem1201
 monitor_filters = direct
+build_flags =
+	${fmt_size_flags.build_flags}
 lib_deps =
 	tempo
+	fmt=https://github.com/fmtlib/fmt.git#11.2.0
 	olikraus/U8g2@^2.35.19
 	arduinogetstarted/ezButton@^1.0.4
 	mathertel/RotaryEncoder@^1.5.3
@@ -32,7 +36,9 @@ lib_deps =
 
 [env:HW1_3]
 extends = pico_base
+extra_scripts = pre:scripts/configure_fmt_header_only.py
 build_flags =
+	${pico_base.build_flags}
 	-DHW1_3
 	-DVERSION="\"1.0.0\""
 build_src_filter = 
@@ -42,8 +48,11 @@ build_src_filter =
 
 [env:HW1_3_V2]
 extends = pico_base
-extra_scripts = post:scripts/compiledb_inject_headers.py
+extra_scripts =
+	pre:scripts/configure_fmt_header_only.py
+	post:scripts/compiledb_inject_headers.py
 build_flags =
+	${pico_base.build_flags}
 	-DHW1_3_V2
 	-DVERSION="\"2.0.0-dev\""
 build_src_filter =
@@ -55,15 +64,18 @@ build_src_filter =
 platform = native
 build_type = test
 test_framework = googletest
+extra_scripts = pre:scripts/configure_fmt_header_only.py
 build_flags =
 	-std=gnu++17
 	-DUNIT_TEST
+	${fmt_size_flags.build_flags}
 	-I include
 	-I test/mocks
 	-I lib/AP33772
 	-Wno-missing-template-arg-list-after-template-kw
 lib_deps =
 	tempo
+	fmt=https://github.com/fmtlib/fmt.git#11.2.0
 	fabiobatsilva/ArduinoFake @ ^0.4.0
 
 [env:native_clangd]
@@ -76,11 +88,13 @@ build_src_filter =
 build_flags =
 	-std=gnu++17
 	-DUNIT_TEST
+	${fmt_size_flags.build_flags}
 	-I include
 	-I test/mocks
 	-I lib/AP33772
 	-Wno-missing-template-arg-list-after-template-kw
 lib_deps =
 	tempo
+	fmt=https://github.com/fmtlib/fmt.git#11.2.0
 	fabiobatsilva/ArduinoFake @ ^0.4.0
 	google/googletest @ ^1.17.0

--- a/scripts/configure_fmt_header_only.py
+++ b/scripts/configure_fmt_header_only.py
@@ -1,0 +1,43 @@
+"""
+Pre-script: write a library.json into the resolved fmt library dir so PlatformIO
+treats fmt as header-only. fmt's upstream `src/fmt.cc` is a C++20 module unit
+that does not compile in our pre-C++20 builds; with FMT_HEADER_ONLY=1 nothing
+in `src/` is needed.
+"""
+
+import json
+import os
+
+Import("env")  # type: ignore[name-defined]
+
+
+def patch_fmt(*_args, **_kwargs):
+    libdeps_root = env.subst("$PROJECT_LIBDEPS_DIR")
+    pioenv = env.subst("$PIOENV")
+    fmt_dir = os.path.join(libdeps_root, pioenv, "fmt")
+    if not os.path.isdir(fmt_dir):
+        return
+
+    manifest_path = os.path.join(fmt_dir, "library.json")
+    desired = {
+        "name": "fmt",
+        "version": "11.2.0",
+        "build": {
+            "includeDir": "include",
+            "srcFilter": ["-<*>"],
+        },
+    }
+    try:
+        with open(manifest_path, "r") as fh:
+            current = json.load(fh)
+        if current == desired:
+            return
+    except (FileNotFoundError, ValueError):
+        pass
+
+    with open(manifest_path, "w") as fh:
+        json.dump(desired, fh, indent=2)
+        fh.write("\n")
+
+
+patch_fmt()

--- a/scripts/fmt_flags.ini
+++ b/scripts/fmt_flags.ini
@@ -1,0 +1,34 @@
+; Shared {fmt} build configuration. Pulled in by every PlatformIO project that
+; consumes tempo's Logger (which `#include`s `<fmt/format.h>`):
+;   - <repo>/platformio.ini             (root: firmware + native tests)
+;   - <repo>/lib/tempo/platformio.ini   (tempo standalone build/tests)
+;   - <repo>/benchmarks/platformio.ini  (logger benchmarks)
+;
+; Each project loads this file via:
+;   [platformio]
+;   extra_configs = <relative path to this file>
+;
+; Then references the section via interpolation, e.g.:
+;   build_flags = ${fmt_size_flags.build_flags}
+;
+; Flash on RP2040 (HW1_3_V2, fmt 11.2.0, gcc 14.3.0, no LTO):
+;   FMT_HEADER_ONLY=1 only         386,904 bytes
+;   all flags                      121,860 bytes
+;
+; FMT_OPTIMIZE_SIZE=2 carries ~265 KB of savings. The other flags measure 0
+; bytes today (no float / locale / int128 / exception paths instantiated) but
+; are kept as future-proofing -- adding e.g. a `{:f}` float without
+; FMT_USE_DOUBLE=0 would re-pull the float formatter.
+;
+; FMT_HEADER_ONLY=1 drives the include-only build; fmt's C++20-module
+; src/fmt.cc is skipped via scripts/configure_fmt_header_only.py.
+
+[fmt_size_flags]
+build_flags =
+	-DFMT_HEADER_ONLY=1
+	-DFMT_OPTIMIZE_SIZE=2
+	-DFMT_USE_EXCEPTIONS=0
+	-DFMT_USE_DOUBLE=0
+	-DFMT_USE_LONG_DOUBLE=0
+	-DFMT_USE_LOCALE=0
+	-DFMT_USE_INT128=0


### PR DESCRIPTION
## Summary
Replace tempo Logger's printf-style internals with `fmt::format_to` through a buffered stream-writer iterator. Public method names stay the same; signatures take `fmt::format_string<Args...>` so format strings are checked against argument types at compile time. fmt 11.2.0 is pulled in header-only via git tag, with size flags shared across the three PlatformIO projects through `scripts/fmt_flags.ini` so flash overhead stays around 28 KB on RP2040.

## Motivation
Logger previously routed through `snprintf` with format strings parsed at runtime, so format/argument mismatches were build clean  but would be runtime Undefined Behavior and long messages were silently truncated by the fixed buffer. `fmt` gives compile-time format-string checking, removes the `snprintf` buffer in favor of a streamed buffered sink, and trades runtime parsing cost for around 28 KB of flash on RP2040.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested: built and flashed `HW1_3_V2` (RAM 4.7 %, Flash 5.8 %), confirmed Logger output reaches the serial monitor with the expected `[hh:mm:ss.mmm][L][tag] body` format. Ran the on-device benchmark in `benchmarks/` to compare snprintf and fmt format-to-buffer paths over representative payloads (single arg, multi-arg, full logger header, hexdump row, long body); fmt is within 2x of snprintf and UART throughput dominates either way.

## Breaking change / migration
- [x] Public lib API (`lib/*` headers)

Details: Logger method signatures now take `fmt::format_string<Args...>` instead of `const char*`, so format strings must be `{}`-style literals (or wrapped in `fmt::runtime`). All in-tree call sites in tempo, the v2 stages, and the v2 tasks are migrated; out-of-tree consumers will need to switch from `%`-style to `{}`-style placeholders.

## Notes
fmt size flags live in `scripts/fmt_flags.ini` and are pulled in via PlatformIO `extra_configs` so the root project, the tempo standalone build, and the benchmarks sub-project share one source of truth. A pre-build script writes a `library.json` into the resolved fmt directory so PlatformIO treats fmt as header-only and skips its C++20 module unit. The benchmark sub-project is intentionally separate and does not run on `pio test` or `pio run` against the main project.