### PR TITLE
feat(v2): fixed PDO operation

### DIFF
--- a/include/v2/hal/ap33772_pd_sink.h
+++ b/include/v2/hal/ap33772_pd_sink.h
@@ -11,6 +11,7 @@
 #include <I2CDevice.h>
 
 #include "v2/hal/pd_sink_controller.h"
+#include "v2/pocketpd.h"
 
 namespace pocketpd {
 
@@ -50,6 +51,18 @@ namespace pocketpd {
         }
         bool set_pps_pdo(int index, int voltage_mv, int current_ma) override {
             return m_driver.set_pps_pdo(index, voltage_mv, current_ma);
+        }
+        int default_index_for(Profile profile) const override {
+            const int count = m_driver.pdo_count();
+            for (int i = 0; i < count; ++i) {
+                if (profile == Profile::PPS && m_driver.is_index_pps(i)) {
+                    return i;
+                }
+                if (profile == Profile::PDO && m_driver.is_index_fixed(i)) {
+                    return i;
+                }
+            }
+            return 0;
         }
     };
 

--- a/include/v2/hal/pd_sink_controller.h
+++ b/include/v2/hal/pd_sink_controller.h
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include "v2/pocketpd.h"
+
 namespace pocketpd {
 
     /**
@@ -53,6 +55,18 @@ namespace pocketpd {
 
         /** @brief Request a PPS APDO with explicit voltage and current. */
         [[nodiscard]] virtual bool set_pps_pdo(int index, int voltage_mv, int current_ma) = 0;
+
+        // —— Defaults
+
+        /**
+         * @brief Default PDO index for a given profile.
+         *
+         * For `Profile::PDO` returns the lowest fixed-PDO index (or 0 if no
+         * fixed PDO is present). For `Profile::PPS` returns the lowest PPS
+         * index (or 0 if none). Used by stages that resume Normal without
+         * picker cursor input.
+         */
+        virtual int default_index_for(Profile profile) const = 0;
     };
 
 } // namespace pocketpd

--- a/include/v2/hal/power_monitor.h
+++ b/include/v2/hal/power_monitor.h
@@ -1,0 +1,88 @@
+/**
+ * @file power_monitor.h
+ * @brief Bus voltage / current sensor HAL.
+ *
+ * Stages, tasks, and tests depend only on the `PowerMonitor` interface. The
+ * Arduino-backed implementation (`Ina226PowerMonitor`) is gated behind
+ * `#ifdef ARDUINO` so the interface compiles cleanly on the `native` env
+ * without pulling `Wire.h` through the INA226 driver. Mocks live in
+ * `test/mocks/MockPowerMonitor.h`.
+ */
+#pragma once
+
+#include <cstdint>
+
+#ifdef ARDUINO
+#include <INA226.h>
+#endif
+
+namespace pocketpd {
+
+    /**
+     * @brief One sampled bus reading. `valid` is false if the underlying driver
+     * could not produce a fresh sample (e.g. I2C error).
+     */
+    struct PowerReading {
+        uint32_t mv = 0;
+        uint32_t ma = 0;
+        bool valid = false;
+    };
+
+    /**
+     * @brief Abstract bus voltage / current monitor. Surface today covers a
+     * blocking sample plus an alert-threshold stub reserved for issue #42
+     * (INA226 Alert pin breaker).
+     */
+    class PowerMonitor {
+    public:
+        virtual ~PowerMonitor() = default;
+
+        /** @brief Bring up the underlying driver (I2C config, calibration, ...). */
+        virtual void begin() = 0;
+
+        /** @brief Sample bus voltage and current. */
+        virtual PowerReading read() = 0;
+
+        /**
+         * @brief Configure overcurrent alert threshold in mA.
+         *
+         * Stub for issue #42 (INA226 Alert pin breaker). Implementations that do
+         * not yet wire the Alert pin should treat this as a no-op.
+         */
+        virtual void set_alert_threshold_ma(uint32_t ma) = 0;
+    };
+
+#ifdef ARDUINO
+
+    /**
+     * @brief INA226-backed implementation of `PowerMonitor`.
+     *
+     * Borrows an `INA226` driver instance by reference. The driver's I2C bus
+     * setup and calibration happen in `begin()`.
+     */
+    class Ina226PowerMonitor : public PowerMonitor {
+    private:
+        INA226& m_driver;
+
+    public:
+        explicit Ina226PowerMonitor(INA226& driver) : m_driver(driver) {}
+
+        void begin() override {
+            m_driver.begin();
+        }
+
+        PowerReading read() override {
+            const auto mv = static_cast<uint32_t>(m_driver.getBusVoltage_mV());
+            const auto ma = static_cast<uint32_t>(m_driver.getCurrent_mA());
+            const bool ok = m_driver.getLastError() == 0;
+            return PowerReading{mv, ma, ok};
+        }
+
+        void set_alert_threshold_ma(uint32_t /*ma*/) override {
+            // issue #42 — Alert pin breaker not yet wired
+        }
+    };
+
+#endif // ARDUINO
+
+} // namespace pocketpd

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -1,35 +1,48 @@
 /**
  * @file normal_stage.h
- * @brief Live operating stage for both PPS and fixed PDO chargers.
- *
- * Profile (`PPS` vs `PDO`) is set at entry by the caller via
- * `Conductor::request<NormalStage>(Profile)` which forwards to
- * `prepare(Profile)`. The profile is locked for the duration of the stage —
- * a long-press of the L button exits back to ProfilePicker SELECT so the
- * user can pick a different profile.
- *
- * Stub today: enters and logs the chosen profile. The full encoder edit
- * (PPS-only), PDO/PPS RDO issuance, output toggle, autosave, sensor read,
- * and energy accumulator land once those subsystems arrive.
+ * @brief Live operating stage for both PPS and fixed PDO chargers. Carries the
+ * display, PD sink, and output-gate dependencies needed to issue the entry RDO,
+ * toggle the load switch on R-SHORT, and render the live snapshot. L-LONG exits
+ * back to ProfilePicker SELECT.
  */
 #pragma once
 
 #include <tempo/bus/visit.h>
