### PR TITLE
feat(v2): add OutputGate HAL and ProfilePicker SELECT/REVIEW transitions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,23 +2,23 @@ BasedOnStyle: LLVM
 ColumnLimit: 100
 IndentWidth: 4
 
-AlwaysBreakTemplateDeclarations: Yes
 AccessModifierOffset: -4
 AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveMacros: Consecutive
 AlignOperands: AlignAfterOperator
 AllowShortFunctionsOnASingleLine: Empty
-InsertBraces: true
-NamespaceIndentation: All
-PointerAlignment: Left
-DerivePointerAlignment: false
-SpaceAfterCStyleCast: true
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: OnePerLine
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+DerivePointerAlignment: false
+InsertBraces: true
+NamespaceIndentation: All
 PackConstructorInitializers: NextLine
+PointerAlignment: Left
 ReflowComments: true
+SpaceAfterCStyleCast: true
 # Header include ordering — Google C++ Style Guide
 # https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes
 #   1. C system headers      (<stdint.h>, <string.h>)

--- a/include/v2/app.h
+++ b/include/v2/app.h
@@ -17,11 +17,11 @@ namespace pocketpd {
 
     class BootStage;
     class ObtainStage;
-    class PdoPickerStage;
+    class ProfilePickerStage;
     class NormalStage;
 
     // —— Application alias
 
-    using App = tempo::Application<Event, BootStage, ObtainStage, PdoPickerStage, NormalStage>;
+    using App = tempo::Application<Event, BootStage, ObtainStage, ProfilePickerStage, NormalStage>;
 
 } // namespace pocketpd

