### PR TITLE
feat(v2): event-driven SensorTask, button + picker tuning

### DIFF
--- a/include/v2/events.h
+++ b/include/v2/events.h
@@ -44,6 +44,13 @@ namespace pocketpd {
         int delta = 0;
     };
 
-    using Event = tempo::Events<PdReadyEvent, ButtonEvent, EncoderEvent>;
+    /**
+     * @brief Published by SensorTask. Carries one bus reading.
+     */
+    struct SensorEvent {
+        SensorSnapshot snapshot;
+    };
+
+    using Event = tempo::Events<PdReadyEvent, ButtonEvent, EncoderEvent, SensorEvent>;
 
 } // namespace pocketpd

--- a/include/v2/hal/ez_button_input.h
+++ b/include/v2/hal/ez_button_input.h
@@ -18,7 +18,7 @@ namespace pocketpd {
         mutable ezButton m_button;
 
     public:
-        explicit EzButtonInput(int pin, unsigned long debounce_ms = 50) : m_button(pin) {
+        explicit EzButtonInput(int pin, unsigned long debounce_ms = 30) : m_button(pin) {
             m_button.setDebounceTime(debounce_ms);
         }
 

--- a/include/v2/hal/ina226_power_monitor.h
+++ b/include/v2/hal/ina226_power_monitor.h
@@ -1,0 +1,44 @@
+/**
+ * @file ina226_power_monitor.h
+ * @brief INA226-backed implementation of `PowerMonitor`.
+ *
+ * Borrows an `INA226` driver instance by reference. The driver's I2C bus
+ * setup and calibration happen in `begin()`.
+ */
+#pragma once
+
+#include <INA226.h>
+
+#include "v2/hal/power_monitor.h"
+
+namespace pocketpd {
+
+    class Ina226PowerMonitor : public PowerMonitor {
+    private:
+        INA226& m_driver;
+
+    public:
+        explicit Ina226PowerMonitor(INA226& driver) : m_driver(driver) {}
+
+        void begin() override {
+            m_driver.begin();
+        }
+
+        PowerReading read() override {
+            const auto mv = static_cast<uint32_t>(m_driver.getBusVoltage_mV());
+            const auto ma = static_cast<uint32_t>(m_driver.getCurrent_mA());
+            const bool ok = m_driver.getLastError() == 0;
+            return PowerReading{mv, ma, ok};
+        }
+
+        /**
+         * @brief Stub for current breaker feature. 
+         * Ticket: Issue #42 — not yet completed
+         * 
+         */
+        void set_alert_threshold_ma(uint32_t /*ma*/) override {
+
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/hal/power_monitor.h
+++ b/include/v2/hal/power_monitor.h
@@ -1,0 +1,45 @@
+/**
+ * @file power_monitor.h
+ * @brief Abstract bus voltage / current sensor HAL.
+ *
+ * The INA226-backed implementation lives in `ina226_power_monitor.h`
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace pocketpd {
+
+    /**
+     * @brief One sampled bus reading. `valid` is false if the underlying driver
+     * could not produce a fresh sample (e.g. I2C error).
+     */
+    struct PowerReading {
+        uint32_t mv = 0;
+        uint32_t ma = 0;
+        bool valid = false;
+    };
+
+    /**
+     * @brief Abstract bus voltage / current monitor.
+     */
+    class PowerMonitor {
+    public:
+        virtual ~PowerMonitor() = default;
+
+        virtual void begin() = 0;
+
+        /**
+         * @brief Sample bus voltage and current.
+         */
+        virtual PowerReading read() = 0;
+
+        /**
+         * @brief Configure overcurrent alert threshold in mA.
+         *
+         * Stub for issue #42 (INA226 Alert pin breaker).
+         */
+        virtual void set_alert_threshold_ma(uint32_t ma) = 0;
+    };
+
+} // namespace pocketpd

--- a/include/v2/hal/u8g2_display.h
+++ b/include/v2/hal/u8g2_display.h
@@ -6,8 +6,6 @@
  */
 #pragma once
 
-#ifdef ARDUINO
-
 #include <tempo/hardware/display.h>
 
 #include <U8g2lib.h>
@@ -21,7 +19,7 @@ namespace pocketpd {
     public:
         void begin() {
             m_u8g2.begin();
-            m_u8g2.setFont(u8g2_font_profont11_tr);
+            set_font(tempo::Font::BASE);
         }
 
         void clear() override {
@@ -30,6 +28,23 @@ namespace pocketpd {
 
         void flush() override {
             m_u8g2.sendBuffer();
+        }
+
+        void set_font(tempo::Font font) override {
+            switch (font) {
+            case tempo::Font::SM:
+                m_u8g2.setFont(u8g2_font_profont11_tr);
+                break;
+            case tempo::Font::BASE:
+                m_u8g2.setFont(u8g2_font_profont12_tr);
+                break;
+            case tempo::Font::LG:
+                m_u8g2.setFont(u8g2_font_profont15_tr);
+                break;
+            case tempo::Font::XL:
+                m_u8g2.setFont(u8g2_font_profont22_tr);
+                break;
+            }
         }
 
         void draw_bitmap(
@@ -48,5 +63,3 @@ namespace pocketpd {
     };
 
 } // namespace pocketpd
-
-#endif // ARDUINO

--- a/include/v2/input/button_gesture.h
+++ b/include/v2/input/button_gesture.h
@@ -15,7 +15,7 @@
 namespace pocketpd {
 
     struct ButtonGestureConfig {
-        uint32_t long_press_ms = 1500;
+        uint32_t long_press_ms = 750;
     };
 
     class ButtonGestureDetector {

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -1,64 +1,137 @@
 /**
  * @file normal_stage.h
  * @brief Live operating stage for both PPS and fixed PDO chargers.
- *
- * Profile (`PPS` vs `PDO`) is set at entry by the caller via
- * `Conductor::request<NormalStage>(Profile)` which forwards to
- * `prepare(Profile)`. The profile is locked for the duration of the stage —
- * a long-press of the L button exits back to ProfilePicker SELECT so the
- * user can pick a different profile.
- *
- * Stub today: enters and logs the chosen profile. The full encoder edit
- * (PPS-only), PDO/PPS RDO issuance, output toggle, autosave, sensor read,
- * and energy accumulator land once those subsystems arrive.
  */
 #pragma once
 
 #include <tempo/bus/visit.h>
+#include <tempo/core/time.h>
+#include <tempo/hardware/display.h>
 
+#include <cstdio>
 #include <variant>
 
 #include "v2/app.h"
 #include "v2/events.h"
-#include "v2/pocketpd.h"
+#include "v2/hal/output_gate.h"
+#include "v2/hal/pd_sink_controller.h"
+#include "v2/state.h"
 
 namespace pocketpd {
 
     class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
-        Profile m_profile = Profile::PDO;
+        using Display = tempo::Display;
+
+        Display& m_display;
+        PdSinkController& m_pd_sink;
+        OutputGate& m_output_gate;
+        SensorSnapshot m_snapshot{};
+
+        int8_t m_active_pdo_index = -1;
+        tempo::IntervalTimer m_render_interval{33};
+
+        void draw();
 
     public:
         static constexpr const char* LOG_TAG = "Normal";
+
+        NormalStage(Display& display, PdSinkController& pd_sink, OutputGate& output_gate)
+            : m_display(display), m_pd_sink(pd_sink), m_output_gate(output_gate) {}
 
         const char* name() const override {
             return "NORMAL";
         }
 
-        Profile profile() const {
-            return m_profile;
+        int8_t active_pdo_index() const {
+            return m_active_pdo_index;
         }
 
-        void prepare(Profile profile) {
-            m_profile = profile;
+        void prepare(int8_t pdo_index = -1) {
+            m_active_pdo_index = pdo_index;
         }
 
         void on_enter(Conductor&) override {
-            log.info("entered profile={}", m_profile == Profile::PPS ? "PPS" : "PDO");
+            if (m_active_pdo_index < 0) {
+                log.info("Entered with no profile selected");
+                draw();
+                return;
+            }
+
+            if (m_pd_sink.is_index_pps(m_active_pdo_index)) {
+                log.info("Entered PPS profile pdo_index={}", m_active_pdo_index);
+            } else {
+                log.info("Entered PDO profile pdo_index={}", m_active_pdo_index);
+                if (!m_pd_sink.set_pdo(m_active_pdo_index)) {
+                    log.error("set_pdo({}) failed", m_active_pdo_index);
+                }
+            }
+
+            draw();
+        }
+
+        void on_tick(Conductor&, uint32_t now_ms) override {
+            if (m_render_interval.tick(now_ms)) {
+                draw();
+            }
         }
 
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
-                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                    if (evt.id == ButtonId::R && evt.gesture == Gesture::SHORT) {
+                        if (m_output_gate.is_enabled()) {
+                            m_output_gate.disable();
+                        } else {
+                            m_output_gate.enable();
+                        }
+                    } else if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
                         conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
                     }
                 },
+                [&](const SensorEvent& evt) { m_snapshot = evt.snapshot; },
                 [](const auto&) {},
             };
 
             std::visit(handler, event);
         }
     };
+
+    inline void NormalStage::draw() {
+        m_display.clear();
+
+        if (m_active_pdo_index < 0) {
+            m_display.set_font(tempo::Font::BASE);
+            m_display.draw_text(8, 34, "No Profile Selected");
+            m_display.flush();
+            return;
+        }
+
+        std::array<char, 32> buffer{};
+
+        auto draw_line = [&](const char* label, uint8_t y, uint32_t value) {
+            m_display.draw_text(1, y, label);
+
+            const unsigned long whole = value / 1000;
+            const unsigned long fraction = (value % 1000) / 10;
+            std::snprintf(buffer.data(), buffer.size(), "%lu.%02lu", whole, fraction);
+
+            const auto w = m_display.text_width(buffer.data());
+            m_display.draw_text(static_cast<uint8_t>(75 - w), y, buffer.data());
+        };
+
+        m_display.set_font(tempo::Font::XL);
+        draw_line("V", 14, m_snapshot.vbus_mv);
+        draw_line("A", 47, m_snapshot.current_ma);
+
+        m_display.set_font(tempo::Font::BASE);
+        std::snprintf(buffer.data(), buffer.size(), "[%u]", m_active_pdo_index);
+        m_display.draw_text(110, 50, buffer.data());
+
+        m_display.draw_text(110, 64, m_pd_sink.is_index_pps(m_active_pdo_index) ? "PPS" : "PDO");
+        m_display.draw_text(90, 14, m_output_gate.is_enabled() ? "ON" : "OFF");
+
+        m_display.flush();
+    }
 
 } // namespace pocketpd

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -92,9 +92,7 @@ namespace pocketpd {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
                     if (evt.gesture == Gesture::SHORT && m_pd_ready) {
-                        const Profile profile =
-                            m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
-                        conductor.request<NormalStage>(profile);
+                        conductor.request<NormalStage>(static_cast<int8_t>(-1));
                     }
                 },
                 [&](const EncoderEvent& evt) {

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -2,8 +2,8 @@
  * @file profile_picker_stage.h
  * @brief Profile-selection / capability-list stage. Two modes via payload-passing transition:
  * - REVIEW renders the source PDO list and waits for input;
- * - SELECT renders the same list with an encoder-driven cursor and lets the user commit a profile
- * via long-press of the encoder button.
+ * - SELECT renders the same list with an encoder-driven cursor. The user commits a profile by
+ * long-pressing the encoder button.
  */
 #pragma once
 
@@ -43,20 +43,12 @@ namespace pocketpd {
 
         tempo::TimeoutTimer m_review_timeout;
 
-        Profile profile_for_charger() const {
-            return m_pd_sink.pps_count() > 0 ? Profile::PPS : Profile::PDO;
-        }
-
-        Profile profile_at(int cursor) const {
-            return m_pd_sink.is_index_pps(cursor) ? Profile::PPS : Profile::PDO;
-        }
-
         void commit(Conductor& conductor) {
             if (m_pd_sink.pdo_count() <= 0) {
                 return; // empty-PDO fallback: long-press is a no-op
             }
             m_cursor = m_pending_cursor;
-            conductor.request<NormalStage>(profile_at(m_cursor));
+            conductor.request<NormalStage>(static_cast<int8_t>(m_cursor));
         }
 
     public:
@@ -106,7 +98,10 @@ namespace pocketpd {
             }
 
             if (m_review_timeout.reached(now_ms)) {
-                conductor.request<NormalStage>(profile_for_charger());
+                if (m_pd_sink.pdo_count() <= 0) {
+                    return; // stay in REVIEW until a charger is detected
+                }
+                conductor.request<NormalStage>(static_cast<int8_t>(-1));
                 return;
             }
         }
@@ -126,8 +121,8 @@ namespace pocketpd {
         void handle_review_event(Conductor& conductor, const Event& event) {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
-                    if (evt.gesture == Gesture::SHORT) {
-                        conductor.request<NormalStage>(profile_for_charger());
+                    if (evt.gesture == Gesture::SHORT && m_pd_sink.pdo_count() > 0) {
+                        conductor.request<NormalStage>(static_cast<int8_t>(-1));
                     }
                 },
                 /**
@@ -186,7 +181,10 @@ namespace pocketpd {
 
         const int count = pd_sink.pdo_count();
         if (count == 0) {
-            display.draw_text(8, 34, "No Profile Detected");
+            const char* msg = "[No Profile Detected]";
+            const auto w = display.text_width(msg);
+            const auto x = static_cast<uint8_t>((128 - w) / 2);
+            display.draw_text(x, 34, msg);
             display.flush();
             return;
         }

--- a/include/v2/tasks/button_task.h
+++ b/include/v2/tasks/button_task.h
@@ -26,6 +26,8 @@ namespace pocketpd {
             ButtonId id;
             tempo::ButtonInput* input;
             ButtonGestureDetector detector;
+            bool was_held = false;
+            uint32_t pressed_at_ms = 0;
 
             DetectorRef() = delete;
         };
@@ -83,13 +85,23 @@ namespace pocketpd {
             for (DetectorRef& ref : m_detectors) {
                 ref.input->update();
 
+                
+                // Debug button latency (including debounce time)
                 const bool is_held = ref.input->is_held();
+                if (is_held && !ref.was_held) {
+                    ref.pressed_at_ms = now_ms;
+                    log.debug("button={} press_start_at={}ms", button_name(ref.id), now_ms);
+                }
+                ref.was_held = is_held;
+
                 const std::optional<Gesture> gesture = ref.detector.update(is_held, now_ms);
                 if (gesture.has_value()) {
+                    const uint32_t duration = now_ms - ref.pressed_at_ms;
                     log.debug(
-                        "button={} detected gesture={}",
+                        "button={} gesture={} hold_duration={}",
                         button_name(ref.id),
-                        gesture.value() == Gesture::SHORT ? "SHORT" : "LONG"
+                        gesture.value() == Gesture::SHORT ? "SHORT" : "LONG",
+                        duration
                     );
                     publish(ButtonEvent{ref.id, gesture.value()});
                 }

--- a/include/v2/tasks/sensor_task.h
+++ b/include/v2/tasks/sensor_task.h
@@ -1,0 +1,41 @@
+/**
+ * @file sensor_task.h
+ * @brief Reads PowerMonitor at 33 ms while NormalStage is active and publishes
+ * a `SensorEvent` carrying the snapshot. NormalStage consumes the event.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/hal/power_monitor.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    class SensorTask : public App::StageScopedTask, public App::UsePublisher<SensorTask> {
+    private:
+        PowerMonitor& m_monitor;
+
+    public:
+        static constexpr uint32_t PERIOD_MS = 33;
+
+        explicit SensorTask(PowerMonitor& monitor)
+            : App::StageScopedTask(PERIOD_MS, App::StageMask::of<NormalStage>()),
+              m_monitor(monitor) {}
+
+        void on_tick(uint32_t now_ms) override {
+            const auto reading = m_monitor.read();
+            SensorSnapshot snapshot{
+                now_ms,
+                reading.mv,
+                reading.ma,
+                reading.valid,
+            };
+            
+            publish(SensorEvent{snapshot});
+        }
+    };
+
+} // namespace pocketpd

--- a/lib/tempo/include/tempo/hardware/display.h
+++ b/lib/tempo/include/tempo/hardware/display.h
@@ -12,6 +12,13 @@
 
 namespace tempo {
 
+    enum class Font : uint8_t {
+        SM,
+        BASE,
+        LG,
+        XL,
+    };
+
     class Display {
     public:
         virtual ~Display() = default;
@@ -20,6 +27,11 @@ namespace tempo {
 
         virtual void clear() = 0;
         virtual void flush() = 0;
+
+        // —— Font selection
+        // Implementation should default to Font::BASE.
+
+        virtual void set_font(Font font) = 0;
 
         // —— Drawing
         //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,11 +12,14 @@
 #include "v2/hal/arduino_output_gate.h"
 #include "v2/hal/arduino_stream_writer.h"
 #include "v2/hal/ez_button_input.h"
+#include "v2/hal/ina226_power_monitor.h"
 #include "v2/hal/rotary_encoder_input.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/tasks/button_task.h"
 #include "v2/tasks/encoder_task.h"
+#include "v2/tasks/sensor_task.h"
 #include <AP33772.h>
+#include <INA226.h>
 
 namespace {
 
@@ -28,6 +31,9 @@ namespace {
 
     ArduinoTwoWireDevice ap33772_i2c{Wire, ap33772::ADDRESS};
     pocketpd::Ap33772PdSink pd_sink{ap33772_i2c, ::delay};
+
+    INA226 ina226_driver{pocketpd::INA226_I2C_ADDR};
+    pocketpd::Ina226PowerMonitor power_monitor{ina226_driver};
 
     pocketpd::U8g2Display u8g2_display;
 
@@ -43,12 +49,13 @@ namespace {
     pocketpd::BootStage boot_stage(u8g2_display);
     pocketpd::ObtainStage obtain_stage(pd_sink);
     pocketpd::ProfilePickerStage profile_picker_stage(u8g2_display, pd_sink);
-    pocketpd::NormalStage normal_stage;
+    pocketpd::NormalStage normal_stage(u8g2_display, pd_sink, output_gate);
 
     // —— Tasks
 
     pocketpd::ButtonTask button_task(encoder_button, l_button, r_button);
     pocketpd::EncoderTask encoder_task(encoder);
+    pocketpd::SensorTask sensor_task{power_monitor};
 
 } // namespace
 
@@ -58,6 +65,10 @@ void setup() {
     Wire.setSDA(pin_SDA);
     Wire.setSCL(pin_SCL);
     Wire.begin();
+
+    ina226_driver.begin();
+    ina226_driver.setMaxCurrentShunt(20.0f, 0.005f);
+    power_monitor.begin();
 
     u8g2_display.begin();
     output_gate.begin();
@@ -70,6 +81,7 @@ void setup() {
 
     app.add_task(button_task);
     app.add_task(encoder_task);
+    app.add_task(sensor_task);
 
     app.start<pocketpd::BootStage>();
 }

--- a/test/mocks/MockDisplay.h
+++ b/test/mocks/MockDisplay.h
@@ -9,6 +9,7 @@ namespace pocketpd {
     public:
         MOCK_METHOD(void, clear, (), (override));
         MOCK_METHOD(void, flush, (), (override));
+        MOCK_METHOD(void, set_font, (tempo::Font font), (override));
         MOCK_METHOD(
             void,
             draw_bitmap,

--- a/test/mocks/MockPowerMonitor.h
+++ b/test/mocks/MockPowerMonitor.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+
+#include <gmock/gmock.h>
+
+#include "v2/hal/power_monitor.h"
+
+namespace pocketpd {
+
+    class MockPowerMonitor : public PowerMonitor {
+    public:
+        MOCK_METHOD(void, begin, (), (override));
+        MOCK_METHOD(PowerReading, read, (), (override));
+        MOCK_METHOD(void, set_alert_threshold_ma, (uint32_t ma), (override));
+    };
+
+    /**
+     * @brief Scripted PowerMonitor for tests that want to feed a sequence of readings.
+     *
+     * `read()` pops the front of the queue if non-empty; once drained it returns the
+     * last queued reading instead of a default-constructed one, so tests that tick
+     * past the script length stay stable.
+     */
+    class FakePowerMonitor : public PowerMonitor {
+    private:
+        std::deque<PowerReading> m_queue;
+        PowerReading m_last;
+        uint32_t m_threshold_ma = 0;
+        bool m_began = false;
+
+    public:
+        void push(PowerReading r) {
+            m_queue.push_back(r);
+            m_last = r;
+        }
+
+        bool began() const {
+            return m_began;
+        }
+
+        uint32_t alert_threshold_ma() const {
+            return m_threshold_ma;
+        }
+
+        void begin() override {
+            m_began = true;
+        }
+
+        PowerReading read() override {
+            if (m_queue.empty()) {
+                return m_last;
+            }
+            PowerReading r = m_queue.front();
+            m_queue.pop_front();
+            return r;
+        }
+
+        void set_alert_threshold_ma(uint32_t ma) override {
+            m_threshold_ma = ma;
+        }
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -1,0 +1,181 @@
+/**
+ * GoogleTest suite for NormalStage (PDO branch — F5 scope).
+ *
+ * Drives App::Conductor with MockDisplay, MockPdSink, MockOutputGate and
+ * asserts entry RDO call, R-SHORT output toggle, L-LONG → ProfilePicker
+ * SELECT, and snapshot-driven render.
+ */
+#define VERSION "\"test\""
+
+#include <MockDisplay.h>
+#include <MockOutputGate.h>
+#include <MockPdSink.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/stage/conductor.h>
+
+#include "v2/app.h"
+#include "v2/stages/normal_stage.h"
+#include "v2/stages/profile_picker_stage.h"
+
+using namespace pocketpd;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+using TestConductor = App::Conductor;
+
+TEST(NormalStage, OnEnterPdoProfileRequestsFixedPdo) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo(2)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+
+    normal.prepare(2);
+    conductor.start<NormalStage>();
+}
+
+TEST(NormalStage, OnEnterPpsProfileDoesNotIssueRdoInF5) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, set_pdo).Times(0);
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+
+    normal.prepare(1);
+    conductor.start<NormalStage>();
+}
+
+TEST(NormalStage, OnEnterWithNegativeIndexRendersNoProfileSelected) {
+    using ::testing::HasSubstr;
+
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, set_pdo).Times(0);
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+    EXPECT_CALL(display, clear()).Times(::testing::AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, HasSubstr("No Profile Selected")))
+        .Times(::testing::AtLeast(1));
+    EXPECT_CALL(display, flush()).Times(::testing::AtLeast(1));
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(-1);
+    conductor.start<NormalStage>();
+}
+
+TEST(NormalStage, RShortToggleEnablesAndDisablesOutput) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    bool enabled = false;
+    EXPECT_CALL(gate, is_enabled()).WillRepeatedly(::testing::ReturnPointee(&enabled));
+    EXPECT_CALL(gate, enable()).WillRepeatedly([&] { enabled = true; });
+    EXPECT_CALL(gate, disable()).WillRepeatedly([&] { enabled = false; });
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(0);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
+    EXPECT_TRUE(enabled);
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
+    EXPECT_FALSE(enabled);
+}
+
+TEST(NormalStage, LLongRequestsProfilePickerSelect) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    ProfilePickerStage picker(display, sink);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    conductor.register_stage(picker);
+    normal.prepare(0);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::SELECT);
+}
+
+TEST(NormalStage, EncoderEventsIgnoredInPdoBranch) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+    EXPECT_CALL(gate, enable).Times(0);
+    EXPECT_CALL(gate, disable).Times(0);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(0);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, EncoderEvent{3}, 0);
+    EXPECT_FALSE(conductor.has_pending());
+}
+
+TEST(NormalStage, OnEnterPdoBranchRendersVAReadoutAndPdoIndex) {
+    using ::testing::HasSubstr;
+    using ::testing::InSequence;
+    using ::testing::StrEq;
+
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, is_index_pps(2)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+    EXPECT_CALL(gate, is_enabled()).WillRepeatedly(Return(false));
+
+    InSequence s;
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(1, 14, StrEq("V"))).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::_, 14, ::testing::_)).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, draw_text(1, 47, StrEq("A"))).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::_, 47, ::testing::_)).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, draw_text(110, 50, HasSubstr("[2]"))).Times(::testing::AtLeast(1));
+    EXPECT_CALL(display, draw_text(110, 64, StrEq("PDO"))).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, StrEq("OFF"))).Times(::testing::AtLeast(1));
+    EXPECT_CALL(display, flush()).Times(1);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(2);
+    normal.on_event(conductor, SensorEvent{SensorSnapshot{0, 5000, 1234, true}}, 0);
+    conductor.start<NormalStage>();
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -9,6 +9,7 @@
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
+#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -131,7 +132,9 @@ TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
 
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    NormalStage normal;
+    NiceMock<MockDisplay> normal_display;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(normal_display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -142,7 +145,7 @@ TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PPS);
+    EXPECT_EQ(normal.active_pdo_index(), -1);
 }
 
 TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