+#include <tempo/core/time.h>
+#include <tempo/hardware/display.h>
 
+#include <cstdio>
 #include <variant>
 
 #include "v2/app.h"
 #include "v2/events.h"
+#include "v2/hal/output_gate.h"
+#include "v2/hal/pd_sink_controller.h"
 #include "v2/pocketpd.h"
+#include "v2/state.h"
 
 namespace pocketpd {
 
     class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
+        using Display = tempo::Display;
+
+        Display& m_display;
+        PdSinkController& m_pd_sink;
+        OutputGate& m_output_gate;
+
         Profile m_profile = Profile::PDO;
+        uint8_t m_active_pdo_index = 0;
+        SensorSnapshot m_snapshot{};
+        tempo::IntervalTimer m_render_gate{33};
+
+        void draw();
 
     public:
         static constexpr const char* LOG_TAG = "Normal";
+
+        NormalStage(Display& display, PdSinkController& pd_sink, OutputGate& output_gate)
+            : m_display(display), m_pd_sink(pd_sink), m_output_gate(output_gate) {}
 
         const char* name() const override {
             return "NORMAL";
@@ -39,18 +52,54 @@ namespace pocketpd {
             return m_profile;
         }
 
-        void prepare(Profile profile) {
+        uint8_t active_pdo_index() const {
+            return m_active_pdo_index;
+        }
+
+        SensorSnapshot& sensor_snapshot() {
+            return m_snapshot;
+        }
+        const SensorSnapshot& sensor_snapshot() const {
+            return m_snapshot;
+        }
+
+        void prepare(Profile profile = Profile::PDO, uint8_t pdo_index = 0) {
             m_profile = profile;
+            m_active_pdo_index = pdo_index;
         }
 
         void on_enter(Conductor&) override {
-            log.info("entered profile={}", m_profile == Profile::PPS ? "PPS" : "PDO");
+            log.info(
+                "entered profile={} pdo_index={}",
+                m_profile == Profile::PPS ? "PPS" : "PDO",
+                m_active_pdo_index
+            );
+
+            if (m_profile == Profile::PDO) {
+                if (!m_pd_sink.set_pdo(m_active_pdo_index)) {
+                    log.error("set_pdo({}) failed", m_active_pdo_index);
+                }
+            }
+
+            draw();
+        }
+
+        void on_tick(Conductor&, uint32_t now_ms) override {
+            if (m_render_gate.tick(now_ms)) {
+                draw();
+            }
         }
 
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
-                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                    if (evt.id == ButtonId::R && evt.gesture == Gesture::SHORT) {
+                        if (m_output_gate.is_enabled()) {
+                            m_output_gate.disable();
+                        } else {
+                            m_output_gate.enable();
+                        }
+                    } else if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
                         conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
                     }
                 },
@@ -60,5 +109,45 @@ namespace pocketpd {
             std::visit(handler, event);
         }
     };
