### PR TITLE
refactor(v2): centralize stage includes via app.h

### DIFF
--- a/include/v2/app.h
+++ b/include/v2/app.h
@@ -11,17 +11,53 @@
 
 #include "v2/events.h"
 
+
 namespace pocketpd {
 
-    // —— Stage forward declarations
+    // —— Forward declare the stages in this application
 
     class BootStage;
     class ObtainStage;
     class ProfilePickerStage;
     class NormalStage;
 
-    // —— Application alias
+    // —— Can also define events here as well
+
+    // —— Define common types
+
+    enum class ProfilePickerMode : uint8_t {
+        REVIEW,
+        SELECT,
+    };
+
+    // —— Define the application alias which is a combination of Events and Stages
 
     using App = tempo::Application<Event, BootStage, ObtainStage, ProfilePickerStage, NormalStage>;
-
 } // namespace pocketpd
+
+/*
+ * Stage headers go below the `App` alias on purpose.
+ *
+ * The cycle: each stage header includes `app.h` because stages inherit
+ * `App::Stage` and call `App::Conductor::request<>()`. But `App` itself
+ * lists the stage types in its template parameters, so it needs to know
+ * the stages exist. If `app.h` included the stage headers at the top,
+ * those headers would re-include `app.h` before `App` was defined, and
+ * neither side could compile.
+ *
+ * The two-step fix:
+ *   1. Forward-declare the stages above (`class BootStage;` etc.). That is
+ *      enough for the `App` alias — it only needs the names, not the full
+ *      class bodies.
+ *   2. Include the real stage headers here, after `App` is defined. When
+ *      they re-include `app.h`, the alias already exists, so they can
+ *      inherit from `App::Stage` without trouble.
+ *
+ * The headers stay in this file (instead of a separate "all stages"
+ * header) so a single `#include "v2/app.h"` gives callers both the alias
+ * and the concrete stage types in one shot.
+ */
+#include "v2/stages/boot_stage.h"
+#include "v2/stages/normal_stage.h"
+#include "v2/stages/obtain_stage.h"
+#include "v2/stages/profile_picker_stage.h"

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -24,8 +24,6 @@
 
 namespace pocketpd {
 
-    class ProfilePickerStage;
-
     class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
         Profile m_profile = Profile::PDO;
@@ -49,7 +47,18 @@ namespace pocketpd {
             log.info("entered profile={}", m_profile == Profile::PPS ? "PPS" : "PDO");
         }
 
-        void on_event(Conductor& conductor, const Event& event, uint32_t) override;
+        void on_event(Conductor& conductor, const Event& event, uint32_t) override {
+            auto handler = tempo::overloaded{
+                [&](const ButtonEvent& evt) {
+                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                        conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
+                    }
+                },
+                [](const auto&) {},
+            };
+
+            std::visit(handler, event);
+        }
     };
 
 } // namespace pocketpd

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -27,8 +27,6 @@
 #include "v2/events.h"
 #include "v2/hal/pd_sink_controller.h"
 #include "v2/pocketpd.h"