@@ -155,7 +158,9 @@ TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
 
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    NormalStage normal;
+    NiceMock<MockDisplay> normal_display;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(normal_display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -166,7 +171,7 @@ TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), -1);
 }
 
 TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -5,6 +5,7 @@
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
+#include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -29,11 +30,12 @@ TEST(ProfilePickerStage, ReviewEmptyListRendersFallback) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+    EXPECT_CALL(display, text_width(StrEq("[No Profile Detected]"))).WillRepeatedly(Return(126));
 
     EXPECT_CALL(display, clear()).Times(1);
-    EXPECT_CALL(display, draw_text(8, 34, StrEq("No Profile Detected"))).Times(1);
+    EXPECT_CALL(display, draw_text(1, 34, StrEq("[No Profile Detected]"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
-    EXPECT_CALL(display, draw_text(::testing::Ne(8), ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(display, draw_text(::testing::Ne(1), ::testing::_, ::testing::_)).Times(0);
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::REVIEW);
@@ -266,7 +268,8 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -277,7 +280,7 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PPS);
+    EXPECT_EQ(normal.active_pdo_index(), -1);
 }
 
 TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
@@ -288,7 +291,8 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -299,7 +303,7 @@ TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), -1);
 }
 
 TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
@@ -310,7 +314,8 @@ TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -324,7 +329,7 @@ TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), -1);
 }
 
 TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