+
+    inline void NormalStage::draw() {
+        m_display.clear();
+
+        char buffer[16];
+
+        m_display.draw_text(1, 14, "V");
+        const auto v_int = m_snapshot.vbus_mv / 1000;
+        const auto v_frac = (m_snapshot.vbus_mv % 1000) / 10;
+        std::snprintf(
+            buffer,
+            sizeof(buffer),
+            "%lu.%02lu",
+            static_cast<unsigned long>(v_int),
+            static_cast<unsigned long>(v_frac)
+        );
+        const auto v_width = m_display.text_width(buffer);
+        m_display.draw_text(static_cast<uint8_t>(75 - v_width), 14, buffer);
+
+        m_display.draw_text(1, 47, "A");
+        const auto a_int = m_snapshot.current_ma / 1000;
+        const auto a_frac = (m_snapshot.current_ma % 1000) / 10;
+        std::snprintf(
+            buffer,
+            sizeof(buffer),
+            "%lu.%02lu",
+            static_cast<unsigned long>(a_int),
+            static_cast<unsigned long>(a_frac)
+        );
+        const auto a_width = m_display.text_width(buffer);
+        m_display.draw_text(static_cast<uint8_t>(75 - a_width), 47, buffer);
+
+        std::snprintf(buffer, sizeof(buffer), "[%u]", static_cast<unsigned>(m_active_pdo_index));
+        m_display.draw_text(95, 50, buffer);
+        m_display.draw_text(110, 62, "PDO");
+
+        m_display.draw_text(90, 14, m_output_gate.is_enabled() ? "ON" : "OFF");
+
+        m_display.flush();
+    }
 
 } // namespace pocketpd

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -94,7 +94,9 @@ namespace pocketpd {
                     if (evt.gesture == Gesture::SHORT && m_pd_ready) {
                         const Profile profile =
                             m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
-                        conductor.request<NormalStage>(profile);
+                        const auto idx =
+                            static_cast<uint8_t>(m_pd_sink.default_index_for(profile));
+                        conductor.request<NormalStage>(profile, idx);
                     }
                 },
                 [&](const EncoderEvent& evt) {

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -56,7 +56,8 @@ namespace pocketpd {
                 return; // empty-PDO fallback: long-press is a no-op
             }
             m_cursor = m_pending_cursor;
-            conductor.request<NormalStage>(profile_at(m_cursor));
+            const auto idx = static_cast<uint8_t>(m_cursor);
+            conductor.request<NormalStage>(profile_at(m_cursor), idx);
         }
 
     public:
@@ -106,7 +107,9 @@ namespace pocketpd {
             }
 
             if (m_review_timeout.reached(now_ms)) {
-                conductor.request<NormalStage>(profile_for_charger());
+                const auto profile = profile_for_charger();
+                const auto idx = static_cast<uint8_t>(m_pd_sink.default_index_for(profile));
+                conductor.request<NormalStage>(profile, idx);
                 return;
             }
         }
