### PR TITLE
feat(v2): disable output on NormalStage profile change

### DIFF
--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -83,6 +83,11 @@ namespace pocketpd {
         }
 
         void on_enter(Conductor&) override {
+            // Turns off output if the profile has changed
+            if (m_active_pdo_index != m_last_active_index) {
+                m_output_gate.disable();
+            }
+
             if (m_active_pdo_index < 0) {
                 m_last_active_index = -1;
                 log.info("Entered with no profile selected");

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -191,14 +191,16 @@ TEST(NormalStage, EncoderEventsIgnoredInPdoBranch) {
     EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
     EXPECT_CALL(sink, set_pps_pdo).Times(0);
-    EXPECT_CALL(gate, enable).Times(0);
-    EXPECT_CALL(gate, disable).Times(0);
 
     NormalStage normal(display, sink, gate);
     TestConductor conductor;
     conductor.register_stage(normal);
     normal.prepare(0);
     conductor.start<NormalStage>();
+
+    ::testing::Mock::VerifyAndClearExpectations(&gate);
+    EXPECT_CALL(gate, enable).Times(0);
+    EXPECT_CALL(gate, disable).Times(0);
 
     normal.on_event(conductor, EncoderEvent{3}, 0);
     EXPECT_FALSE(conductor.has_pending());


### PR DESCRIPTION
## Summary
On entry to `NormalStage` with a different PDO than last time, force the output FET off. Without this, switching between profiles carries the prior FET state across, so a load that was fine on the old profile (e.g. 15 V / 3 A fixed) can pull more current than the new profile allows (e.g. 5 V / 1 A PPS) the moment the request lands, tripping the source before the user has a chance to adjust the config.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested: built `HW1_3_V2` firmware and ran the native suite (91 tests pass). On-device verification still TODO.

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details: output now starts in the OFF state every time the active profile changes (and on first entry to NormalStage). Same-profile re-entry (e.g. NormalStage → ProfilePicker → NormalStage with the same PDO selected) preserves the prior FET state.

## Notes