@@ -343,7 +348,8 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -355,7 +361,7 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PPS);
+    EXPECT_EQ(normal.active_pdo_index(), 1);
 }
 
 TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
@@ -369,7 +375,9 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -381,7 +389,7 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PDO);
+    EXPECT_EQ(normal.active_pdo_index(), 0);
 }
 
 TEST(ProfilePickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
@@ -391,7 +399,8 @@ TEST(ProfilePickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -412,7 +421,8 @@ TEST(ProfilePickerStage, SelectIgnoresRLongPressAndEncoderShortPress) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -428,14 +438,16 @@ TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
-    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
     EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
-    normal.prepare(Profile::PPS); // simulate prior session
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    normal.prepare(7); // simulate prior session
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -446,7 +458,7 @@ TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.profile(), Profile::PPS); // unchanged
+    EXPECT_EQ(normal.active_pdo_index(), 7); // unchanged
 }
 
 TEST(ProfilePickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
@@ -485,7 +497,9 @@ TEST(ProfilePickerStage, SelectCommitPromotesPendingCursorAndPreservesAcrossReen
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -516,7 +530,8 @@ TEST(ProfilePickerStage, SelectExitViaLDoesNotPromotePendingCursor) {
 
     ProfilePickerStage stage(display, sink);
     stage.prepare(ProfilePickerStage::Mode::SELECT);
-    NormalStage normal;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(normal);
@@ -529,14 +544,17 @@ TEST(ProfilePickerStage, SelectExitViaLDoesNotPromotePendingCursor) {
 }
 
 TEST(NormalStage, LongPressLReturnsToProfilePicker) {
-    NormalStage normal;
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     ProfilePickerStage picker(display, sink);
     TestConductor conductor;
     conductor.register_stage(normal);
     conductor.register_stage(picker);
-    normal.prepare(Profile::PDO);
+    normal.prepare(0);
     conductor.start<NormalStage>();
 
     normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
@@ -548,14 +566,17 @@ TEST(NormalStage, LongPressLReturnsToProfilePicker) {
 }
 
 TEST(NormalStage, IgnoresOtherButtonsAndShortPressOnL) {
-    NormalStage normal;
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     ProfilePickerStage picker(display, sink);
     TestConductor conductor;
     conductor.register_stage(normal);
     conductor.register_stage(picker);
-    normal.prepare(Profile::PDO);
+    normal.prepare(0);
     conductor.start<NormalStage>();
 
     normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);

--- a/test/test_v2_sensor/test.cpp
+++ b/test/test_v2_sensor/test.cpp
@@ -1,0 +1,74 @@
+/**
+ * GoogleTest suite for SensorTask.
+ *
+ * Drives a FakePowerMonitor through scripted readings; asserts SensorTask
+ * publishes a SensorEvent carrying the snapshot with the tick timestamp.
+ */
+#define VERSION "\"test\""
+
+#include <MockPowerMonitor.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/bus/event_queue.h>
+#include <tempo/bus/publisher.h>
+
+#include <variant>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/tasks/sensor_task.h"
+
+using namespace pocketpd;
+
+using TestQueue = tempo::EventQueue<Event, 8>;
+using TestPublisher = tempo::QueuePublisher<Event, 8>;
+
+namespace {
+
+    const SensorEvent* pop_sensor(TestQueue& q) {
+        static Event last;
+        if (!q.pop(last)) {
+            return nullptr;
+        }
+        return std::get_if<SensorEvent>(&last);
+    }
+
+} // namespace
+
+TEST(SensorTask, OnTickPublishesSensorEventWithTimestampAndValues) {
+    FakePowerMonitor monitor;
+    TestQueue q;
+    TestPublisher pub(q);
+    SensorTask task(monitor);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
+
+    monitor.push({5000, 1234, true});
+    task.on_tick(42);
+
+    const auto* evt = pop_sensor(q);
+    ASSERT_NE(evt, nullptr);
+    EXPECT_EQ(evt->snapshot.timestamp_ms, 42u);
+    EXPECT_EQ(evt->snapshot.vbus_mv, 5000u);
+    EXPECT_EQ(evt->snapshot.current_ma, 1234u);
+    EXPECT_TRUE(evt->snapshot.valid);
+}
+
+TEST(SensorTask, InvalidReadingPropagatesValidFalse) {
+    FakePowerMonitor monitor;
+    TestQueue q;
+    TestPublisher pub(q);
+    SensorTask task(monitor);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
+
+    monitor.push({0, 0, false});
+    task.on_tick(99);
+
+    const auto* evt = pop_sensor(q);
+    ASSERT_NE(evt, nullptr);
+    EXPECT_FALSE(evt->snapshot.valid);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
This PR turns the Normal stage into a live operating screen and bundling a few changes that came out while building.

- **Normal screen.** First real screen. It renders the live bus voltage and current as the primary readouts, with the profile index, a PDO/PPS marker, and the output ON/OFF state as smaller labels. The R Button toggles the output transistor on a short press; the L Button still returns to the profile picker on a long press.
- **Display font scale.** Adds four logical sizes
- **Sensor task.** Samples the INA226 at 33 ms and publishes a sensor event the Normal screen consumes.
- **Long-press tuning.** Inherited 1500 ms threshold from v1 felt slow on real usage. Reduced after adding debug logs to the button task to measure actual wall-clock latency.
- **Profile picker empty-state.** Picker used to exit to Normal even when the charger advertised zero profiles. On a cold boot with nothing plugged in that reads as a glitch. Now stays on its empty-state until a charger appears.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested: flashed HW1_3_V2; exercised long-press-to-picker path with serial timing logs (~750 ms wall clock); verified V/A fonts at the larger size; confirmed the picker stays put with no charger plugged.

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details: Normal payload changes from a profile enum to a profile index; long-press threshold 1500 → 750 ms; debounce 50 → 30 ms; profile picker no longer auto-exits to Normal when no charger is detected.

## Notes


<img width="3024" height="4032" alt="IMG_2997" src="https://github.com/user-attachments/assets/746f6ea4-fcd9-481a-9ea4-96a7e2772482" />

* The cut off is because of screen refreshing at 33ms cadence