@@ -127,7 +130,10 @@ namespace pocketpd {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
                     if (evt.gesture == Gesture::SHORT) {
-                        conductor.request<NormalStage>(profile_for_charger());
+                        const auto profile = profile_for_charger();
+                        const auto idx =
+                            static_cast<uint8_t>(m_pd_sink.default_index_for(profile));
+                        conductor.request<NormalStage>(profile, idx);
                     }
                 },
                 /**

--- a/include/v2/tasks/sensor_task.h
+++ b/include/v2/tasks/sensor_task.h
@@ -1,0 +1,46 @@
+/**
+ * @file sensor_task.h
+ * @brief Reads PowerMonitor at 33 ms while NormalStage is active and copies
+ * the result into NormalStage's SensorSnapshot.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "v2/app.h"
+#include "v2/hal/power_monitor.h"
+#include "v2/stages/normal_stage.h"
+
+namespace pocketpd {
+
+    class SensorTask : public App::StageScopedTask {
+    private:
+        PowerMonitor& m_monitor;
+        NormalStage& m_normal;
+
+    public:
+        static constexpr uint32_t PERIOD_MS = 33;
+
+        SensorTask(PowerMonitor& monitor, NormalStage& normal)
+            : App::StageScopedTask(PERIOD_MS, App::StageMask::of<NormalStage>()),
+              m_monitor(monitor),
+              m_normal(normal) {}
+
+        /// Test-driven entry point — bypasses the periodic gate.
+        void poll(uint32_t now_ms) {
+            const auto reading = m_monitor.read();
+            m_normal.sensor_snapshot() = SensorSnapshot{
+                now_ms,
+                reading.mv,
+                reading.ma,
+                reading.valid,
+            };
+        }
+
+    protected:
+        void on_tick(uint32_t now_ms) override {
+            poll(now_ms);
+        }
+    };
+
+} // namespace pocketpd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,11 +12,14 @@
 #include "v2/hal/arduino_output_gate.h"
 #include "v2/hal/arduino_stream_writer.h"
 #include "v2/hal/ez_button_input.h"
+#include "v2/hal/power_monitor.h"
 #include "v2/hal/rotary_encoder_input.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/tasks/button_task.h"
 #include "v2/tasks/encoder_task.h"
+#include "v2/tasks/sensor_task.h"
 #include <AP33772.h>
+#include <INA226.h>
 
 namespace {
 
@@ -28,6 +31,9 @@ namespace {
 
     ArduinoTwoWireDevice ap33772_i2c{Wire, ap33772::ADDRESS};
     pocketpd::Ap33772PdSink pd_sink{ap33772_i2c, ::delay};
+
+    INA226 ina226_driver{pocketpd::INA226_I2C_ADDR};
+    pocketpd::Ina226PowerMonitor power_monitor{ina226_driver};
 
     pocketpd::U8g2Display u8g2_display;
 
@@ -43,12 +49,13 @@ namespace {
     pocketpd::BootStage boot_stage(u8g2_display);
     pocketpd::ObtainStage obtain_stage(pd_sink);
     pocketpd::ProfilePickerStage profile_picker_stage(u8g2_display, pd_sink);
-    pocketpd::NormalStage normal_stage;
+    pocketpd::NormalStage normal_stage(u8g2_display, pd_sink, output_gate);
 
     // —— Tasks
 
     pocketpd::ButtonTask button_task(encoder_button, l_button, r_button);
     pocketpd::EncoderTask encoder_task(encoder);
+    pocketpd::SensorTask sensor_task{power_monitor, normal_stage};
 
 } // namespace
 
@@ -58,6 +65,10 @@ void setup() {
     Wire.setSDA(pin_SDA);
     Wire.setSCL(pin_SCL);
     Wire.begin();
+
+    ina226_driver.begin();
+    ina226_driver.setMaxCurrentShunt(20.0f, 0.005f);
+    power_monitor.begin();
 
     u8g2_display.begin();
     output_gate.begin();
@@ -70,6 +81,7 @@ void setup() {
 
     app.add_task(button_task);
     app.add_task(encoder_task);
+    app.add_task(sensor_task);
 
     app.start<pocketpd::BootStage>();
 }

--- a/test/mocks/MockPdSink.h
+++ b/test/mocks/MockPdSink.h
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 
 #include "v2/hal/pd_sink_controller.h"
+#include "v2/pocketpd.h"
 
 namespace pocketpd {
 
@@ -18,6 +19,7 @@ namespace pocketpd {
         MOCK_METHOD(int, pdo_max_current_ma, (int index), (const, override));
         MOCK_METHOD(bool, set_pdo, (int index), (override));
         MOCK_METHOD(bool, set_pps_pdo, (int index, int voltage_mv, int current_ma), (override));
+        MOCK_METHOD(int, default_index_for, (Profile profile), (const, override));
     };
 
 } // namespace pocketpd

--- a/test/mocks/MockPowerMonitor.h
+++ b/test/mocks/MockPowerMonitor.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+
+#include <gmock/gmock.h>
+
+#include "v2/hal/power_monitor.h"
+
+namespace pocketpd {
+
+    class MockPowerMonitor : public PowerMonitor {
+    public:
+        MOCK_METHOD(void, begin, (), (override));
+        MOCK_METHOD(PowerReading, read, (), (override));
+        MOCK_METHOD(void, set_alert_threshold_ma, (uint32_t ma), (override));
+    };
+
+    /**
+     * @brief Scripted PowerMonitor for tests that want to feed a sequence of readings.
+     *
+     * `read()` pops the front of the queue if non-empty; once drained it returns the
+     * last queued reading instead of a default-constructed one, so tests that tick
+     * past the script length stay stable.
+     */
+    class FakePowerMonitor : public PowerMonitor {
+    private:
+        std::deque<PowerReading> m_queue;
+        PowerReading m_last;
+        uint32_t m_threshold_ma = 0;
+        bool m_began = false;
+
+    public:
+        void push(PowerReading r) {
+            m_queue.push_back(r);
+            m_last = r;
+        }
+
+        bool began() const {
+            return m_began;
+        }
+
+        uint32_t alert_threshold_ma() const {
+            return m_threshold_ma;
+        }
+
+        void begin() override {
+            m_began = true;
+        }
+
+        PowerReading read() override {
+            if (m_queue.empty()) {
+                return m_last;
+            }
+            PowerReading r = m_queue.front();
+            m_queue.pop_front();
+            return r;
+        }
+
+        void set_alert_threshold_ma(uint32_t ma) override {
+            m_threshold_ma = ma;
+        }
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -1,0 +1,156 @@
+/**
+ * GoogleTest suite for NormalStage (PDO branch — F5 scope).
+ *
+ * Drives App::Conductor with MockDisplay, MockPdSink, MockOutputGate and
+ * asserts entry RDO call, R-SHORT output toggle, L-LONG → ProfilePicker
+ * SELECT, and snapshot-driven render.
+ */
+#define VERSION "\"test\""
+
+#include <MockDisplay.h>
+#include <MockOutputGate.h>
+#include <MockPdSink.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/stage/conductor.h>
+
+#include "v2/app.h"
+#include "v2/stages/normal_stage.h"
+#include "v2/stages/profile_picker_stage.h"
+
+using namespace pocketpd;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+using TestConductor = App::Conductor;
+
+TEST(NormalStage, OnEnterPdoProfileRequestsFixedPdo) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, set_pdo(2)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+
+    normal.prepare(Profile::PDO, 2);
+    conductor.start<NormalStage>();
+}
+
+TEST(NormalStage, OnEnterPpsProfileDoesNotIssueRdoInF5) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, set_pdo).Times(0);
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+
+    normal.prepare(Profile::PPS, 1);
+    conductor.start<NormalStage>();
+}
+
+TEST(NormalStage, RShortToggleEnablesAndDisablesOutput) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    bool enabled = false;
+    EXPECT_CALL(gate, is_enabled()).WillRepeatedly(::testing::ReturnPointee(&enabled));
+    EXPECT_CALL(gate, enable()).WillRepeatedly([&] { enabled = true; });
+    EXPECT_CALL(gate, disable()).WillRepeatedly([&] { enabled = false; });
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(Profile::PDO, 0);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
+    EXPECT_TRUE(enabled);
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
+    EXPECT_FALSE(enabled);
+}
+
+TEST(NormalStage, LLongRequestsProfilePickerSelect) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    ProfilePickerStage picker(display, sink);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    conductor.register_stage(picker);
+    normal.prepare(Profile::PDO, 0);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::SELECT);
+}
+
+TEST(NormalStage, EncoderEventsIgnoredInPdoBranch) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+    EXPECT_CALL(gate, enable).Times(0);
+    EXPECT_CALL(gate, disable).Times(0);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(Profile::PDO, 0);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, EncoderEvent{3}, 0);
+    EXPECT_FALSE(conductor.has_pending());
+}
+
+TEST(NormalStage, OnEnterPdoBranchRendersVAReadoutAndPdoIndex) {
+    using ::testing::HasSubstr;
+    using ::testing::InSequence;
+    using ::testing::StrEq;
+
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+    EXPECT_CALL(gate, is_enabled()).WillRepeatedly(Return(false));
+
+    InSequence s;
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(1, 14, StrEq("V"))).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::_, 14, ::testing::_)).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, draw_text(1, 47, StrEq("A"))).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::_, 47, ::testing::_)).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, draw_text(::testing::_, 50, HasSubstr("[2]"))).Times(::testing::AtLeast(1));
+    EXPECT_CALL(display, draw_text(110, 62, StrEq("PDO"))).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, StrEq("OFF"))).Times(::testing::AtLeast(1));
+    EXPECT_CALL(display, flush()).Times(1);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(Profile::PDO, 2);
+    normal.sensor_snapshot() = SensorSnapshot{0, 5000, 1234, true};
+
+    conductor.start<NormalStage>();
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -9,6 +9,7 @@
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
+#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -128,10 +129,13 @@ TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, default_index_for(Profile::PPS)).WillRepeatedly(Return(2));
 
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    NormalStage normal;
+    NiceMock<MockDisplay> normal_display;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(normal_display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -143,6 +147,7 @@ TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PPS);
+    EXPECT_EQ(normal.active_pdo_index(), 2u);
 }
 
 TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
