### PR TITLE
feat(v2): NormalStage live operation with PPS and fixed modes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,3 +21,5 @@ CheckOptions:
     value: true
   - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
     value: true
+  - key: cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: true

--- a/include/v2/hal/ap33772_pd_sink.h
+++ b/include/v2/hal/ap33772_pd_sink.h
@@ -51,6 +51,9 @@ namespace pocketpd {
         bool set_pps_pdo(int index, int voltage_mv, int current_ma) override {
             return m_driver.set_pps_pdo(index, voltage_mv, current_ma);
         }
+        bool reset() const {
+            return m_driver.reset();
+        }
     };
 
 } // namespace pocketpd

--- a/include/v2/hal/u8g2_display.h
+++ b/include/v2/hal/u8g2_display.h
@@ -60,6 +60,10 @@ namespace pocketpd {
         uint16_t text_width(const char* text) override {
             return m_u8g2.getStrWidth(text);
         }
+
+        void draw_box(uint8_t x, uint8_t y, uint8_t w, uint8_t h) override {
+            m_u8g2.drawBox(x, y, w, h);
+        }
     };
 
 } // namespace pocketpd

--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -57,6 +57,10 @@ namespace pocketpd {
     constexpr std::array<uint16_t, 3> VOLTAGE_INCREMENTS_MV = {20, 100, 1000};
     constexpr std::array<uint16_t, 3> CURRENT_INCREMENTS_MA = {50, 100, 1000};
 
+    // PPS RDO stepping per USB-PD 3.0 spec.
+    constexpr int32_t PPS_VOLTAGE_STEP_MV = 20;
+    constexpr int32_t PPS_CURRENT_STEP_MA = 50;
+
     // —— I2C addresses
 
     constexpr uint8_t INA226_I2C_ADDR = 0x40;

--- a/include/v2/stages/normal/fixed_mode.h
+++ b/include/v2/stages/normal/fixed_mode.h
@@ -1,0 +1,13 @@
+/**
+ * @file fixed_mode.h
+ * @brief Fixed-PDO sub-mode marker for NormalStage.
+ *
+ * Empty tag struct. The fixed-PDO branch carry no per-mode state.
+ */
+#pragma once
+
+namespace pocketpd {
+
+    struct FixedMode {};
+
+} // namespace pocketpd

--- a/include/v2/stages/normal/normal_view.h
+++ b/include/v2/stages/normal/normal_view.h
@@ -1,0 +1,128 @@
+/**
+ * @file normal_view.h
+ * @brief View layer for NormalStage. Renders a NormalViewModel snapshot.
+ */
+#pragma once
+
+#include <tempo/hardware/display.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+
+#include "v2/pocketpd.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    /**
+     * @brief Frozen snapshot of everything NormalView needs to draw one frame.
+     *
+     */
+    struct NormalViewModel {
+        int8_t active_pdo_index = -1;
+        bool has_profile = false;
+        bool is_pps = false;
+        bool output_enabled = false;
+        SensorSnapshot snapshot{};
+
+        // —— PPS branch (valid when has_profile && is_pps)
+
+        int32_t target_mv = 0;
+        int32_t target_ma = 0;
+        AdjustMode adjust_mode = AdjustMode::VOLTAGE;
+        uint8_t cursor_idx = 0;
+
+        // —— Fixed branch (valid when has_profile && !is_pps)
+
+        int32_t pdo_max_mv = 0;
+        int32_t pdo_max_ma = 0;
+    };
+
+    class NormalView {
+    private:
+        static constexpr uint8_t V_MEASURED_Y = 14;
+        static constexpr uint8_t A_MEASURED_Y = 47;
+        static constexpr uint8_t V_TARGET_Y = 27;
+        static constexpr uint8_t A_TARGET_Y = 62;
+        static constexpr uint8_t TARGET_RIGHT_X = 75;
+        static constexpr uint8_t STATUS_X = 110;
+        static constexpr uint8_t OUTPUT_LABEL_X = 90;
+        static constexpr std::array<uint8_t, 3> CURSOR_X = {45, 39, 33};
+        static constexpr uint8_t CURSOR_W = 6;
+
+    public:
+        static void render(tempo::Display& d, const NormalViewModel& vm) {
+            d.clear();
+
+            if (!vm.has_profile) {
+                d.set_font(tempo::Font::BASE);
+                d.draw_text(8, 34, "No Profile Selected");
+                d.flush();
+                return;
+            }
+
+            std::array<char, 32> buf{};
+
+            d.set_font(tempo::Font::XL);
+            draw_measured(d, "V", V_MEASURED_Y, vm.snapshot.vbus_mv, buf);
+            draw_measured(d, "A", A_MEASURED_Y, vm.snapshot.current_ma, buf);
+
+            d.set_font(tempo::Font::BASE);
+            std::snprintf(buf.data(), buf.size(), "[%u]", vm.active_pdo_index);
+            d.draw_text(STATUS_X, 50, buf.data());
+            d.draw_text(STATUS_X, 64, vm.is_pps ? "PPS" : "PDO");
+            d.draw_text(OUTPUT_LABEL_X, 14, vm.output_enabled ? "ON" : "OFF");
+
+            if (vm.is_pps) {
+                draw_target_pps(d, vm, buf);
+            } else {
+                draw_target_fixed(d, vm, buf);
+            }
+
+            d.flush();
+        }
+
+    private:
+        static void draw_measured(
+            tempo::Display& d, const char* label, uint8_t y, uint32_t value,
+            std::array<char, 32>& buf
+        ) {
+            d.draw_text(1, y, label);
+            const unsigned long whole = value / 1000;
+            const unsigned long fraction = (value % 1000) / 10;
+            std::snprintf(buf.data(), buf.size(), "%lu.%02lu", whole, fraction);
+            const auto width = d.text_width(buf.data());
+            d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - width), y, buf.data());
+        }
+
+        static void draw_target_fixed(
+            tempo::Display& d, const NormalViewModel& vm, std::array<char, 32>& buf
+        ) {
+            std::snprintf(buf.data(), buf.size(), "%ld mV", static_cast<long>(vm.pdo_max_mv));
+            auto w = d.text_width(buf.data());
+            d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), V_TARGET_Y, buf.data());
+
+            std::snprintf(buf.data(), buf.size(), "%ld mA", static_cast<long>(vm.pdo_max_ma));
+            w = d.text_width(buf.data());
+            d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), A_TARGET_Y, buf.data());
+        }
+
+        static void draw_target_pps(
+            tempo::Display& d, const NormalViewModel& vm, std::array<char, 32>& buf
+        ) {
+            std::snprintf(buf.data(), buf.size(), "%ld mV", static_cast<long>(vm.target_mv));
+            auto w = d.text_width(buf.data());
+            d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), V_TARGET_Y, buf.data());
+
+            std::snprintf(buf.data(), buf.size(), "%ld mA", static_cast<long>(vm.target_ma));
+            w = d.text_width(buf.data());
+            d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), A_TARGET_Y, buf.data());
+
+            const uint8_t cursor_y =
+                ((vm.adjust_mode == AdjustMode::VOLTAGE) ? V_TARGET_Y : A_TARGET_Y) + 1;
+            d.draw_box(CURSOR_X.at(vm.cursor_idx), cursor_y, CURSOR_W, 1);
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/normal/pps_mode.h
+++ b/include/v2/stages/normal/pps_mode.h
@@ -1,0 +1,120 @@
+/**
+ * @file pps_mode.h
+ * @brief PPS sub-mode for NormalStage. Live mV/mA targets + encoder edits.
+ *
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "v2/events.h"
+#include "v2/hal/pd_sink_controller.h"
+#include "v2/pocketpd.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    struct PPSMode {
+        int32_t target_mv = 5000;
+        int32_t target_ma = 1000;
+        uint8_t voltage_idx = 0;
+        uint8_t current_idx = 0;
+        AdjustMode adjust_mode = AdjustMode::VOLTAGE;
+
+        /**
+         * @brief Bind to a PD sink + PDO index and seed targets.
+         *
+         * Set `target_mv` to PDO minimum voltage. `target_ma` defaults to 1 A.
+         */
+        PPSMode(PdSinkController& sink, int8_t pdo_idx) : m_sink(&sink), m_pdo_idx(pdo_idx) {
+            const int v_lo = sink.pdo_min_voltage_mv(pdo_idx);
+            if (v_lo > 0) {
+                target_mv = v_lo;
+            }
+        }
+
+        /**
+         * @brief Handle a button gesture on the PPS branch only.
+         *
+         * - L SHORT toggle voltage/current adjustment
+         * - ENCODER SHORT cycle the active increment table index.
+         *
+         * Stage-level gestures (R SHORT output toggle, L LONG → ProfilePicker) are filtered
+         * upstream and never reach this method.
+         */
+        void on_button(const ButtonEvent& evt) {
+            if (evt.id == ButtonId::L && evt.gesture == Gesture::SHORT) {
+                adjust_mode = (adjust_mode == AdjustMode::VOLTAGE) ? AdjustMode::CURRENT
+                                                                   : AdjustMode::VOLTAGE;
+                return;
+            }
+            if (evt.id == ButtonId::ENCODER && evt.gesture == Gesture::SHORT) {
+                if (adjust_mode == AdjustMode::VOLTAGE) {
+                    voltage_idx = (voltage_idx + 1) % VOLTAGE_INCREMENTS_MV.size();
+                } else {
+                    current_idx = (current_idx + 1) % CURRENT_INCREMENTS_MA.size();
+                }
+            }
+        }
+
+        /**
+         * @brief Apply an encoder delta to the focused target and reissue.
+         *
+         * @return Result of the underlying `set_pps_pdo` call. `true` when the
+         * delta is zero (no reissue needed). `false` only on actual sink
+         * failure.
+         */
+        [[nodiscard]] bool on_encoder(const EncoderEvent& evt) {
+            if (evt.delta == 0) {
+                return true;
+            }
+            apply_encoder_delta(-evt.delta);
+            return apply();
+        }
+
+        /**
+         * @brief Clamp the current target to PDO + step grid and push to sink.
+         *
+         * @return Result of `set_pps_pdo`. Stage log on `false`.
+         */
+        [[nodiscard]] bool apply() {
+            clamp_to_pdo();
+            return m_sink->set_pps_pdo(m_pdo_idx, target_mv, target_ma);
+        }
+
+        uint8_t cursor_index() const {
+            return (adjust_mode == AdjustMode::VOLTAGE) ? voltage_idx : current_idx;
+        }
+
+    private:
+        PdSinkController* m_sink;
+        int8_t m_pdo_idx;
+
+        void apply_encoder_delta(int delta) {
+            if (adjust_mode == AdjustMode::VOLTAGE) {
+                const int32_t step = VOLTAGE_INCREMENTS_MV.at(voltage_idx);
+                target_mv += delta * step;
+            } else {
+                const int32_t step = CURRENT_INCREMENTS_MA.at(current_idx);
+                target_ma += delta * step;
+            }
+        }
+
+        void clamp_to_pdo() {
+            const int32_t v_lo = m_sink->pdo_min_voltage_mv(m_pdo_idx);
+            const int32_t v_hi = m_sink->pdo_max_voltage_mv(m_pdo_idx);
+            const int32_t a_hi = m_sink->pdo_max_current_ma(m_pdo_idx);
+
+            if (v_lo > 0 && v_hi > 0) {
+                target_mv = std::clamp(target_mv, v_lo, v_hi);
+                target_mv -= target_mv % PPS_VOLTAGE_STEP_MV;
+            }
+            if (a_hi > 0) {
+                target_ma = std::clamp(target_ma, int32_t{0}, a_hi);
+                target_ma -= target_ma % PPS_CURRENT_STEP_MA;
+            }
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -8,16 +8,20 @@
 #include <tempo/core/time.h>
 #include <tempo/hardware/display.h>
 
-#include <cstdio>
 #include <variant>
 
 #include "v2/app.h"
 #include "v2/events.h"
 #include "v2/hal/output_gate.h"
 #include "v2/hal/pd_sink_controller.h"
+#include "v2/stages/normal/fixed_mode.h"
+#include "v2/stages/normal/normal_view.h"
+#include "v2/stages/normal/pps_mode.h"
 #include "v2/state.h"
 
 namespace pocketpd {
+
+    using Mode = std::variant<FixedMode, PPSMode>;
 
     class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
@@ -27,11 +31,10 @@ namespace pocketpd {
         PdSinkController& m_pd_sink;
         OutputGate& m_output_gate;
         SensorSnapshot m_snapshot{};
-
         int8_t m_active_pdo_index = -1;
+        int8_t m_last_active_index = -1;
+        Mode m_mode;
         tempo::IntervalTimer m_render_interval{33};
-
-        void draw();
 
     public:
         static constexpr const char* LOG_TAG = "Normal";
@@ -47,26 +50,50 @@ namespace pocketpd {
             return m_active_pdo_index;
         }
 
+        const Mode& mode() const {
+            return m_mode;
+        }
+
+        int32_t target_mv() const {
+            const auto* p = std::get_if<PPSMode>(&m_mode);
+            return p ? p->target_mv : 0;
+        }
+        int32_t target_ma() const {
+            const auto* p = std::get_if<PPSMode>(&m_mode);
+            return p ? p->target_ma : 0;
+        }
+        AdjustMode adjust_mode() const {
+            const auto* p = std::get_if<PPSMode>(&m_mode);
+            return p ? p->adjust_mode : AdjustMode::VOLTAGE;
+        }
+        uint8_t voltage_increment_index() const {
+            const auto* p = std::get_if<PPSMode>(&m_mode);
+            return p ? p->voltage_idx : 0;
+        }
+        uint8_t current_increment_index() const {
+            const auto* p = std::get_if<PPSMode>(&m_mode);
+            return p ? p->current_idx : 0;
+        }
+
         void prepare(int8_t pdo_index = -1) {
             m_active_pdo_index = pdo_index;
         }
 
         void on_enter(Conductor&) override {
             if (m_active_pdo_index < 0) {
+                m_last_active_index = -1;
                 log.info("Entered with no profile selected");
                 draw();
                 return;
             }
 
             if (m_pd_sink.is_index_pps(m_active_pdo_index)) {
-                log.info("Entered PPS profile pdo_index={}", m_active_pdo_index);
+                enter_pps_profile();
             } else {
-                log.info("Entered PDO profile pdo_index={}", m_active_pdo_index);
-                if (!m_pd_sink.set_pdo(m_active_pdo_index)) {
-                    log.error("set_pdo({}) failed", m_active_pdo_index);
-                }
+                enter_fixed_profile();
             }
 
+            m_last_active_index = m_active_pdo_index;
             draw();
         }
 
@@ -85,8 +112,28 @@ namespace pocketpd {
                         } else {
                             m_output_gate.enable();
                         }
-                    } else if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                        return;
+                    }
+
+                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
                         conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
+                        return;
+                    }
+
+                    // V/I are adjustable in PPS mode
+                    if (auto* pps = std::get_if<PPSMode>(&m_mode)) {
+                        pps->on_button(evt);
+                    }
+                },
+                [&](const EncoderEvent& evt) {
+                    auto* pps = std::get_if<PPSMode>(&m_mode);
+                    if (pps == nullptr) {
+                        return;
+                    }
+
+                    if (!pps->on_encoder(evt)) {
+                        const auto msg = "set_pps_pdo({}, {}, {}) failed";
+                        log.error(msg, m_active_pdo_index, pps->target_mv, pps->target_ma);
                     }
                 },
                 [&](const SensorEvent& evt) { m_snapshot = evt.snapshot; },