--- a/include/v2/hal/arduino_output_gate.h
+++ b/include/v2/hal/arduino_output_gate.h
@@ -1,0 +1,47 @@
+/**
+ * @file arduino_output_gate.h
+ * @brief Arduino-backed `OutputGate` implementation that drives a single GPIO pin.
+ *
+ * Active-high wiring on the PocketPD board: `HIGH` = output on, `LOW` = output off. `begin()`
+ * forces the pin LOW so power stays off until something explicitly enables it.
+ */
+#pragma once
+
+#include <Arduino.h>
+
+#include <cstdint>
+
+#include "v2/hal/output_gate.h"
+
+namespace pocketpd {
+
+    class ArduinoOutputGate : public OutputGate {
+    private:
+        const uint8_t m_pin;
+        bool m_enabled = false;
+
+    public:
+        explicit ArduinoOutputGate(uint8_t pin) : m_pin(pin) {}
+
+        void begin() {
+            pinMode(m_pin, OUTPUT);
+            digitalWrite(m_pin, LOW);
+            m_enabled = false;
+        }
+
+        void enable() override {
+            digitalWrite(m_pin, HIGH);
+            m_enabled = true;
+        }
+
+        void disable() override {
+            digitalWrite(m_pin, LOW);
+            m_enabled = false;
+        }
+
+        bool is_enabled() const override {
+            return m_enabled;
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/hal/output_gate.h
+++ b/include/v2/hal/output_gate.h
@@ -1,0 +1,19 @@
+/**
+ * @file output_gate.h
+ * @brief Load-switch enable line abstraction.
+ *
+ */
+#pragma once
+
+namespace pocketpd {
+
+    class OutputGate {
+    public:
+        virtual ~OutputGate() = default;
+
+        virtual void enable() = 0;
+        virtual void disable() = 0;
+        virtual bool is_enabled() const = 0;
+    };
+
+} // namespace pocketpd

--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -21,8 +21,8 @@ namespace pocketpd {
      *
      */
     constexpr uint32_t BOOT_TO_OBTAIN_MS = 500;
-    constexpr uint32_t OBTAIN_TO_PDOPICKER_MS = 1500;
-    constexpr uint32_t PDOPICKER_REVIEW_TO_NORMAL_MS = 3000;
+    constexpr uint32_t OBTAIN_TO_PROFILE_PICKER_MS = 1500;
+    constexpr uint32_t PROFILE_PICKER_REVIEW_TO_NORMAL_MS = 3000;
 
     /**
      * @brief Which PD protocol the active charger speaks.

--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -22,6 +22,7 @@ namespace pocketpd {
      */
     constexpr uint32_t BOOT_TO_OBTAIN_MS = 500;
     constexpr uint32_t OBTAIN_TO_PDOPICKER_MS = 1500;
+    constexpr uint32_t PDOPICKER_REVIEW_TO_NORMAL_MS = 3000;
 
     /**
      * @brief Which PD protocol the active charger speaks.

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -5,7 +5,8 @@
  * Profile (`PPS` vs `PDO`) is set at entry by the caller via
  * `Conductor::request<NormalStage>(Profile)` which forwards to
  * `prepare(Profile)`. The profile is locked for the duration of the stage —
- * to switch profile, exit to PdoPicker SELECT and re-enter.
+ * a long-press of the L button exits back to ProfilePicker SELECT so the
+ * user can pick a different profile.
  *
  * Stub today: enters and logs the chosen profile. The full encoder edit
  * (PPS-only), PDO/PPS RDO issuance, output toggle, autosave, sensor read,
@@ -13,15 +14,20 @@
  */
 #pragma once
 
+#include <tempo/bus/visit.h>
+
+#include <variant>
+
 #include "v2/app.h"
+#include "v2/events.h"
 #include "v2/pocketpd.h"
 
 namespace pocketpd {
 
+    class ProfilePickerStage;
+
     class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
-        // Still don't know if we should use pending variable or not. TBD.
-        Profile m_pending_profile = Profile::PDO;
         Profile m_profile = Profile::PDO;
 
     public:
@@ -36,13 +42,14 @@ namespace pocketpd {
         }
 
         void prepare(Profile profile) {
-            m_pending_profile = profile;
+            m_profile = profile;
         }
 
         void on_enter(Conductor&) override {
-            m_profile = m_pending_profile;
             log.info("entered profile={}", m_profile == Profile::PPS ? "PPS" : "PDO");
         }
+
+        void on_event(Conductor& conductor, const Event& event, uint32_t) override;
     };
 
 } // namespace pocketpd

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -5,8 +5,8 @@
  *
  * After the announce, ObtainStage acts as a short window to handle user input:
  *  1. a short button press resumes Normal operation immediately,
- *  2. encoder rotation jumps to PdoPicker in SELECT mode, and
- *  3. otherwise the stage times out into PdoPicker REVIEW so the PDO list can be reviewed.
+ *  2. encoder rotation jumps to ProfilePicker in SELECT mode, and
+ *  3. otherwise the stage times out into ProfilePicker REVIEW so the PDO list can be reviewed.
  *
  * Issue #33: ObtainStage must NOT issue an RDO request. The first request runs later
  * (NormalPpsStage / NormalPdoStage) once EEPROM has been consulted. Until then the AP33772 holds
@@ -28,7 +28,7 @@
 #include "v2/hal/pd_sink_controller.h"
 #include "v2/pocketpd.h"
 #include "v2/stages/normal_stage.h"
-#include "v2/stages/pdo_picker_stage.h"
+#include "v2/stages/profile_picker_stage.h"
 
 namespace pocketpd {
 
@@ -77,12 +77,12 @@ namespace pocketpd {
             }
 
             if (!m_timeout.armed()) {
-                m_timeout.set(now_ms, OBTAIN_TO_PDOPICKER_MS);
+                m_timeout.set(now_ms, OBTAIN_TO_PROFILE_PICKER_MS);
                 return;
             }
 
             if (m_timeout.reached(now_ms)) {
-                conductor.request<PdoPickerStage>(PdoPickerStage::Mode::REVIEW);
+                conductor.request<ProfilePickerStage>(ProfilePickerStage::Mode::REVIEW);
                 return; // Should return after stage change request to avoid executing more code
             }
         }
@@ -99,7 +99,7 @@ namespace pocketpd {
                 },
                 [&](const EncoderEvent& evt) {
                     if (evt.delta != 0) {
-                        conductor.request<PdoPickerStage>(PdoPickerStage::Mode::SELECT);
+                        conductor.request<ProfilePickerStage>(ProfilePickerStage::Mode::SELECT);
                     }
                 },
                 [](const auto&) {

--- a/include/v2/stages/pdo_picker_stage.h
+++ b/include/v2/stages/pdo_picker_stage.h
@@ -1,28 +1,31 @@
 /**
  * @file pdo_picker_stage.h
- * @brief PDO picker / capability list stage. Two modes via tempo payload-passing transition:
- * REVIEW renders the source PDO list and waits for input; SELECT renders the same list with an
- * encoder-driven cursor.
+ * @brief PDO picker / capability list stage. Two modes via payload-passing transition:
+ * - REVIEW renders the source PDO list and waits for input;
+ * - SELECT renders the same list with an encoder-driven cursor and lets the user commit a profile
+ * via long-press of select-VI.
  *
- * REVIEW renders once on entry — the PDO list is fixed for the lifetime of the negotiation, so
- * no on_tick redraw is needed. SELECT re-renders on each cursor move. Output gating on SELECT
- * entry, REVIEW exit transitions, and long-press commit are not yet wired.
+ * Issue #32: SELECT entry disables the load switch so the user cannot change profile
+ * mid-delivery.
  */
 #pragma once
 
-#include <tempo/bus/publisher.h>
 #include <tempo/bus/visit.h>
+#include <tempo/core/time.h>
 #include <tempo/hardware/display.h>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdio>
 #include <variant>
-#include <algorithm>
 
 #include "v2/app.h"
 #include "v2/events.h"
+#include "v2/hal/output_gate.h"
 #include "v2/hal/pd_sink_controller.h"
+#include "v2/pocketpd.h"
+#include "v2/stages/normal_stage.h"
 
 namespace pocketpd {
 
@@ -33,16 +36,30 @@ namespace pocketpd {
         enum class Mode : uint8_t { REVIEW, SELECT };
 
     private:
-        tempo::Display& m_display;
+        using Display = tempo::Display;
+
+        Display& m_display;
         PdSinkController& m_pd_sink;
+        OutputGate& m_output_gate;
+
         Mode m_mode = Mode::REVIEW;
-        int m_cursor = 0;
+        int m_cursor_index = 0;
+
+        tempo::TimeoutTimer m_review_timeout;
+
+        Profile profile_for_charger() const {
+            return m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
+        }
+
+        Profile profile_at_cursor() const {
+            return m_pd_sink.is_index_pps(m_cursor_index) ? Profile::PPS : Profile::PDO;
+        }
 
     public:
         static constexpr const char* LOG_TAG = "PdoPick";
 
-        PdoPickerStage(tempo::Display& display, PdSinkController& pd_sink)
-            : m_display(display), m_pd_sink(pd_sink) {}
+        PdoPickerStage(tempo::Display& display, PdSinkController& pd_sink, OutputGate& output_gate)
+            : m_display(display), m_pd_sink(pd_sink), m_output_gate(output_gate) {}
 
         const char* name() const override {
             return "PDO_PICKER";
@@ -57,19 +74,66 @@ namespace pocketpd {
         }
 
         void on_enter(Conductor&) override {
-            if (m_mode == Mode::REVIEW) {
+            switch (m_mode) {
+            case Mode::REVIEW:
+                m_review_timeout.disarm();
                 render_pdo_list(m_display, m_pd_sink);
-            } else {
-                m_cursor = 0;
-                render_pdo_list(m_display, m_pd_sink, m_cursor);
+                break;
+            case Mode::SELECT:
+                m_cursor_index = 0;
+                m_output_gate.disable();
+                render_pdo_list(m_display, m_pd_sink, m_cursor_index);
+                break;
             }
         }
 
-        void on_event(Conductor&, const Event& event, uint32_t) override {
-            if (m_mode != Mode::SELECT) {
+        void on_tick(Conductor& conductor, uint32_t now_ms) override {
+            if (m_mode != Mode::REVIEW) {
                 return;
             }
 
+            if (!m_review_timeout.armed()) {
+                m_review_timeout.set(now_ms, PDOPICKER_REVIEW_TO_NORMAL_MS);
+                return;
+            }
+
+            if (m_review_timeout.reached(now_ms)) {
+                conductor.request<NormalStage>(profile_for_charger());
+                return;
+            }
+        }
+
+        void on_event(Conductor& conductor, const Event& event, uint32_t) override {
+            switch (m_mode) {
+            case Mode::REVIEW:
+                handle_review_event(conductor, event);
+                break;
+            case Mode::SELECT:
+                handle_select_event(conductor, event);
+                break;
+            }
+        }
+
+    private:
+        void handle_review_event(Conductor& conductor, const Event& event) {
+            auto handler = tempo::overloaded{
+                [&](const ButtonEvent& evt) {
+                    if (evt.gesture == Gesture::SHORT) {
+                        conductor.request<NormalStage>(profile_for_charger());
+                    }
+                },
+                [&](const EncoderEvent& evt) {
+                    if (evt.delta != 0) {
+                        conductor.request<PdoPickerStage>(Mode::SELECT);
+                    }
+                },
+                [](const auto&) {},
+            };
+
+            std::visit(handler, event);
+        }
+
+        void handle_select_event(Conductor& conductor, const Event& event) {
             auto handler = tempo::overloaded{
                 [&](const EncoderEvent& evt) {
                     const int count = m_pd_sink.pdo_count();
@@ -77,13 +141,23 @@ namespace pocketpd {
                         return;
                     }
 
-                    int next = std::clamp(m_cursor + evt.delta, 0, count - 1);
-                    if (next == m_cursor) {
+                    int next = std::clamp(m_cursor_index + evt.delta, 0, count - 1);
+                    if (next == m_cursor_index) {
                         return;
                     }
 
-                    m_cursor = next;
-                    render_pdo_list(m_display, m_pd_sink, m_cursor);
+                    m_cursor_index = next;
+                    render_pdo_list(m_display, m_pd_sink, m_cursor_index);
+                },
+                [&](const ButtonEvent& evt) {
+                    if (evt.id != ButtonId::SELECT_VI || evt.gesture != Gesture::LONG) {
+                        return;
+                    }
+                    if (m_pd_sink.pdo_count() <= 0) {
+                        return; // empty-PDO fallback: long-press is a no-op
+                    }
+
+                    conductor.request<NormalStage>(profile_at_cursor());
                 },
                 [](const auto&) {},
             };
@@ -94,7 +168,6 @@ namespace pocketpd {
 
     inline void
     render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor) {
-
         display.clear();
 
         const int count = pd_sink.pdo_count();
@@ -105,17 +178,21 @@ namespace pocketpd {
         }
 
         std::array<char, 32> buffer{};
+
         for (int row_index = 0; row_index < count; row_index++) {
             const auto y = static_cast<uint8_t>(9 * (row_index + 1));
-            
+
             if (row_index == cursor) {
                 display.draw_text(0, y, ">");
             }
-            
+
             if (pd_sink.is_index_fixed(row_index)) {
                 const int v = pd_sink.pdo_max_voltage_mv(row_index) / 1000;
                 const int a = pd_sink.pdo_max_current_ma(row_index) / 1000;
-                std::snprintf(buffer.data(), buffer.size(), "PDO: %dV @ %dA", v, a);
+
+                const char* fmt = "PDO: %dV @ %dA";
+                std::snprintf(buffer.data(), buffer.size(), fmt, v, a);
+
                 display.draw_text(5, y, buffer.data());
             } else if (pd_sink.is_index_pps(row_index)) {
                 const int min_mv = pd_sink.pdo_min_voltage_mv(row_index);
@@ -128,16 +205,9 @@ namespace pocketpd {
                 const int max_dv = (max_mv % 1000) / 100;
 
                 const int a = pd_sink.pdo_max_current_ma(row_index) / 1000;
-                std::snprintf(
-                    buffer.data(),
-                    buffer.size(),
-                    "PPS: %d.%dV~%d.%dV @ %dA",
-                    min_v,
-                    min_dv,
-                    max_v,
-                    max_dv,
-                    a
-                );
+
+                const char* fmt = "PPS: %d.%dV~%d.%dV @ %dA";
+                std::snprintf(buffer.data(), buffer.size(), fmt, min_v, min_dv, max_v, max_dv, a);
 
                 display.draw_text(5, y, buffer.data());
             }
@@ -145,5 +215,4 @@ namespace pocketpd {
 
         display.flush();
     }
-
 } // namespace pocketpd

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -1,12 +1,9 @@
 /**
- * @file pdo_picker_stage.h
- * @brief PDO picker / capability list stage. Two modes via payload-passing transition:
+ * @file profile_picker_stage.h
+ * @brief Profile-selection / capability-list stage. Two modes via payload-passing transition:
  * - REVIEW renders the source PDO list and waits for input;
  * - SELECT renders the same list with an encoder-driven cursor and lets the user commit a profile
- * via long-press of select-VI.
- *
- * Issue #32: SELECT entry disables the load switch so the user cannot change profile
- * mid-delivery.
+ * via long-press of the encoder button.
  */
 #pragma once
 
@@ -22,16 +19,16 @@
 
 #include "v2/app.h"
 #include "v2/events.h"
-#include "v2/hal/output_gate.h"
 #include "v2/hal/pd_sink_controller.h"
 #include "v2/pocketpd.h"
 #include "v2/stages/normal_stage.h"
+#include "v2/state.h"
 
 namespace pocketpd {
 
     void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor = -1);
 
-    class PdoPickerStage : public App::Stage, public App::UseLog<PdoPickerStage> {
+    class ProfilePickerStage : public App::Stage, public App::UseLog<ProfilePickerStage> {
     public:
         enum class Mode : uint8_t { REVIEW, SELECT };
 
@@ -40,10 +37,10 @@ namespace pocketpd {
 
         Display& m_display;
         PdSinkController& m_pd_sink;
-        OutputGate& m_output_gate;
 
         Mode m_mode = Mode::REVIEW;
-        int m_cursor_index = 0;
+        int m_cursor = 0;
+        int m_pending_cursor = 0;
 
         tempo::TimeoutTimer m_review_timeout;
 
@@ -51,22 +48,34 @@ namespace pocketpd {
             return m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
         }
 
-        Profile profile_at_cursor() const {
-            return m_pd_sink.is_index_pps(m_cursor_index) ? Profile::PPS : Profile::PDO;
+        Profile profile_at(int cursor) const {
+            return m_pd_sink.is_index_pps(cursor) ? Profile::PPS : Profile::PDO;
+        }
+
+        void commit(Conductor& conductor) {
+            if (m_pd_sink.pdo_count() <= 0) {
+                return; // empty-PDO fallback: long-press is a no-op
+            }
+            m_cursor = m_pending_cursor;
+            conductor.request<NormalStage>(profile_at(m_cursor));
         }
 
     public:
-        static constexpr const char* LOG_TAG = "PdoPick";
+        static constexpr const char* LOG_TAG = "ProfilePicker";
 
-        PdoPickerStage(tempo::Display& display, PdSinkController& pd_sink, OutputGate& output_gate)
-            : m_display(display), m_pd_sink(pd_sink), m_output_gate(output_gate) {}
+        ProfilePickerStage(tempo::Display& display, PdSinkController& pd_sink)
+            : m_display(display), m_pd_sink(pd_sink) {}
 
         const char* name() const override {
-            return "PDO_PICKER";
+            return "PROFILE_PICKER";
         }
 
         Mode mode() const {
             return m_mode;
+        }
+
+        int cursor_index() const {
+            return m_cursor;
         }
 
         void prepare(Mode mode) {
@@ -74,15 +83,15 @@ namespace pocketpd {
         }
 
         void on_enter(Conductor&) override {
+            m_review_timeout.disarm();
+
             switch (m_mode) {
             case Mode::REVIEW:
-                m_review_timeout.disarm();
                 render_pdo_list(m_display, m_pd_sink);
                 break;
             case Mode::SELECT:
-                m_cursor_index = 0;
-                m_output_gate.disable();
-                render_pdo_list(m_display, m_pd_sink, m_cursor_index);
+                m_pending_cursor = m_cursor;
+                render_pdo_list(m_display, m_pd_sink, m_pending_cursor);
                 break;
             }
         }
@@ -93,7 +102,7 @@ namespace pocketpd {
             }
 
             if (!m_review_timeout.armed()) {
-                m_review_timeout.set(now_ms, PDOPICKER_REVIEW_TO_NORMAL_MS);
+                m_review_timeout.set(now_ms, PROFILE_PICKER_REVIEW_TO_NORMAL_MS);
                 return;
             }
 
@@ -122,9 +131,14 @@ namespace pocketpd {
                         conductor.request<NormalStage>(profile_for_charger());
                     }
                 },
+                /**
+                 * @brief In review mode, turning the encoder auto-enters the SELECT mode
+                 *
+                 * @param evt incoming EncoderEvent
+                 */
                 [&](const EncoderEvent& evt) {
                     if (evt.delta != 0) {
-                        conductor.request<PdoPickerStage>(Mode::SELECT);
+                        conductor.request<ProfilePickerStage>(Mode::SELECT);
                     }
                 },
                 [](const auto&) {},
@@ -141,23 +155,24 @@ namespace pocketpd {
                         return;
                     }
 
-                    int next = std::clamp(m_cursor_index + evt.delta, 0, count - 1);
-                    if (next == m_cursor_index) {
+                    int next = std::clamp(m_pending_cursor + evt.delta, 0, count - 1);
+                    if (next == m_pending_cursor) {
                         return;
                     }
 
-                    m_cursor_index = next;
-                    render_pdo_list(m_display, m_pd_sink, m_cursor_index);
+                    m_pending_cursor = next;
+                    render_pdo_list(m_display, m_pd_sink, m_pending_cursor);
                 },
                 [&](const ButtonEvent& evt) {
-                    if (evt.id != ButtonId::SELECT_VI || evt.gesture != Gesture::LONG) {
+                    // Exit — do nothing
+                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                        conductor.request<NormalStage>();
                         return;
                     }
-                    if (m_pd_sink.pdo_count() <= 0) {
-                        return; // empty-PDO fallback: long-press is a no-op
-                    }
 
-                    conductor.request<NormalStage>(profile_at_cursor());
+                    if (evt.id == ButtonId::ENCODER && evt.gesture == Gesture::LONG) {
+                        commit(conductor);
+                    }
                 },
                 [](const auto&) {},
             };
@@ -214,5 +229,18 @@ namespace pocketpd {
         }
 
         display.flush();
+    }
+
+    inline void NormalStage::on_event(Conductor& conductor, const Event& event, uint32_t) {
+        auto handler = tempo::overloaded{
+            [&](const ButtonEvent& evt) {
+                if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                    conductor.request<ProfilePickerStage>(ProfilePickerStage::Mode::SELECT);
+                }
+            },
+            [](const auto&) {},
+        };
+
+        std::visit(handler, event);
     }
 } // namespace pocketpd

--- a/include/v2/state.h
+++ b/include/v2/state.h
@@ -16,15 +16,13 @@
 namespace pocketpd {
 
     /**
-     * @brief Identifier for the three physical buttons.
-     *
-     * `OUTPUT_TOGGLE` (not `OUTPUT`) avoids a collision with the Arduino
-     * `OUTPUT` macro that some translation units pull in.
+     * @brief Identifier for the three physical buttons. `L` and `R` denote
+     * the left and right side buttons; `ENCODER` is the rotary push.
      */
     enum class ButtonId : uint8_t {
         ENCODER,
-        OUTPUT_TOGGLE,
-        SELECT_VI,
+        R,
+        L,
     };
 
     enum class Gesture : uint8_t {

--- a/include/v2/tasks/button_task.h
+++ b/include/v2/tasks/button_task.h
@@ -39,8 +39,8 @@ namespace pocketpd {
 
         ButtonTask(
             tempo::ButtonInput& btn_encoder,
-            tempo::ButtonInput& btn_vi_selector,
-            tempo::ButtonInput& btn_output,
+            tempo::ButtonInput& btn_l,
+            tempo::ButtonInput& btn_r,
             ButtonGestureConfig gesture_config = {}
         )
             : App::BackgroundTask(POLL_PERIOD_MS),
@@ -51,13 +51,13 @@ namespace pocketpd {
                       ButtonGestureDetector{gesture_config},
                   },
                   DetectorRef{
-                      ButtonId::SELECT_VI,
-                      &btn_vi_selector,
+                      ButtonId::L,
+                      &btn_l,
                       ButtonGestureDetector{gesture_config},
                   },
                   DetectorRef{
-                      ButtonId::OUTPUT_TOGGLE,
-                      &btn_output,
+                      ButtonId::R,
+                      &btn_r,
                       ButtonGestureDetector{gesture_config},
                   },
               } {}
@@ -69,11 +69,11 @@ namespace pocketpd {
         const char* button_name(ButtonId id) {
             switch (id) {
             case ButtonId::ENCODER:
-                return "ENCODER";
-            case ButtonId::SELECT_VI:
-                return "SELECT_VI";
-            case ButtonId::OUTPUT_TOGGLE:
-                return "OUTPUT_TOGGLE";
+                return "ENCODER_BTN";
+            case ButtonId::L:
+                return "L_BTN";
+            case ButtonId::R:
+                return "R_BTN";
             default:
                 return "UNKNOWN";
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "v2/app.h"
 #include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/arduino_clock.h"
+#include "v2/hal/arduino_output_gate.h"
 #include "v2/hal/arduino_stream_writer.h"
 #include "v2/hal/ez_button_input.h"
 #include "v2/hal/rotary_encoder_input.h"
@@ -34,6 +35,8 @@ namespace {
 
     pocketpd::U8g2Display u8g2_display;
 
+    pocketpd::ArduinoOutputGate output_gate{pin_output_Enable};
+
     pocketpd::EzButtonInput encoder_button{pin_encoder_SW};
     pocketpd::EzButtonInput output_button{pin_button_outputSW};
     pocketpd::EzButtonInput select_vi_button{pin_button_selectVI};
@@ -43,7 +46,7 @@ namespace {
 
     pocketpd::BootStage boot_stage(u8g2_display);
     pocketpd::ObtainStage obtain_stage(pd_sink);
-    pocketpd::PdoPickerStage pdo_picker_stage(u8g2_display, pd_sink);
+    pocketpd::PdoPickerStage pdo_picker_stage(u8g2_display, pd_sink, output_gate);
     pocketpd::NormalStage normal_stage;
 
     // —— Tasks
@@ -61,6 +64,7 @@ void setup() {
     Wire.begin();
 
     u8g2_display.begin();
+    output_gate.begin();
     encoder.begin();
 
     app.register_stage(boot_stage);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@
 #include "v2/stages/boot_stage.h"
 #include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
-#include "v2/stages/pdo_picker_stage.h"
+#include "v2/stages/profile_picker_stage.h"
 #include "v2/tasks/button_task.h"
 #include "v2/tasks/encoder_task.h"
 #include <AP33772.h>
@@ -38,20 +38,20 @@ namespace {
     pocketpd::ArduinoOutputGate output_gate{pin_output_Enable};
 
     pocketpd::EzButtonInput encoder_button{pin_encoder_SW};
-    pocketpd::EzButtonInput output_button{pin_button_outputSW};
-    pocketpd::EzButtonInput select_vi_button{pin_button_selectVI};
+    pocketpd::EzButtonInput r_button{pin_button_outputSW};
+    pocketpd::EzButtonInput l_button{pin_button_selectVI};
     pocketpd::RotaryEncoderInput encoder{pin_encoder_A, pin_encoder_B};
 
     // —— Stages
 
     pocketpd::BootStage boot_stage(u8g2_display);
     pocketpd::ObtainStage obtain_stage(pd_sink);
-    pocketpd::PdoPickerStage pdo_picker_stage(u8g2_display, pd_sink, output_gate);
+    pocketpd::ProfilePickerStage profile_picker_stage(u8g2_display, pd_sink);
     pocketpd::NormalStage normal_stage;
 
     // —— Tasks
 
-    pocketpd::ButtonTask button_task(encoder_button, select_vi_button, output_button);
+    pocketpd::ButtonTask button_task(encoder_button, l_button, r_button);
     pocketpd::EncoderTask encoder_task(encoder);
 
 } // namespace
@@ -69,7 +69,7 @@ void setup() {
 
     app.register_stage(boot_stage);
     app.register_stage(obtain_stage);
-    app.register_stage(pdo_picker_stage);
+    app.register_stage(profile_picker_stage);
     app.register_stage(normal_stage);
 
     app.add_task(button_task);

--- a/test/mocks/MockOutputGate.h
+++ b/test/mocks/MockOutputGate.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "v2/hal/output_gate.h"
+
+namespace pocketpd {
+
+    class MockOutputGate : public OutputGate {
+    public:
+        MOCK_METHOD(void, enable, (), (override));
+        MOCK_METHOD(void, disable, (), (override));
+        MOCK_METHOD(bool, is_enabled, (), (const, override));
+    };
+
+    /**
+     * @brief Scripted OutputGate for tests that want to read back the resulting state.
+     */
+    class FakeOutputGate : public OutputGate {
+    private:
+        bool m_enabled = false;
+
+    public:
+        void enable() override {
+            m_enabled = true;
+        }
+
+        void disable() override {
+            m_enabled = false;
+        }
+
+        bool is_enabled() const override {
+            return m_enabled;
+        }
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_inputs/test.cpp
+++ b/test/test_v2_inputs/test.cpp
@@ -83,10 +83,10 @@ TEST(ButtonGestureDetector, ConsecutivePressesEachEmitShort) {
 // —— ButtonTask
 
 TEST(ButtonTask, ShortGestureOnQuickRelease) {
-    FakeButtonInput encoder, vi_selector, output;
+    FakeButtonInput encoder, l, r;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(encoder, vi_selector, output);
+    ButtonTask task(encoder, l, r);
     task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
     encoder.set_held(true);
@@ -101,10 +101,10 @@ TEST(ButtonTask, ShortGestureOnQuickRelease) {
 }
 
 TEST(ButtonTask, LongGestureFiresWhileHeldAndSilencesRelease) {
-    FakeButtonInput encoder, vi_selector, output;
+    FakeButtonInput encoder, l, r;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(encoder, vi_selector, output);
+    ButtonTask task(encoder, l, r);
     task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
     encoder.set_held(true);
@@ -123,38 +123,38 @@ TEST(ButtonTask, LongGestureFiresWhileHeldAndSilencesRelease) {
     EXPECT_FALSE(q.pop(tmp));
 }
 
-TEST(ButtonTask, OutputButtonShortGestureRoutesToOutputToggle) {
-    FakeButtonInput encoder, vi_selector, output;
+TEST(ButtonTask, RButtonShortGestureRoutesToR) {
+    FakeButtonInput encoder, l, r;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(encoder, vi_selector, output);
+    ButtonTask task(encoder, l, r);
     task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
-    output.set_held(true);
+    r.set_held(true);
     task.poll(0);
-    output.set_held(false);
+    r.set_held(false);
     task.poll(50);
 
     const auto* btn = pop_as<ButtonEvent>(q);
     ASSERT_NE(btn, nullptr);
-    EXPECT_EQ(btn->id, ButtonId::OUTPUT_TOGGLE);
+    EXPECT_EQ(btn->id, ButtonId::R);
     EXPECT_EQ(btn->gesture, Gesture::SHORT);
 }
 
-TEST(ButtonTask, SelectViLongPress) {
-    FakeButtonInput encoder, vi_selector, output;
+TEST(ButtonTask, LButtonLongPress) {
+    FakeButtonInput encoder, l, r;
     TestQueue q;
     TestPublisher pub(q);
-    ButtonTask task(encoder, vi_selector, output);
+    ButtonTask task(encoder, l, r);
     task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
 
-    vi_selector.set_held(true);
+    l.set_held(true);
     task.poll(0);
     task.poll(kDefaultCfg.long_press_ms);
 
     const auto* btn = pop_as<ButtonEvent>(q);
     ASSERT_NE(btn, nullptr);
-    EXPECT_EQ(btn->id, ButtonId::SELECT_VI);
+    EXPECT_EQ(btn->id, ButtonId::L);
     EXPECT_EQ(btn->gesture, Gesture::LONG);
 }
 

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -9,6 +9,7 @@
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
+#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -196,7 +197,8 @@ TEST(ObtainStage, EncoderRotationJumpsToPdoPickerInSelectMode) {
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NiceMock<MockDisplay> picker_display;
-    PdoPickerStage picker(picker_display, sink);
+    FakeOutputGate picker_output_gate;
+    PdoPickerStage picker(picker_display, sink, picker_output_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(picker);
@@ -221,7 +223,8 @@ TEST(ObtainStage, TimeoutTransitionsToPdoPickerInReviewMode) {
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NiceMock<MockDisplay> picker_display;
-    PdoPickerStage picker(picker_display, sink);
+    FakeOutputGate picker_output_gate;
+    PdoPickerStage picker(picker_display, sink, picker_output_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(picker);

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -3,13 +3,12 @@
  *
  * Drives Conductor<...> with scripted MockPdSink and a real EventQueue /
  * QueuePublisher so PdReadyEvent payload can be inspected. Also covers the
- * input-driven exits (short button → resume, encoder → PdoPicker SELECT,
- * timeout → PdoPicker REVIEW).
+ * input-driven exits (short button → resume, encoder → ProfilePicker SELECT,
+ * timeout → ProfilePicker REVIEW).
  */
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
-#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -24,7 +23,7 @@
 #include "v2/stages/boot_stage.h"
 #include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
-#include "v2/stages/pdo_picker_stage.h"
+#include "v2/stages/profile_picker_stage.h"
 
 using namespace pocketpd;
 using ::testing::NiceMock;
@@ -138,7 +137,7 @@ TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
     conductor.register_stage(normal);
     conductor.start<ObtainStage>();
 
-    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
@@ -162,7 +161,7 @@ TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
     conductor.register_stage(normal);
     conductor.start<ObtainStage>();
 
-    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
@@ -182,11 +181,11 @@ TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {
     conductor.register_stage(stage);
     conductor.start<ObtainStage>();
 
-    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
     EXPECT_FALSE(conductor.has_pending());
 }
 
-TEST(ObtainStage, EncoderRotationJumpsToPdoPickerInSelectMode) {
+TEST(ObtainStage, EncoderRotationJumpsToProfilePickerInSelectMode) {
     NiceMock<MockPdSink> sink;
     TestQueue queue;
     TestPublisher publisher(queue);
@@ -197,8 +196,7 @@ TEST(ObtainStage, EncoderRotationJumpsToPdoPickerInSelectMode) {
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NiceMock<MockDisplay> picker_display;
-    FakeOutputGate picker_output_gate;
-    PdoPickerStage picker(picker_display, sink, picker_output_gate);
+    ProfilePickerStage picker(picker_display, sink);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(picker);
@@ -208,11 +206,11 @@ TEST(ObtainStage, EncoderRotationJumpsToPdoPickerInSelectMode) {
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<PdoPickerStage>());
-    EXPECT_EQ(picker.mode(), PdoPickerStage::Mode::SELECT);
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::SELECT);
 }
 
-TEST(ObtainStage, TimeoutTransitionsToPdoPickerInReviewMode) {
+TEST(ObtainStage, TimeoutTransitionsToProfilePickerInReviewMode) {
     NiceMock<MockPdSink> sink;
     TestQueue queue;
     TestPublisher publisher(queue);
@@ -223,22 +221,21 @@ TEST(ObtainStage, TimeoutTransitionsToPdoPickerInReviewMode) {
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
     NiceMock<MockDisplay> picker_display;
-    FakeOutputGate picker_output_gate;
-    PdoPickerStage picker(picker_display, sink, picker_output_gate);
+    ProfilePickerStage picker(picker_display, sink);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(picker);
     conductor.start<ObtainStage>();
 
     conductor.tick(0);
-    conductor.tick(OBTAIN_TO_PDOPICKER_MS - 1);
+    conductor.tick(OBTAIN_TO_PROFILE_PICKER_MS - 1);
     EXPECT_FALSE(conductor.has_pending());
 
-    conductor.tick(OBTAIN_TO_PDOPICKER_MS);
+    conductor.tick(OBTAIN_TO_PROFILE_PICKER_MS);
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<PdoPickerStage>());
-    EXPECT_EQ(picker.mode(), PdoPickerStage::Mode::REVIEW);
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::REVIEW);
 }
 
 TEST(BootStage, RequestsObtainAfterTimeout) {

--- a/test/test_v2_pdopicker/test.cpp
+++ b/test/test_v2_pdopicker/test.cpp
@@ -1,10 +1,11 @@
 /**
  * @file test.cpp
- * @brief PdoPickerStage render + cursor tests, scripted MockPdSink + MockDisplay.
+ * @brief PdoPickerStage render + cursor + transition tests, scripted MockPdSink + MockDisplay.
  */
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
+#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -12,6 +13,8 @@
 
 #include "v2/app.h"
 #include "v2/events.h"
+#include "v2/pocketpd.h"
+#include "v2/stages/normal_stage.h"
 #include "v2/stages/pdo_picker_stage.h"
 
 using namespace pocketpd;
@@ -26,6 +29,7 @@ using TestConductor = App::Conductor;
 TEST(PdoPickerStage, ReviewEmptyListRendersFallback) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
     EXPECT_CALL(display, clear()).Times(1);
@@ -33,7 +37,7 @@ TEST(PdoPickerStage, ReviewEmptyListRendersFallback) {
     EXPECT_CALL(display, flush()).Times(1);
     EXPECT_CALL(display, draw_text(::testing::Ne(8), ::testing::_, ::testing::_)).Times(0);
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -43,6 +47,7 @@ TEST(PdoPickerStage, ReviewEmptyListRendersFallback) {
 TEST(PdoPickerStage, ReviewRendersSingleFixedPdo) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
@@ -53,7 +58,7 @@ TEST(PdoPickerStage, ReviewRendersSingleFixedPdo) {
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -63,6 +68,7 @@ TEST(PdoPickerStage, ReviewRendersSingleFixedPdo) {
 TEST(PdoPickerStage, ReviewRendersFixedAndPpsLines) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
 
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
@@ -79,7 +85,7 @@ TEST(PdoPickerStage, ReviewRendersFixedAndPpsLines) {
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 9V @ 2A"))).Times(1);
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 3A"))).Times(1);
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -90,6 +96,7 @@ TEST(PdoPickerStage, ReviewRendersMultiplePpsLines) {
     // issue #24: chargers can advertise multiple PPS APDOs; each must render.
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
 
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(false));
@@ -107,7 +114,7 @@ TEST(PdoPickerStage, ReviewRendersMultiplePpsLines) {
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PPS: 3.3V~11.0V @ 3A"))).Times(1);
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 5A"))).Times(1);
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -117,6 +124,7 @@ TEST(PdoPickerStage, ReviewRendersMultiplePpsLines) {
 TEST(PdoPickerStage, SelectEntryDrawsCursorAtFirstRow) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
@@ -134,8 +142,41 @@ TEST(PdoPickerStage, SelectEntryDrawsCursorAtFirstRow) {
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PDO: 9V @ 2A"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::SELECT);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, SelectEntryDisablesOutput) {
+    // issue #32: switching profile must not happen while output is delivering.
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+
+    MockOutputGate output_gate;
+    EXPECT_CALL(output_gate, disable()).Times(1);
+    EXPECT_CALL(output_gate, enable()).Times(0);
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<PdoPickerStage>();
+}
+
+TEST(PdoPickerStage, ReviewEntryDoesNotTouchOutput) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+
+    MockOutputGate output_gate;
+    EXPECT_CALL(output_gate, disable()).Times(0);
+    EXPECT_CALL(output_gate, enable()).Times(0);
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<PdoPickerStage>();
@@ -147,6 +188,7 @@ TEST(PdoPickerStage, SelectEncoderMovesCursorAndRerenders) {
 
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
     for (int i = 0; i < 3; ++i) {
         EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
@@ -155,7 +197,7 @@ TEST(PdoPickerStage, SelectEncoderMovesCursorAndRerenders) {
         EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
     }
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -179,6 +221,7 @@ TEST(PdoPickerStage, SelectEncoderClampsAtTopAndBottom) {
 
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     for (int i = 0; i < 2; ++i) {
         EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
@@ -187,7 +230,7 @@ TEST(PdoPickerStage, SelectEncoderClampsAtTopAndBottom) {
         EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
     }
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -215,9 +258,10 @@ TEST(PdoPickerStage, SelectEncoderClampsAtTopAndBottom) {
 TEST(PdoPickerStage, SelectEmptyListIgnoresEncoder) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -229,9 +273,10 @@ TEST(PdoPickerStage, SelectEmptyListIgnoresEncoder) {
     stage.on_event(conductor, EncoderEvent{1}, 0);
 }
 
-TEST(PdoPickerStage, ReviewIgnoresEncoderEvents) {
+TEST(PdoPickerStage, ReviewEncoderRequestsSelectModeReentry) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
@@ -242,22 +287,199 @@ TEST(PdoPickerStage, ReviewIgnoresEncoderEvents) {
     EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(9000));
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(2000));
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<PdoPickerStage>();
-    ::testing::Mock::VerifyAndClearExpectations(&display);
 
-    // Cursor logic / re-render is SELECT-only. REVIEW must not redraw.
-    EXPECT_CALL(display, clear()).Times(0);
-    EXPECT_CALL(display, flush()).Times(0);
-    EXPECT_CALL(display, draw_text(0, ::testing::_, ::testing::_)).Times(0);
     stage.on_event(conductor, EncoderEvent{1}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<PdoPickerStage>());
+    EXPECT_EQ(stage.mode(), PdoPickerStage::Mode::SELECT);
+    EXPECT_FALSE(output_gate.is_enabled());
+}
+
+TEST(PdoPickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<PdoPickerStage>();
+
+    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PPS);
+}
+
+TEST(PdoPickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<PdoPickerStage>();
+
+    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PDO);
+}
+
+TEST(PdoPickerStage, ReviewTimeoutTransitionsToNormal) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<PdoPickerStage>();
+
+    conductor.tick(0);
+    conductor.tick(PDOPICKER_REVIEW_TO_NORMAL_MS - 1);
+    EXPECT_FALSE(conductor.has_pending());
+
+    conductor.tick(PDOPICKER_REVIEW_TO_NORMAL_MS);
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PDO);
+}
+
+TEST(PdoPickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, is_index_fixed(1)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(1)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(21000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<PdoPickerStage>();
+
+    stage.on_event(conductor, EncoderEvent{1}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PPS);
+}
+
+TEST(PdoPickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<PdoPickerStage>();
+
+    // Cursor stays at row 0 (fixed) — no encoder rotation.
+    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PDO);
+}
+
+TEST(PdoPickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<PdoPickerStage>();
+
+    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::LONG}, 0);
+    EXPECT_FALSE(conductor.has_pending());
+}
+
+TEST(PdoPickerStage, SelectIgnoresLongPressOnNonSelectVi) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+
+    PdoPickerStage stage(display, sink, output_gate);
+    stage.prepare(PdoPickerStage::Mode::SELECT);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<PdoPickerStage>();
+
+    stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::LONG}, 0);
+    EXPECT_FALSE(conductor.has_pending());
+
+    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::SHORT}, 0);
+    EXPECT_FALSE(conductor.has_pending());
 }
 
 TEST(PdoPickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
     NiceMock<MockPdSink> sink;
+    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
@@ -272,7 +494,7 @@ TEST(PdoPickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
         EXPECT_CALL(display, flush());
     }
 
-    PdoPickerStage stage(display, sink);
+    PdoPickerStage stage(display, sink, output_gate);
     stage.prepare(PdoPickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -1,11 +1,10 @@
 /**
  * @file test.cpp
- * @brief PdoPickerStage render + cursor + transition tests, scripted MockPdSink + MockDisplay.
+ * @brief ProfilePickerStage render + cursor + transition tests, scripted MockPdSink + MockDisplay.
  */
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
-#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -15,7 +14,7 @@
 #include "v2/events.h"
 #include "v2/pocketpd.h"
 #include "v2/stages/normal_stage.h"
-#include "v2/stages/pdo_picker_stage.h"
+#include "v2/stages/profile_picker_stage.h"
 
 using namespace pocketpd;
 using ::testing::AnyNumber;
@@ -26,10 +25,9 @@ using ::testing::StrEq;
 
 using TestConductor = App::Conductor;
 
-TEST(PdoPickerStage, ReviewEmptyListRendersFallback) {
+TEST(ProfilePickerStage, ReviewEmptyListRendersFallback) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
     EXPECT_CALL(display, clear()).Times(1);
@@ -37,17 +35,16 @@ TEST(PdoPickerStage, ReviewEmptyListRendersFallback) {
     EXPECT_CALL(display, flush()).Times(1);
     EXPECT_CALL(display, draw_text(::testing::Ne(8), ::testing::_, ::testing::_)).Times(0);
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 }
 
-TEST(PdoPickerStage, ReviewRendersSingleFixedPdo) {
+TEST(ProfilePickerStage, ReviewRendersSingleFixedPdo) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
@@ -58,17 +55,16 @@ TEST(PdoPickerStage, ReviewRendersSingleFixedPdo) {
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 }
 
-TEST(PdoPickerStage, ReviewRendersFixedAndPpsLines) {
+TEST(ProfilePickerStage, ReviewRendersFixedAndPpsLines) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
 
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
@@ -85,18 +81,17 @@ TEST(PdoPickerStage, ReviewRendersFixedAndPpsLines) {
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 9V @ 2A"))).Times(1);
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 3A"))).Times(1);
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 }
 
-TEST(PdoPickerStage, ReviewRendersMultiplePpsLines) {
+TEST(ProfilePickerStage, ReviewRendersMultiplePpsLines) {
     // issue #24: chargers can advertise multiple PPS APDOs; each must render.
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
 
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(false));
@@ -114,17 +109,16 @@ TEST(PdoPickerStage, ReviewRendersMultiplePpsLines) {
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PPS: 3.3V~11.0V @ 3A"))).Times(1);
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 5A"))).Times(1);
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 }
 
-TEST(PdoPickerStage, SelectEntryDrawsCursorAtFirstRow) {
+TEST(ProfilePickerStage, SelectEntryDrawsCursorAtFirstRow) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
@@ -142,53 +136,19 @@ TEST(PdoPickerStage, SelectEntryDrawsCursorAtFirstRow) {
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PDO: 9V @ 2A"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 }
 
-TEST(PdoPickerStage, SelectEntryDisablesOutput) {
-    // issue #32: switching profile must not happen while output is delivering.
-    NiceMock<MockDisplay> display;
-    NiceMock<MockPdSink> sink;
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
-
-    MockOutputGate output_gate;
-    EXPECT_CALL(output_gate, disable()).Times(1);
-    EXPECT_CALL(output_gate, enable()).Times(0);
-
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
-}
-
-TEST(PdoPickerStage, ReviewEntryDoesNotTouchOutput) {
-    NiceMock<MockDisplay> display;
-    NiceMock<MockPdSink> sink;
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
-
-    MockOutputGate output_gate;
-    EXPECT_CALL(output_gate, disable()).Times(0);
-    EXPECT_CALL(output_gate, enable()).Times(0);
-
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
-}
-
-TEST(PdoPickerStage, SelectEncoderMovesCursorAndRerenders) {
+TEST(ProfilePickerStage, SelectEncoderMovesCursorAndRerenders) {
     using ::testing::_;
     using ::testing::AnyNumber;
 
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
     for (int i = 0; i < 3; ++i) {
         EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
@@ -197,11 +157,11 @@ TEST(PdoPickerStage, SelectEncoderMovesCursorAndRerenders) {
         EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
     }
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
     ::testing::Mock::VerifyAndClearExpectations(&display);
 
@@ -215,13 +175,12 @@ TEST(PdoPickerStage, SelectEncoderMovesCursorAndRerenders) {
     stage.on_event(conductor, EncoderEvent{1}, 0);
 }
 
-TEST(PdoPickerStage, SelectEncoderClampsAtTopAndBottom) {
+TEST(ProfilePickerStage, SelectEncoderClampsAtTopAndBottom) {
     using ::testing::_;
     using ::testing::AnyNumber;
 
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     for (int i = 0; i < 2; ++i) {
         EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
@@ -230,11 +189,11 @@ TEST(PdoPickerStage, SelectEncoderClampsAtTopAndBottom) {
         EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
     }
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
     ::testing::Mock::VerifyAndClearExpectations(&display);
 
     EXPECT_CALL(display, clear()).Times(0);
@@ -255,17 +214,16 @@ TEST(PdoPickerStage, SelectEncoderClampsAtTopAndBottom) {
     stage.on_event(conductor, EncoderEvent{4}, 0);
 }
 
-TEST(PdoPickerStage, SelectEmptyListIgnoresEncoder) {
+TEST(ProfilePickerStage, SelectEmptyListIgnoresEncoder) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
     ::testing::Mock::VerifyAndClearExpectations(&display);
 
     EXPECT_CALL(display, clear()).Times(0);
@@ -273,10 +231,9 @@ TEST(PdoPickerStage, SelectEmptyListIgnoresEncoder) {
     stage.on_event(conductor, EncoderEvent{1}, 0);
 }
 
-TEST(PdoPickerStage, ReviewEncoderRequestsSelectModeReentry) {
+TEST(ProfilePickerStage, ReviewEncoderRequestsSelectModeReentry) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
@@ -287,37 +244,35 @@ TEST(PdoPickerStage, ReviewEncoderRequestsSelectModeReentry) {
     EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(9000));
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(2000));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
     stage.on_event(conductor, EncoderEvent{1}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<PdoPickerStage>());
-    EXPECT_EQ(stage.mode(), PdoPickerStage::Mode::SELECT);
-    EXPECT_FALSE(output_gate.is_enabled());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(stage.mode(), ProfilePickerStage::Mode::SELECT);
 }
 
-TEST(PdoPickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
+TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
-    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
@@ -325,22 +280,21 @@ TEST(PdoPickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
     EXPECT_EQ(normal.profile(), Profile::PPS);
 }
 
-TEST(PdoPickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
+TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
-    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::SHORT}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
@@ -348,36 +302,34 @@ TEST(PdoPickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
     EXPECT_EQ(normal.profile(), Profile::PDO);
 }
 
-TEST(PdoPickerStage, ReviewTimeoutTransitionsToNormal) {
+TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
     conductor.tick(0);
-    conductor.tick(PDOPICKER_REVIEW_TO_NORMAL_MS - 1);
+    conductor.tick(PROFILE_PICKER_REVIEW_TO_NORMAL_MS - 1);
     EXPECT_FALSE(conductor.has_pending());
 
-    conductor.tick(PDOPICKER_REVIEW_TO_NORMAL_MS);
+    conductor.tick(PROFILE_PICKER_REVIEW_TO_NORMAL_MS);
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PDO);
 }
 
-TEST(PdoPickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
+TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
@@ -389,16 +341,16 @@ TEST(PdoPickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
     EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(21000));
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
     stage.on_event(conductor, EncoderEvent{1}, 0);
-    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::LONG}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
@@ -406,26 +358,25 @@ TEST(PdoPickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
     EXPECT_EQ(normal.profile(), Profile::PPS);
 }
 
-TEST(PdoPickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
+TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
     EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
     // Cursor stays at row 0 (fixed) — no encoder rotation.
-    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::LONG}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
@@ -433,53 +384,73 @@ TEST(PdoPickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
     EXPECT_EQ(normal.profile(), Profile::PDO);
 }
 
-TEST(PdoPickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
+TEST(ProfilePickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
-    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::LONG}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
     EXPECT_FALSE(conductor.has_pending());
 }
 
-TEST(PdoPickerStage, SelectIgnoresLongPressOnNonSelectVi) {
+TEST(ProfilePickerStage, SelectIgnoresRLongPressAndEncoderShortPress) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
     EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::SELECT);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NormalStage normal;
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
 
-    stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
-    stage.on_event(conductor, ButtonEvent{ButtonId::OUTPUT_TOGGLE, Gesture::LONG}, 0);
-    EXPECT_FALSE(conductor.has_pending());
-
-    stage.on_event(conductor, ButtonEvent{ButtonId::SELECT_VI, Gesture::SHORT}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
     EXPECT_FALSE(conductor.has_pending());
 }
 
-TEST(PdoPickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
+TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
+    NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    FakeOutputGate output_gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
+    NormalStage normal;
+    normal.prepare(Profile::PPS); // simulate prior session
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<ProfilePickerStage>();
+
+    stage.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.profile(), Profile::PPS); // unchanged
+}
+
+TEST(ProfilePickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
+    NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
@@ -494,11 +465,104 @@ TEST(PdoPickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
         EXPECT_CALL(display, flush());
     }
 
-    PdoPickerStage stage(display, sink, output_gate);
-    stage.prepare(PdoPickerStage::Mode::REVIEW);
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.start<PdoPickerStage>();
+    conductor.start<ProfilePickerStage>();
+}
+
+TEST(ProfilePickerStage, SelectCommitPromotesPendingCursorAndPreservesAcrossReentry) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
+        EXPECT_CALL(sink, is_index_pps(i)).WillRepeatedly(Return(false));
+        EXPECT_CALL(sink, pdo_max_voltage_mv(i)).WillRepeatedly(Return(5000));
+        EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
+    }
+
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<ProfilePickerStage>();
+
+    // Move cursor and commit — committed cursor follows pending only on commit.
+    stage.on_event(conductor, EncoderEvent{2}, 0);
+    EXPECT_EQ(stage.cursor_index(), 0); // committed unchanged before commit
+    stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+    EXPECT_EQ(stage.cursor_index(), 2);
+
+    // Re-enter SELECT — committed cursor must persist.
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
+    stage.on_enter(conductor);
+    EXPECT_EQ(stage.cursor_index(), 2);
+}
+
+TEST(ProfilePickerStage, SelectExitViaLDoesNotPromotePendingCursor) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_CALL(sink, is_index_fixed(i)).WillRepeatedly(Return(true));
+        EXPECT_CALL(sink, is_index_pps(i)).WillRepeatedly(Return(false));
+        EXPECT_CALL(sink, pdo_max_voltage_mv(i)).WillRepeatedly(Return(5000));
+        EXPECT_CALL(sink, pdo_max_current_ma(i)).WillRepeatedly(Return(3000));
+    }
+
+    ProfilePickerStage stage(display, sink);
+    stage.prepare(ProfilePickerStage::Mode::SELECT);
+    NormalStage normal;
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<ProfilePickerStage>();
+
+    stage.on_event(conductor, EncoderEvent{2}, 0);
+    stage.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+
+    EXPECT_EQ(stage.cursor_index(), 0); // committed cursor untouched by L exit
+}
+
+TEST(NormalStage, LongPressLReturnsToProfilePicker) {
+    NormalStage normal;
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    ProfilePickerStage picker(display, sink);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    conductor.register_stage(picker);
+    normal.prepare(Profile::PDO);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::SELECT);
+}
+
+TEST(NormalStage, IgnoresOtherButtonsAndShortPressOnL) {
+    NormalStage normal;
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    ProfilePickerStage picker(display, sink);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    conductor.register_stage(picker);
+    normal.prepare(Profile::PDO);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
+    normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
+    normal.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+
+    EXPECT_FALSE(conductor.has_pending());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary
Adds the `OutputGate` HAL primitive and lands the ProfilePicker (formerly `PdoPicker`) stage with REVIEW + SELECT modes:

- REVIEW renders the source PDO list. Exits to NormalStage on a short button press or a 3 s timeout; encoder rotation re-enters the picker in SELECT mode.
- SELECT renders an encoder-driven cursor over the same list:
  - Long-press of the encoder commits the row under the cursor.
  - Long-press of L exits to NormalStage without changing the profile or promoting the in-progress cursor.
- From NormalStage, long-press of L re-enters the picker in SELECT mode.

## Linked issues
Refs #24

## Hardware tested
- [x] HW1_3

How tested:
- \`pio test -e native\` — 63/63 passed across the v2 stage and task suites.
- \`pio run -e HW1_3_V2\` — RAM 4.7 %, Flash 5.8 %.

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details:
- \`PdoPickerStage\` → \`ProfilePickerStage\`
- \`OBTAIN_TO_PDOPICKER_MS\` → \`OBTAIN_TO_PROFILE_PICKER_MS\`
- \`PDOPICKER_REVIEW_TO_NORMAL_MS\` → \`PROFILE_PICKER_REVIEW_TO_NORMAL_MS\`
- \`ButtonId::SELECT_VI\` → \`ButtonId::L\`
- \`ButtonId::OUTPUT_TOGGLE\` → \`ButtonId::R\`
- The picker no longer disables the OutputGate on SELECT entry.

## Notes
The \`OutputGate\` HAL is in place but no consumer drives it in this PR — NormalStage will wire it up in a follow-up.