### PR TITLE
feat(v2): animate arrow bitmap while output enabled

### DIFF
--- a/include/v2/hal/u8g2_display.h
+++ b/include/v2/hal/u8g2_display.h
@@ -53,6 +53,12 @@ namespace pocketpd {
             m_u8g2.drawBitmap(x, y, width_bytes, height, data);
         }
 
+        void draw_xbm(
+            uint8_t x, uint8_t y, uint8_t width, uint8_t height, const uint8_t* data
+        ) override {
+            m_u8g2.drawXBMP(x, y, width, height, data);
+        }
+
         void draw_text(uint8_t x, uint8_t y, const char* text) override {
             m_u8g2.drawStr(x, y, text);
         }

--- a/include/v2/stages/normal/normal_view.h
+++ b/include/v2/stages/normal/normal_view.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstdio>
 
+#include "v2/images.h"
 #include "v2/pocketpd.h"
 #include "v2/state.h"
 
@@ -24,6 +25,7 @@ namespace pocketpd {
         bool has_profile = false;
         bool is_pps = false;
         bool output_enabled = false;
+        uint8_t arrow_frame = 0;
         SensorSnapshot snapshot{};
 
         // —— PPS branch (valid when has_profile && is_pps)
@@ -48,6 +50,10 @@ namespace pocketpd {
         static constexpr uint8_t TARGET_RIGHT_X = 75;
         static constexpr uint8_t STATUS_X = 110;
         static constexpr uint8_t OUTPUT_LABEL_X = 90;
+        static constexpr uint8_t ARROW_X = 105;
+        static constexpr uint8_t ARROW_Y = 0;
+        static constexpr uint8_t ARROW_W = 20;
+        static constexpr uint8_t ARROW_H = 20;
         static constexpr std::array<uint8_t, 3> CURSOR_X = {45, 39, 33};
         static constexpr uint8_t CURSOR_W = 6;
 
@@ -78,6 +84,11 @@ namespace pocketpd {
                 draw_target_pps(d, vm, buf);
             } else {
                 draw_target_fixed(d, vm, buf);
+            }
+
+            if (vm.output_enabled) {
+                const uint8_t frame = vm.arrow_frame % bitmap::ARROW_FRAMES.size();
+                d.draw_xbm(ARROW_X, ARROW_Y, ARROW_W, ARROW_H, bitmap::ARROW_FRAMES.at(frame));
             }
 
             d.flush();

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -35,6 +35,7 @@ namespace pocketpd {
         int8_t m_last_active_index = -1;
         Mode m_mode;
         tempo::IntervalTimer m_render_interval{40};
+        uint8_t m_arrow_frame = 0;
 
         uint32_t m_last_draw_ms = 0;
         static constexpr uint32_t SENSOR_EMA_DEN = 4;
@@ -212,6 +213,7 @@ namespace pocketpd {
                 .active_pdo_index = m_active_pdo_index,
                 .has_profile = m_active_pdo_index >= 0,
                 .output_enabled = m_output_gate.is_enabled(),
+                .arrow_frame = m_arrow_frame,
                 .snapshot = m_snapshot,
             };
 
@@ -239,6 +241,9 @@ namespace pocketpd {
 
         void draw() {
             NormalView::render(m_display, build_view_model());
+            if (m_output_gate.is_enabled()) {
+                m_arrow_frame = (m_arrow_frame + 1) % pocketpd::bitmap::ARROW_FRAMES.size();
+            }
         }
     };
 

--- a/lib/tempo/include/tempo/hardware/display.h
+++ b/lib/tempo/include/tempo/hardware/display.h
@@ -45,6 +45,16 @@ namespace tempo {
         ) = 0;
 
         /**
+         * @brief Draw an XBM-format bitmap. Each byte packs 8 horizontal pixels with the
+         * least-significant bit at the leftmost position (XBM convention, opposite of
+         * `draw_bitmap`). Each row is `ceil(width / 8)` bytes; rows are stored top-to-bottom.
+         *
+         */
+        virtual void draw_xbm(
+            uint8_t x, uint8_t y, uint8_t width, uint8_t height, const uint8_t* data
+        ) = 0;
+
+        /**
          * @brief Draw text at the given coordinates. Text is drawn using the current font.
          *
          */

--- a/test/mocks/MockDisplay.h
+++ b/test/mocks/MockDisplay.h
@@ -16,6 +16,12 @@ namespace pocketpd {
             (uint8_t x, uint8_t y, uint8_t width_bytes, uint8_t height, const uint8_t* data),
             (override)
         );
+        MOCK_METHOD(
+            void,
+            draw_xbm,
+            (uint8_t x, uint8_t y, uint8_t width, uint8_t height, const uint8_t* data),
+            (override)
+        );
         MOCK_METHOD(void, draw_text, (uint8_t x, uint8_t y, const char* text), (override));
         MOCK_METHOD(uint16_t, text_width, (const char* text), (override));
         MOCK_METHOD(void, draw_box, (uint8_t x, uint8_t y, uint8_t w, uint8_t h), (override));


### PR DESCRIPTION
## Summary
NormalStage now animates the arrow bitmap on the OLED while the output is enabled. Each draw advances the frame index modulo `bitmap::ARROW_FRAMES.size()`; when the output is disabled the frame freezes.

 Required adding `Display::draw_xbm` to the tempo HAL since u8g2's bitmaps and XBM bitmaps have opposite bit ordering. 

## Linked issues

## Hardware tested
- [x ] HW1_3

How tested:
- `pio run -e HW1_3_V2` — clean build
- `pio test -e native` — full suite passes; `MockDisplay` extended with `draw_xbm` mock so render-only tests still match expectations

https://github.com/user-attachments/assets/7d01ee85-4117-4eb2-af20-96014a50fb12


## Breaking change / migration
<!-- - [x] Public lib API (`lib/*` headers) -->
Details:
`tempo::Display` gains one new pure virtual `draw_xbm(...)`. Any out-of-tree implementer of `Display` must add an override.

## Notes