@@ -95,43 +142,78 @@ namespace pocketpd {
 
             std::visit(handler, event);
         }
-    };
 
-    inline void NormalStage::draw() {
-        m_display.clear();
+    private:
+        /**
+         * @brief Enter (or re-enter) a PPS profile. Construct fresh state on profile change or
+         * mode switch; otherwise preserve the user's prior target edits and reissue.
+         */
+        void enter_pps_profile() {
+            const bool same_profile = (m_active_pdo_index == m_last_active_index);
+            const bool reusable = same_profile && std::holds_alternative<PPSMode>(m_mode);
 
-        if (m_active_pdo_index < 0) {
-            m_display.set_font(tempo::Font::BASE);
-            m_display.draw_text(8, 34, "No Profile Selected");
-            m_display.flush();
-            return;
+            if (!reusable) {
+                PPSMode pps{m_pd_sink, m_active_pdo_index};
+                m_mode = pps;
+
+                const auto msg = "Entered PPS profile pdo_index={} target_mv={} target_ma={}";
+                log.info(msg, m_active_pdo_index, pps.target_mv, pps.target_ma);
+            }
+
+            auto& pps = std::get<PPSMode>(m_mode);
+            if (!pps.apply()) {
+                const auto msg = "set_pps_pdo({}, {}, {}) failed";
+                log.error(msg, m_active_pdo_index, pps.target_mv, pps.target_ma);
+            }
         }
 
-        std::array<char, 32> buffer{};
+        /**
+         * @brief Enter a fixed PDO profile. Trigger `set_pdo` on every entry.
+         */
+        void enter_fixed_profile() {
+            if (!std::holds_alternative<FixedMode>(m_mode)) {
+                m_mode = FixedMode{};
+            }
 
-        auto draw_line = [&](const char* label, uint8_t y, uint32_t value) {
-            m_display.draw_text(1, y, label);
+            log.info("Entered PDO profile pdo_index={}", m_active_pdo_index);
+            if (!m_pd_sink.set_pdo(m_active_pdo_index)) {
+                log.error("set_pdo({}) failed", m_active_pdo_index);
+            }
+        }
 
-            const unsigned long whole = value / 1000;
-            const unsigned long fraction = (value % 1000) / 10;
-            std::snprintf(buffer.data(), buffer.size(), "%lu.%02lu", whole, fraction);
+        NormalViewModel build_view_model() const {
+            NormalViewModel vm = {
+                .active_pdo_index = m_active_pdo_index,
+                .has_profile = m_active_pdo_index >= 0,
+                .output_enabled = m_output_gate.is_enabled(),
+                .snapshot = m_snapshot,
+            };
 
-            const auto w = m_display.text_width(buffer.data());
-            m_display.draw_text(static_cast<uint8_t>(75 - w), y, buffer.data());
-        };
+            if (!vm.has_profile) {
+                return vm;
+            }
 
-        m_display.set_font(tempo::Font::XL);
-        draw_line("V", 14, m_snapshot.vbus_mv);
-        draw_line("A", 47, m_snapshot.current_ma);
+            auto handle_mode = tempo::overloaded{
+                [&](const FixedMode& mode) {
+                    vm.pdo_max_mv = m_pd_sink.pdo_max_voltage_mv(m_active_pdo_index);
+                    vm.pdo_max_ma = m_pd_sink.pdo_max_current_ma(m_active_pdo_index);
+                },
+                [&](const PPSMode& mode) {
+                    vm.is_pps = true;
+                    vm.target_mv = mode.target_mv;
+                    vm.target_ma = mode.target_ma;
+                    vm.adjust_mode = mode.adjust_mode;
+                    vm.cursor_idx = mode.cursor_index();
+                },
+            };
 
-        m_display.set_font(tempo::Font::BASE);
-        std::snprintf(buffer.data(), buffer.size(), "[%u]", m_active_pdo_index);
-        m_display.draw_text(110, 50, buffer.data());
+            std::visit(handle_mode, m_mode);
+            return vm;
+        }
 
-        m_display.draw_text(110, 64, m_pd_sink.is_index_pps(m_active_pdo_index) ? "PPS" : "PDO");
-        m_display.draw_text(90, 14, m_output_gate.is_enabled() ? "ON" : "OFF");
-
-        m_display.flush();
-    }
+        void draw() {
+            NormalView::render(m_display, build_view_model());
+        }
+    };
 
 } // namespace pocketpd