@@ -152,10 +157,14 @@ TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+    EXPECT_CALL(sink, default_index_for(Profile::PDO)).WillRepeatedly(Return(0));
 
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    NormalStage normal;
+    NiceMock<MockDisplay> normal_display;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(normal_display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -167,6 +176,7 @@ TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), 0u);
 }
 
 TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -5,6 +5,7 @@
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
+#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -263,10 +264,12 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, default_index_for(Profile::PPS)).WillRepeatedly(Return(1));
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -278,6 +281,7 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PPS);
+    EXPECT_EQ(normal.active_pdo_index(), 1);
 }
 
 TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
@@ -285,10 +289,13 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+    EXPECT_CALL(sink, default_index_for(Profile::PDO)).WillRepeatedly(Return(0));
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -300,6 +307,7 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), 0);
 }
 
 TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
@@ -307,10 +315,13 @@ TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
+    EXPECT_CALL(sink, default_index_for(Profile::PDO)).WillRepeatedly(Return(0));
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -325,6 +336,7 @@ TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), 0);
 }
 
 TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
@@ -343,7 +355,8 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -356,6 +369,7 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PPS);
+    EXPECT_EQ(normal.active_pdo_index(), 1);
 }
 
 TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
@@ -369,7 +383,9 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -382,6 +398,7 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
     EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), 0);
 }
 
 TEST(ProfilePickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
@@ -391,7 +408,8 @@ TEST(ProfilePickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -412,7 +430,8 @@ TEST(ProfilePickerStage, SelectIgnoresRLongPressAndEncoderShortPress) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -434,7 +453,8 @@ TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     normal.prepare(Profile::PPS); // simulate prior session
     TestConductor conductor;
     conductor.register_stage(stage);
@@ -485,7 +505,9 @@ TEST(ProfilePickerStage, SelectCommitPromotesPendingCursorAndPreservesAcrossReen
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -516,7 +538,8 @@ TEST(ProfilePickerStage, SelectExitViaLDoesNotPromotePendingCursor) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -529,9 +552,11 @@ TEST(ProfilePickerStage, SelectExitViaLDoesNotPromotePendingCursor) {
 }
 
 TEST(NormalStage, LongPressLReturnsToProfilePicker) {
-    NormalStage normal;
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     ProfilePickerStage picker(display, sink);
     TestConductor conductor;
     conductor.register_stage(normal);
@@ -548,9 +573,11 @@ TEST(NormalStage, LongPressLReturnsToProfilePicker) {
 }
 
 TEST(NormalStage, IgnoresOtherButtonsAndShortPressOnL) {
-    NormalStage normal;
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     ProfilePickerStage picker(display, sink);
     TestConductor conductor;
     conductor.register_stage(normal);

--- a/test/test_v2_sensor/test.cpp
+++ b/test/test_v2_sensor/test.cpp
@@ -1,0 +1,59 @@
+/**
+ * GoogleTest suite for SensorTask.
+ *
+ * Drives a FakePowerMonitor through scripted readings; asserts SensorTask
+ * copies them into NormalStage::sensor_snapshot() with the tick timestamp.
+ */
+#define VERSION "\"test\""
+
+#include <MockDisplay.h>
+#include <MockOutputGate.h>
+#include <MockPdSink.h>
+#include <MockPowerMonitor.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "v2/stages/normal_stage.h"
+#include "v2/tasks/sensor_task.h"
+
+using namespace pocketpd;
+using ::testing::NiceMock;
+
+TEST(SensorTask, PollWritesSnapshotWithTimestampAndValues) {
+    FakePowerMonitor monitor;
+    NiceMock<MockDisplay> normal_display;
+    NiceMock<MockPdSink> normal_sink;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(normal_display, normal_sink, normal_gate);
+
+    monitor.push({5000, 1234, true});
+
+    SensorTask task(monitor, normal);
+    task.poll(42);
+
+    const auto& snap = normal.sensor_snapshot();
+    EXPECT_EQ(snap.timestamp_ms, 42u);
+    EXPECT_EQ(snap.vbus_mv, 5000u);
+    EXPECT_EQ(snap.current_ma, 1234u);
+    EXPECT_TRUE(snap.valid);
+}
+
+TEST(SensorTask, InvalidReadingPropagatesValidFalse) {
+    FakePowerMonitor monitor;
+    NiceMock<MockDisplay> normal_display;
+    NiceMock<MockPdSink> normal_sink;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(normal_display, normal_sink, normal_gate);
+
+    monitor.push({0, 0, false});
+
+    SensorTask task(monitor, normal);
+    task.poll(99);
+
+    EXPECT_FALSE(normal.sensor_snapshot().valid);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
**Motivation:** v1's NormalStage god-function bundled live readouts, output toggle, and CV/CC heuristic in one render path that was hard to test and shipped a flicker bug (issue #43). v2's NormalStage was a stub since F3 — F5 fills in the fixed-PDO half so a charger plugged into the device runs end-to-end on the v2 architecture: pick a fixed PDO in the picker, see live V/A on the OLED, R-button toggles the load switch.

**Change:** Adds `PowerMonitor` HAL wrapping INA226 (with `set_alert_threshold_ma` stub for issue #42), a `SensorTask` (`StageScopedTask<NormalStage>` at 33 ms) that copies `PowerReading` into `NormalStage::sensor_snapshot()`, and a fleshed-out `NormalStage` PDO branch that issues the fixed-PDO RDO on entry, renders V/A/PDO[i]/ON-OFF inline at 33 ms gated by `tempo::IntervalTimer`, and toggles `OutputGate` on R-SHORT. Picker and ObtainStage now forward the chosen index alongside the profile via the extended `prepare(Profile, uint8_t pdo_index)` payload, with a new `PdSinkController::default_index_for(Profile)` helper for non-cursor entry paths. CV/CC heuristic is dropped (issue #43); PPS branch stays stub for F7. No `OledTask`, no `OutputToggleEvent`, no shared `UiState` god struct — each subsystem owns its state.

## Linked issues
Refs #43

## Hardware tested
- [ ] HW1_3
- [x] None (no hardware change)

How tested:
Native suite covers entry RDO, output toggle, L-LONG exit, encoder-ignored, render call sequence, and SensorTask snapshot fill across 71 test cases. Hardware bench check pending — to verify locally:
- \`pio run -e HW1_3_V2\`
- \`pio test -e native\`
- Flash and confirm: PDO commit issues correct RDO; live V matches multimeter; R-button toggles output; long-L returns to ProfilePicker SELECT.

## Breaking change / migration
None. Internal API only. \`NormalStage\` ctor now requires \`Display&\`, \`PdSinkController&\`, \`OutputGate&\` — main.cpp wiring updated in this PR.

Details:

## Notes
- Stacks on PR #70 (\`feature/v2-app-stage-includes\`). Base will auto-update to \`main\` once #70 merges.
- INA226 shunt configured in main.cpp as 5 mΩ via \`setMaxCurrentShunt(20.0f, 0.005f)\` to match HW1_3 production board.
- PPS branch is intentionally a no-op in this PR — \`OnEnterPpsProfileDoesNotIssueRdoInF5\` test pins this. F7 fills it in.
- Follow-up: hardware bench verification (multi-PDO charger, multi-PPS charger, output toggle response, current readout accuracy).