### PR TITLE
feat(v2): add CommandTask for serial command echo

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: "
   -cppcoreguidelines-avoid-const-or-ref-data-members,
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard
   "

--- a/include/v2/hal/arduino_stream_reader.h
+++ b/include/v2/hal/arduino_stream_reader.h
@@ -1,0 +1,23 @@
+/**
+ * @file arduino_stream_reader.h
+ * @brief `tempo::StreamReader` backed by the global Arduino `Serial` UART.
+ */
+#pragma once
+
+#include <Arduino.h>
+#include <tempo/hardware/stream.h>
+
+namespace pocketpd {
+
+    class ArduinoStreamReader : public tempo::StreamReader {
+    public:
+        int available() override {
+            return Serial.available();
+        }
+
+        int read() override {
+            return Serial.read();
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/tasks/command_task.h
+++ b/include/v2/tasks/command_task.h
@@ -1,0 +1,96 @@
+/**
+ * @file command_task.h
+ * @brief Polls a `tempo::StreamReader` for host-side serial input. On every
+ * newline (`\n` or `\r`) the buffered bytes are echoed back through the
+ * supplied `tempo::StreamWriter` followed by a single `\n`. Lines longer than
+ * `MAX_MSG_LEN` bytes are echoed and reset on overflow.
+ *
+ * The buffer is kept null-terminated at all times so consumers can treat
+ * `m_buffer.data()` as a C-string without carrying the length around.
+ * `BUFFER_SIZE` is the array size; `MAX_MSG_LEN = BUFFER_SIZE - 1` is the
+ * maximum payload length, leaving one byte reserved for the terminator.
+ */
+#pragma once
+
+#include <tempo/hardware/stream.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "v2/app.h"
+
+namespace pocketpd {
+
+    class CommandTask : public App::BackgroundTask,
+                        public App::UseLog<CommandTask>,
+                        public App::UsePublisher<CommandTask> {
+    private:
+        static constexpr uint32_t POLL_PERIOD_MS = 10;
+        static constexpr size_t BUFFER_SIZE = 128;
+        static constexpr size_t MAX_MSG_LEN = BUFFER_SIZE - 1;
+
+        tempo::StreamReader& m_source;
+        tempo::StreamWriter& m_writer;
+        
+        std::array<char, BUFFER_SIZE> m_buffer{};
+        size_t m_len = 0;
+
+        /**
+         * @brief Make sure we are always null terminated
+         *
+         */
+        void terminate() {
+            m_buffer[m_len] = '\0';
+        }
+
+        void echo_buffer() {
+            terminate();
+            log.debug("rx={} bytes", m_len);
+            log.info(m_buffer.data());
+            m_len = 0;
+            terminate();
+        }
+
+    public:
+        static constexpr const char* LOG_TAG = "CommandTask";
+
+        CommandTask(tempo::StreamReader& source, tempo::StreamWriter& writer)
+            : App::BackgroundTask(POLL_PERIOD_MS), m_source(source), m_writer(writer) {}
+
+        const char* name() const override {
+            return LOG_TAG;
+        }
+
+        void poll(uint32_t) {
+            while (m_source.available() > 0) {
+                const int next = m_source.read();
+                if (next < 0) {
+                    break;
+                }
+                const char ch = static_cast<char>(next);
+
+                if (ch == '\n' || ch == '\r') {
+                    if (m_len > 0) {
+                        echo_buffer();
+                    }
+                    continue;
+                }
+
+                if (m_len >= MAX_MSG_LEN) {
+                    log.warn("command overflow at {} bytes; flushing", MAX_MSG_LEN);
+                    echo_buffer();
+                }
+
+                m_buffer[m_len++] = ch;
+                terminate();
+            }
+        }
+
+    protected:
+        void on_tick(uint32_t now_ms) override {
+            poll(now_ms);
+        }
+    };
+
+} // namespace pocketpd

--- a/lib/tempo/include/tempo/app/application.h
+++ b/lib/tempo/include/tempo/app/application.h
@@ -43,6 +43,7 @@ namespace tempo {
         // clang-format off
         static constexpr size_t MaxTasks           = DEFAULT_MAX_TASKS;
         static constexpr size_t EventQueueCapacity = DEFAULT_EVENT_QUEUE_CAP;
+        static constexpr const char* LOG_TAG = "Application";
 
         using Event           = TEvent;
         using Scheduler       = tempo::CooperativeScheduler<Event, MaxTasks, Stages...>;
@@ -60,16 +61,14 @@ namespace tempo {
 
         template <typename Derived>
         using UseLog          = tempo::UseLog<Derived>;
+
         template <typename Derived>
         using UsePublisher    = tempo::UsePublisher<Derived, Event>;
 
         using tempo::UseLog<Application>::log;
         // clang-format on
-
     private:
         static inline Application* instance = nullptr;
-
-        constexpr static const char* LOG_TAG = "Application";
 
         // —— External references
 

--- a/lib/tempo/include/tempo/hardware/stream.h
+++ b/lib/tempo/include/tempo/hardware/stream.h
@@ -1,6 +1,6 @@
 /**
  * @file stream.h
- * @brief Byte sink interface for log/diagnostic output.
+ * @brief Byte sink and source interfaces.
  */
 #pragma once
 #include <cstddef>
@@ -17,8 +17,8 @@ namespace tempo {
 
         /**
          * @brief Compile-time literal fast path.
-         * 
-         * @return size_t 
+         *
+         * @return size_t amount of bytes written
          */
         template <size_t N, typename T>
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
@@ -31,6 +31,25 @@ namespace tempo {
             );
             return write(literal, N - 1); // strip null terminator
         }
+    };
+
+    class StreamReader {
+    public:
+        virtual ~StreamReader() = default;
+
+        /**
+         * @brief Bytes ready to read
+         *
+         * @return Number of buffered bytes, or 0 when empty.
+         */
+        virtual int available() = 0;
+
+        /**
+         * @brief Pop one byte from the source.
+         *
+         * @return The next byte as 0..255, or -1 if no byte is available.
+         */
+        virtual int read() = 0;
     };
 
 } // namespace tempo

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,12 +10,14 @@
 #include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/arduino_clock.h"
 #include "v2/hal/arduino_output_gate.h"
+#include "v2/hal/arduino_stream_reader.h"
 #include "v2/hal/arduino_stream_writer.h"
 #include "v2/hal/ez_button_input.h"
 #include "v2/hal/ina226_power_monitor.h"
 #include "v2/hal/rotary_encoder_input.h"
 #include "v2/hal/u8g2_display.h"
 #include "v2/tasks/button_task.h"
+#include "v2/tasks/command_task.h"
 #include "v2/tasks/encoder_task.h"
 #include "v2/tasks/sensor_task.h"
 #include <AP33772.h>
@@ -23,14 +25,11 @@
 
 namespace {
 
-    pocketpd::ArduinoClock arduino_clock;
-    pocketpd::ArduinoStreamWriter arduino_stream_writer;
-    pocketpd::App app(arduino_clock, arduino_stream_writer);
 
     // —— Hardware adapters
 
-    ArduinoTwoWireDevice ap33772_i2c{Wire, ap33772::ADDRESS};
-    pocketpd::Ap33772PdSink pd_sink{ap33772_i2c, ::delay};
+    ArduinoTwoWireDevice i2c_device_ap33772{Wire, ap33772::ADDRESS};
+    pocketpd::Ap33772PdSink pd_sink{i2c_device_ap33772, ::delay};
 
     INA226 ina226_driver{pocketpd::INA226_I2C_ADDR};
     pocketpd::Ina226PowerMonitor power_monitor{ina226_driver};
@@ -44,6 +43,12 @@ namespace {
     pocketpd::EzButtonInput l_button{pin_button_selectVI};
     pocketpd::RotaryEncoderInput encoder{pin_encoder_A, pin_encoder_B};
 
+    pocketpd::ArduinoClock arduino_clock;
+    pocketpd::ArduinoStreamWriter arduino_stream_writer;
+    pocketpd::ArduinoStreamReader arduino_stream_reader;
+    
+    pocketpd::App app(arduino_clock, arduino_stream_writer);
+
     // —— Stages
 
     pocketpd::BootStage boot_stage(u8g2_display);
@@ -56,6 +61,7 @@ namespace {
     pocketpd::ButtonTask button_task(encoder_button, l_button, r_button);
     pocketpd::EncoderTask encoder_task(encoder);
     pocketpd::SensorTask sensor_task{power_monitor};
+    pocketpd::CommandTask command_task{arduino_stream_reader, arduino_stream_writer};
 
 } // namespace
 
@@ -82,6 +88,7 @@ void setup() {
     app.add_task(button_task);
     app.add_task(encoder_task);
     app.add_task(sensor_task);
+    app.add_task(command_task);
 
     app.start<pocketpd::BootStage>();
 }

--- a/test/mocks/MockStreamReader.h
+++ b/test/mocks/MockStreamReader.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <tempo/hardware/stream.h>
+
+#include <cstddef>
+#include <queue>
+#include <string>
+
+namespace pocketpd {
+
+    class MockStreamReader : public tempo::StreamReader {
+    public:
+        MOCK_METHOD(int, available, (), (override));
+        MOCK_METHOD(int, read, (), (override));
+    };
+
+    /**
+     * @brief Scripted StreamReader. `push(...)` enqueues bytes to be popped
+     * one at a time by `read()`. `available()` reports the queue size.
+     */
+    class FakeStreamReader : public tempo::StreamReader {
+    private:
+        std::queue<unsigned char> m_bytes;
+
+    public:
+        void push(const char* data, size_t len) {
+            for (size_t i = 0; i < len; ++i) {
+                m_bytes.push(static_cast<unsigned char>(data[i]));
+            }
+        }
+
+        void push(const std::string& s) {
+            push(s.data(), s.size());
+        }
+
+        int available() override {
+            return static_cast<int>(m_bytes.size());
+        }
+
+        int read() override {
+            if (m_bytes.empty()) {
+                return -1;
+            }
+            const int byte = m_bytes.front();
+            m_bytes.pop();
+            return byte;
+        }
+    };
+
+} // namespace pocketpd

--- a/test/mocks/MockStreamWriter.h
+++ b/test/mocks/MockStreamWriter.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <tempo/hardware/stream.h>
+
+#include <cstddef>
+#include <string>
+
+namespace pocketpd {
+
+    class MockStreamWriter : public tempo::StreamWriter {
+    public:
+        MOCK_METHOD(size_t, write, (const char* data, size_t len), (override));
+        MOCK_METHOD(void, flush, (), (override));
+    };
+
+    /**
+     * @brief Recording StreamWriter. Appends every write to `captured` so tests
+     * can assert on log / echo output.
+     */
+    class CapturingStreamWriter : public tempo::StreamWriter {
+    public:
+        std::string captured;
+        size_t write_calls = 0;
+        size_t flush_calls = 0;
+
+        size_t write(const char* data, size_t len) override {
+            captured.append(data, len);
+            ++write_calls;
+            return len;
+        }
+
+        void flush() override {
+            ++flush_calls;
+        }
+
+        void clear() {
+            captured.clear();
+            write_calls = 0;
+            flush_calls = 0;
+        }
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_command/test.cpp
+++ b/test/test_v2_command/test.cpp
@@ -1,0 +1,165 @@
+/**
+ * GoogleTest suite for CommandTask.
+ *
+ * Drives a FakeStreamReader through scripted byte sequences and asserts the
+ * task echoes complete lines through the attached Logger (CapturingStreamWriter
+ * captures the bytes the Logger emits).
+ *
+ * The Application singleton is constructed once at namespace scope so its
+ * `add_task` can attach a real Logger to the task under test.
+ */
+#define VERSION "\"test\""
+
+#include <MockStreamReader.h>
+#include <MockStreamWriter.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/core/time.h>
+
+#include <cstdint>
+#include <string>
+
+#include "v2/app.h"
+#include "v2/tasks/command_task.h"
+
+using namespace pocketpd;
+
+namespace {
+
+    class FixedClock : public tempo::Clock {
+    public:
+        uint32_t now = 0;
+        uint32_t now_ms() const override {
+            return now;
+        }
+    };
+
+    FixedClock& shared_clock() {
+        static FixedClock c;
+        return c;
+    }
+
+    CapturingStreamWriter& shared_writer() {
+        static CapturingStreamWriter w;
+        return w;
+    }
+
+    /**
+     * @brief Build the Application singleton on first access. Tempo only
+     * permits one Application per binary, so all CommandTask tests share it.
+     */
+    App& shared_app() {
+        static App app{shared_clock(), shared_writer()};
+        return app;
+    }
+
+    constexpr uint32_t TICK_MS = 0;
+
+} // namespace
+
+class CommandTaskTest : public ::testing::Test {
+protected:
+    FakeStreamReader reader;
+    CommandTask task{reader, shared_writer()};
+
+    void SetUp() override {
+        shared_writer().clear();
+        shared_app().add_task(task);
+    }
+};
+
+TEST_F(CommandTaskTest, EmptySourceProducesNoOutput) {
+    task.poll(TICK_MS);
+    EXPECT_TRUE(shared_writer().captured.empty());
+}
+
+TEST_F(CommandTaskTest, EchoesLineOnNewline) {
+    reader.push("hello\n");
+    task.poll(TICK_MS);
+
+    EXPECT_NE(shared_writer().captured.find("hello"), std::string::npos);
+    EXPECT_EQ(reader.available(), 0);
+}
+
+TEST_F(CommandTaskTest, EchoesLineOnCarriageReturn) {
+    reader.push("hello\r");
+    task.poll(TICK_MS);
+
+    EXPECT_NE(shared_writer().captured.find("hello"), std::string::npos);
+    EXPECT_EQ(reader.available(), 0);
+}
+
+TEST_F(CommandTaskTest, NoEchoBeforeTerminator) {
+    reader.push("hello");
+    task.poll(TICK_MS);
+
+    EXPECT_EQ(shared_writer().captured.find("hello"), std::string::npos);
+    EXPECT_EQ(reader.available(), 0);
+}
+
+TEST_F(CommandTaskTest, PartialLineThenTerminatorEchoesFullLine) {
+    reader.push("hel");
+    task.poll(TICK_MS);
+    EXPECT_EQ(shared_writer().captured.find("hello"), std::string::npos);
+
+    reader.push("lo\n");
+    task.poll(TICK_MS);
+
+    EXPECT_NE(shared_writer().captured.find("hello"), std::string::npos);
+}
+
+TEST_F(CommandTaskTest, EmptyLinesAreIgnored) {
+    reader.push("\n\r\n");
+    task.poll(TICK_MS);
+
+    EXPECT_TRUE(shared_writer().captured.empty());
+    EXPECT_EQ(reader.available(), 0);
+}
+
+TEST_F(CommandTaskTest, MultipleLinesInSinglePoll) {
+    reader.push("alpha\nbeta\n");
+    task.poll(TICK_MS);
+
+    const std::string& out = shared_writer().captured;
+    const auto alpha = out.find("alpha");
+    const auto beta = out.find("beta");
+    ASSERT_NE(alpha, std::string::npos);
+    ASSERT_NE(beta, std::string::npos);
+    EXPECT_LT(alpha, beta);
+    EXPECT_EQ(reader.available(), 0);
+}
+
+TEST_F(CommandTaskTest, OverflowFlushesAndContinues) {
+    constexpr size_t MAX_MSG_LEN = 127;
+    const std::string overflow(MAX_MSG_LEN + 5, 'x');
+    reader.push(overflow);
+    reader.push("\n");
+    reader.push("next\n");
+    task.poll(TICK_MS);
+
+    const std::string& out = shared_writer().captured;
+    const auto first_x = out.find('x');
+    const auto next_pos = out.find("next");
+    ASSERT_NE(first_x, std::string::npos);
+    ASSERT_NE(next_pos, std::string::npos);
+    EXPECT_LT(first_x, next_pos);
+    EXPECT_EQ(reader.available(), 0);
+}
+
+TEST_F(CommandTaskTest, TwoSeparatePollsHandleSeparateLines) {
+    reader.push("first\n");
+    task.poll(TICK_MS);
+    const auto first_size = shared_writer().captured.size();
+
+    reader.push("second\n");
+    task.poll(TICK_MS);
+
+    EXPECT_NE(shared_writer().captured.find("first"), std::string::npos);
+    EXPECT_NE(shared_writer().captured.find("second"), std::string::npos);
+    EXPECT_GT(shared_writer().captured.size(), first_size);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
Adds a `CommandTask` that polls the host UART for line-based commands and echoes each completed line back via the existing `Logger`. The task line-buffers up to 127 bytes (one slot reserved for the null terminator), flushes on `\n` / `\r`, and resets on overflow. 

To support testability and keep the HAL boundary clean, this also introduces `tempo::StreamReader` as the symmetric counterpart to `tempo::StreamWriter`.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested:
- `pio run -e HW1_3_V2` — clean build, 132916 B flash
- `pio test -e native` — 91/91 tests pass, including 9 new `test_v2_command` cases covering newline / CR termination, partial lines across polls, multi-line single poll, empty-line skip, overflow flush + continue, and two-poll separation
- `pio test -e native -d lib/tempo` — 31/31 tempo tests pass

<img width="1433" height="531" alt="Screenshot 2026-05-08 at 1 42 45 AM" src="https://github.com/user-attachments/assets/1fff5e67-0768-4bd1-906f-8776828bd467" />


## Breaking change / migration

Details:

## Notes
- `Application::LOG_TAG` moved from private to public so the `has_log_tag` SFINAE detection sees it; bundled into the same tempo commit.
- `.clang-tidy` disables `cppcoreguidelines-pro-bounds-constant-array-index` for the []-index access pattern in `CommandTask`.