--- a/lib/tempo/include/tempo/hardware/display.h
+++ b/lib/tempo/include/tempo/hardware/display.h
@@ -29,23 +29,29 @@ namespace tempo {
         virtual void flush() = 0;
 
         // —— Font selection
-        // Implementation should default to Font::BASE.
 
         virtual void set_font(Font font) = 0;
 
         // —— Drawing
-        //
-        // Bitmap data is 1 bpp packed 8 pixels per byte horizontally; one row
-        // is `width_bytes` bytes. Pixel width therefore equals `width_bytes * 8`. Rows are stored
-        // top-to-bottom.
 
+        /**
+         * @brief Draw a bitmap at the given coordinates. Bitmap data is 1 bpp packed 8 pixels per
+         * byte horizontally; one row is `width_bytes` bytes. Pixel width therefore equals
+         * `width_bytes * 8`. Rows are stored top-to-bottom.
+         *
+         */
         virtual void draw_bitmap(
             uint8_t x, uint8_t y, uint8_t width_bytes, uint8_t height, const uint8_t* data
         ) = 0;
 
-        // Text Y is the baseline (matches U8g2 / typographic convention).
+        /**
+         * @brief Draw text at the given coordinates. Text is drawn using the current font.
+         *
+         */
         virtual void draw_text(uint8_t x, uint8_t y, const char* text) = 0;
         virtual uint16_t text_width(const char* text) = 0;
+
+        virtual void draw_box(uint8_t x, uint8_t y, uint8_t w, uint8_t h) = 0;
     };
 
 } // namespace tempo