-#include "v2/stages/normal_stage.h"
-#include "v2/stages/profile_picker_stage.h"
 
 namespace pocketpd {
 
@@ -39,8 +37,14 @@ namespace pocketpd {
         PdSinkController& m_pd_sink;
         bool m_pd_ready = false;
 
-        tempo::IntervalTimer m_dump_timer{3000};
+        tempo::IntervalTimer m_dump_timer{1000};
         tempo::TimeoutTimer m_timeout;
+
+        void dump_pdo_list() {
+            std::array<char, 1024> buffer{};
+            ap33772::format_pdo(m_pd_sink, buffer.data(), buffer.size());
+            log.info(buffer.data());
+        }
 
     public:
         static constexpr const char* LOG_TAG = "Obtain";
@@ -71,24 +75,20 @@ namespace pocketpd {
         void on_tick(Conductor& conductor, uint32_t now_ms) override {
             // Periodically dump the PDO list for debugging
             if (m_dump_timer.tick(now_ms)) {
-                std::array<char, 2048> buffer{};
-                ap33772::format_pdo(m_pd_sink, buffer.data(), buffer.size());
-                log.info("{}", buffer.data());
+                dump_pdo_list();
             }
 
             if (!m_timeout.armed()) {
                 m_timeout.set(now_ms, OBTAIN_TO_PROFILE_PICKER_MS);
-                return;
             }
 
             if (m_timeout.reached(now_ms)) {
-                conductor.request<ProfilePickerStage>(ProfilePickerStage::Mode::REVIEW);
-                return; // Should return after stage change request to avoid executing more code
+                conductor.request<ProfilePickerStage>(ProfilePickerMode::REVIEW);
             }
         }
 
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
-            
+
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
                     if (evt.gesture == Gesture::SHORT && m_pd_ready) {
@@ -99,7 +99,7 @@ namespace pocketpd {
                 },
                 [&](const EncoderEvent& evt) {
                     if (evt.delta != 0) {
-                        conductor.request<ProfilePickerStage>(ProfilePickerStage::Mode::SELECT);
+                        conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
                     }
                 },
                 [](const auto&) {

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -21,7 +21,6 @@
 #include "v2/events.h"
 #include "v2/hal/pd_sink_controller.h"
 #include "v2/pocketpd.h"
-#include "v2/stages/normal_stage.h"
 #include "v2/state.h"
 
 namespace pocketpd {
@@ -30,7 +29,7 @@ namespace pocketpd {
 
     class ProfilePickerStage : public App::Stage, public App::UseLog<ProfilePickerStage> {
     public:
-        enum class Mode : uint8_t { REVIEW, SELECT };
+        using Mode = ProfilePickerMode;
 
     private:
         using Display = tempo::Display;
@@ -138,7 +137,7 @@ namespace pocketpd {
                  */
                 [&](const EncoderEvent& evt) {
                     if (evt.delta != 0) {
-                        conductor.request<ProfilePickerStage>(Mode::SELECT);
+                        conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
                     }
                 },
                 [](const auto&) {},
@@ -231,16 +230,4 @@ namespace pocketpd {
         display.flush();
     }
 
-    inline void NormalStage::on_event(Conductor& conductor, const Event& event, uint32_t) {
-        auto handler = tempo::overloaded{
-            [&](const ButtonEvent& evt) {
-                if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
-                    conductor.request<ProfilePickerStage>(ProfilePickerStage::Mode::SELECT);
-                }
-            },
-            [](const auto&) {},
-        };
-
-        std::visit(handler, event);
-    }
 } // namespace pocketpd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,10 +14,6 @@
 #include "v2/hal/ez_button_input.h"
 #include "v2/hal/rotary_encoder_input.h"
 #include "v2/hal/u8g2_display.h"
-#include "v2/stages/boot_stage.h"
-#include "v2/stages/normal_stage.h"
-#include "v2/stages/obtain_stage.h"
-#include "v2/stages/profile_picker_stage.h"
 #include "v2/tasks/button_task.h"
 #include "v2/tasks/encoder_task.h"
 #include <AP33772.h>


### PR DESCRIPTION
## Summary
**Motivation:** stages need to request transitions to other stages (`NormalStage` → `ProfilePickerStage` on long-press, `ProfilePickerStage` → `NormalStage` on commit, etc.), which previously meant `normal_stage.h` included `profile_picker_stage.h` and vice versa — a cyclic include between siblings. The old workaround was to forward-declare the sibling and define `on_event` out-of-line in whichever header happened to come last, which is fragile (one stale include re-introduces the cycle) and pushes implementation out of the class body for no good reason.

**Change:** `app.h` is now the single entry point. It forward-declares the four v2 stages, defines the `App` alias, then includes the stage headers at the bottom. Stage headers no longer include their siblings — they include `app.h`, which transitively pulls in every stage. The cycle is broken once, in one file, instead of being managed pairwise across stage headers.

Required two adjustments to make stage headers truly sibling-free:

- Hoisted `ProfilePickerStage::Mode` to a namespace-level `ProfilePickerMode` enum so `obtain_stage.h` can `request<ProfilePickerStage>(ProfilePickerMode::SELECT)` without naming `ProfilePickerStage::Mode`.
- Inlined `NormalStage::on_event` back into `normal_stage.h` (it had been pushed into `profile_picker_stage.h` to dodge the cycle).

The reasoning is captured in a block comment above the bottom-of-file includes in `app.h` for future readers.

## Linked issues

## Hardware tested
- [x] None (no hardware change)

How tested:
Header reorganization only — no behavior change. To verify locally:
- `pio run -e HW1_3_V2`
- `pio test -e native`

## Breaking change / migration
None. Internal include layout only.