--- a/test/mocks/MockDisplay.h
+++ b/test/mocks/MockDisplay.h
@@ -18,6 +18,7 @@ namespace pocketpd {
         );
         MOCK_METHOD(void, draw_text, (uint8_t x, uint8_t y, const char* text), (override));
         MOCK_METHOD(uint16_t, text_width, (const char* text), (override));
+        MOCK_METHOD(void, draw_box, (uint8_t x, uint8_t y, uint8_t w, uint8_t h), (override));
     };
 
 } // namespace pocketpd

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -1,9 +1,10 @@
 /**
- * GoogleTest suite for NormalStage (PDO branch — F5 scope).
+ * GoogleTest suite for NormalStage (PDO + PPS branches).
  *
  * Drives App::Conductor with MockDisplay, MockPdSink, MockOutputGate and
  * asserts entry RDO call, R-SHORT output toggle, L-LONG → ProfilePicker
- * SELECT, and snapshot-driven render.
+ * SELECT, snapshot-driven render, PPS encoder edits + bounds, increment
+ * cycling, and AdjustMode flip.
  */
 #define VERSION "\"test\""
 
@@ -41,14 +42,17 @@ TEST(NormalStage, OnEnterPdoProfileRequestsFixedPdo) {
     conductor.start<NormalStage>();
 }
 
-TEST(NormalStage, OnEnterPpsProfileDoesNotIssueRdoInF5) {
+TEST(NormalStage, OnEnterPpsProfileResetsTargetsToDefaults) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     NiceMock<MockOutputGate> gate;
 
     EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(1)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(11000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
     EXPECT_CALL(sink, set_pdo).Times(0);
-    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+    EXPECT_CALL(sink, set_pps_pdo(1, 3300, 1000)).Times(1).WillOnce(Return(true));
 
     NormalStage normal(display, sink, gate);
     TestConductor conductor;
@@ -56,6 +60,61 @@ TEST(NormalStage, OnEnterPpsProfileDoesNotIssueRdoInF5) {
 
     normal.prepare(1);
     conductor.start<NormalStage>();
+    EXPECT_EQ(normal.target_mv(), 3300);
+    EXPECT_EQ(normal.target_ma(), 1000);
+}
+
+TEST(NormalStage, ReEnteringSamePpsProfilePreservesEdits) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(1)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(11000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, set_pps_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(1);
+    conductor.start<NormalStage>();
+
+    normal.on_event(conductor, EncoderEvent{-100}, 0);
+    ASSERT_EQ(normal.target_mv(), 5300);
+
+    normal.prepare(1);
+    normal.on_enter(conductor);
+    EXPECT_EQ(normal.target_mv(), 5300);
+    EXPECT_EQ(normal.target_ma(), 1000);
+}
+
+TEST(NormalStage, SwitchingPpsProfilesResetsTargetsToNewMinimum) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, is_index_pps(2)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(1)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(11000));
+    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(2)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(2)).WillRepeatedly(Return(20000));
+    EXPECT_CALL(sink, pdo_max_current_ma(2)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, set_pps_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(1);
+    conductor.start<NormalStage>();
+    normal.on_event(conductor, EncoderEvent{-100}, 0);
+    ASSERT_NE(normal.target_mv(), 3300);
+
+    normal.prepare(2);
+    normal.on_enter(conductor);
+    EXPECT_EQ(normal.target_mv(), 5000);
+    EXPECT_EQ(normal.target_ma(), 1000);
 }
 
 TEST(NormalStage, OnEnterWithNegativeIndexRendersNoProfileSelected) {
@@ -131,6 +190,7 @@ TEST(NormalStage, EncoderEventsIgnoredInPdoBranch) {
     NiceMock<MockOutputGate> gate;
     EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
     EXPECT_CALL(gate, enable).Times(0);
     EXPECT_CALL(gate, disable).Times(0);
 
@@ -144,28 +204,154 @@ TEST(NormalStage, EncoderEventsIgnoredInPdoBranch) {
     EXPECT_FALSE(conductor.has_pending());
 }
 
+namespace {
+
+    struct PpsHarness {
+        NiceMock<MockDisplay> display;
+        NiceMock<MockPdSink> sink;
+        NiceMock<MockOutputGate> gate;
+        NormalStage normal{display, sink, gate};
+        TestConductor conductor;
+
+        explicit PpsHarness(int pdo_index = 1, int v_lo = 3300, int v_hi = 11000, int a_hi = 3000) {
+            EXPECT_CALL(sink, is_index_pps(pdo_index)).WillRepeatedly(Return(true));
+            EXPECT_CALL(sink, pdo_min_voltage_mv(pdo_index)).WillRepeatedly(Return(v_lo));
+            EXPECT_CALL(sink, pdo_max_voltage_mv(pdo_index)).WillRepeatedly(Return(v_hi));
+            EXPECT_CALL(sink, pdo_max_current_ma(pdo_index)).WillRepeatedly(Return(a_hi));
+            EXPECT_CALL(sink, set_pps_pdo).WillRepeatedly(Return(true));
+            conductor.register_stage(normal);
+            normal.prepare(static_cast<int8_t>(pdo_index));
+            conductor.start<NormalStage>();
+        }
+    };
+
+} // namespace
+
+TEST(NormalStage, EncoderDeltaInVoltageModeAdjustsTargetMv) {
+    PpsHarness h;
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 3360, 1000)).Times(1).WillOnce(Return(true));
+    h.normal.on_event(h.conductor, EncoderEvent{-3}, 0);
+    EXPECT_EQ(h.normal.target_mv(), 3360);
+    EXPECT_EQ(h.normal.adjust_mode(), AdjustMode::VOLTAGE);
+}
+
+TEST(NormalStage, EncoderDeltaInCurrentModeAdjustsTargetMa) {
+    PpsHarness h;
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
+    ASSERT_EQ(h.normal.adjust_mode(), AdjustMode::CURRENT);
+
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 3300, 1200)).Times(1).WillOnce(Return(true));
+    h.normal.on_event(h.conductor, EncoderEvent{-4}, 0);
+    EXPECT_EQ(h.normal.target_ma(), 1200);
+}
+
+TEST(NormalStage, EncoderShortPressCyclesIncrementIndex) {
+    PpsHarness h;
+    EXPECT_EQ(h.normal.voltage_increment_index(), 0);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    EXPECT_EQ(h.normal.voltage_increment_index(), 1);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    EXPECT_EQ(h.normal.voltage_increment_index(), 2);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    EXPECT_EQ(h.normal.voltage_increment_index(), 0);
+
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
+    ASSERT_EQ(h.normal.adjust_mode(), AdjustMode::CURRENT);
+    EXPECT_EQ(h.normal.current_increment_index(), 0);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    EXPECT_EQ(h.normal.current_increment_index(), 1);
+    EXPECT_EQ(h.normal.voltage_increment_index(), 0);
+}
+
+TEST(NormalStage, EncoderEditUsesActiveIncrementMagnitude) {
+    PpsHarness h;
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    ASSERT_EQ(h.normal.voltage_increment_index(), 2);
+
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 4300, 1000)).Times(1).WillOnce(Return(true));
+    h.normal.on_event(h.conductor, EncoderEvent{-1}, 0);
+    EXPECT_EQ(h.normal.target_mv(), 4300);
+}
+
+TEST(NormalStage, EncoderEditClampsTargetVoltageToPdoBounds) {
+    PpsHarness h(1, 3300, 11000, 3000);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 11000, ::testing::_)).WillRepeatedly(Return(true));
+    h.normal.on_event(h.conductor, EncoderEvent{-20}, 0);
+    EXPECT_EQ(h.normal.target_mv(), 11000);
+
+    h.normal.on_event(h.conductor, EncoderEvent{20}, 0);
+    EXPECT_EQ(h.normal.target_mv(), 3300);
+}
+
+TEST(NormalStage, EncoderEditClampsCurrentAtZero) {
+    PpsHarness h(1, 3300, 11000, 3000);
+    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
+    ASSERT_EQ(h.normal.adjust_mode(), AdjustMode::CURRENT);
+
+    EXPECT_CALL(h.sink, set_pps_pdo).WillRepeatedly(Return(true));
+    h.normal.on_event(h.conductor, EncoderEvent{-20}, 0);
+    ASSERT_EQ(h.normal.target_ma(), 2000);
+    h.normal.on_event(h.conductor, EncoderEvent{50}, 0);
+    EXPECT_EQ(h.normal.target_ma(), 0);
+}
+
+TEST(NormalStage, EncoderEditSnapsTargetVoltageToPpsStepGrid) {
+    PpsHarness h(1, 3300, 11000, 3000);
+    EXPECT_CALL(h.sink, set_pps_pdo).WillRepeatedly(Return(true));
+    h.normal.on_event(h.conductor, EncoderEvent{-1}, 0);
+    EXPECT_EQ(h.normal.target_mv() % PPS_VOLTAGE_STEP_MV, 0);
+    h.normal.on_event(h.conductor, EncoderEvent{-1}, 0);
+    EXPECT_EQ(h.normal.target_mv() % PPS_VOLTAGE_STEP_MV, 0);
+}
+
+TEST(NormalStage, LShortDoesNothingInPdoBranch) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(0);
+    conductor.start<NormalStage>();
+
+    const auto mode_before = normal.adjust_mode();
+    normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
+    EXPECT_EQ(normal.adjust_mode(), mode_before);
+}
+
 TEST(NormalStage, OnEnterPdoBranchRendersVAReadoutAndPdoIndex) {
+    using ::testing::AtLeast;
     using ::testing::HasSubstr;
-    using ::testing::InSequence;
     using ::testing::StrEq;
 
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     NiceMock<MockOutputGate> gate;
     EXPECT_CALL(sink, is_index_pps(2)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(2)).WillRepeatedly(Return(20000));
+    EXPECT_CALL(sink, pdo_max_current_ma(2)).WillRepeatedly(Return(5000));
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     EXPECT_CALL(gate, is_enabled()).WillRepeatedly(Return(false));
 
-    InSequence s;
-    EXPECT_CALL(display, clear()).Times(1);
-    EXPECT_CALL(display, draw_text(1, 14, StrEq("V"))).Times(1);
-    EXPECT_CALL(display, draw_text(::testing::_, 14, ::testing::_)).Times(::testing::AnyNumber());
-    EXPECT_CALL(display, draw_text(1, 47, StrEq("A"))).Times(1);
-    EXPECT_CALL(display, draw_text(::testing::_, 47, ::testing::_)).Times(::testing::AnyNumber());
-    EXPECT_CALL(display, draw_text(110, 50, HasSubstr("[2]"))).Times(::testing::AtLeast(1));
-    EXPECT_CALL(display, draw_text(110, 64, StrEq("PDO"))).Times(1);
-    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, StrEq("OFF"))).Times(::testing::AtLeast(1));
-    EXPECT_CALL(display, flush()).Times(1);
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber());
+    EXPECT_CALL(display, clear()).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(1, 14, StrEq("V"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(1, 47, StrEq("A"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, 27, HasSubstr("20000 mV"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, 62, HasSubstr("5000 mA"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(110, 50, HasSubstr("[2]"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(110, 64, StrEq("PDO"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, StrEq("OFF"))).Times(AtLeast(1));
+    EXPECT_CALL(display, flush()).Times(AtLeast(1));
 
     NormalStage normal(display, sink, gate);
     TestConductor conductor;

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -439,8 +439,8 @@ TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
-    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
-    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(::testing::_)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(::testing::_)).WillRepeatedly(Return(3000));
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
 
     ProfilePickerStage stage(display, sink);


### PR DESCRIPTION
## Summary
- Splits NormalStage into a state owner plus pure mode types (`PPSMode`, `FixedMode`) and a render-only `NormalView`. `PPSMode` binds the PD sink and PDO index at construction. Encoder adjustments clamp to the active PPS range before reissuing `set_pps_pdo`.
- Adds `tempo::Display::draw_box` so the PPS adjust cursor underline can be drawn.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested: 82 native tests pass via \`pio test -e native\`. HW1_3_V2 firmware builds clean. On-device PPS verification still pending.


https://github.com/user-attachments/assets/13d22f40-da07-455f-9c10-816d0a774e50



## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)
- [x] Public lib API (\`lib/*\` headers)


## Notes