### PR TITLE
feat(v2): add EnergyStage and EnergyTask for energy totals

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ ColumnLimit: 100
 IndentWidth: 4
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: BlockIndent
+AlignAfterOpenBracket: Align
 AlignConsecutiveMacros: Consecutive
 AlignOperands: AlignAfterOperator
 AllowShortFunctionsOnASingleLine: Empty

--- a/include/v2/app.h
+++ b/include/v2/app.h
@@ -20,6 +20,7 @@ namespace pocketpd {
     class ObtainStage;
     class ProfilePickerStage;
     class NormalStage;
+    class EnergyStage;
 
     // —— Can also define events here as well
 
@@ -32,7 +33,8 @@ namespace pocketpd {
 
     // —— Define the application alias which is a combination of Events and Stages
 
-    using App = tempo::Application<Event, BootStage, ObtainStage, ProfilePickerStage, NormalStage>;
+    using App = tempo::Application<
+        Event, BootStage, ObtainStage, ProfilePickerStage, NormalStage, EnergyStage>;
 } // namespace pocketpd
 
 /*
@@ -58,6 +60,7 @@ namespace pocketpd {
  * and the concrete stage types in one shot.
  */
 #include "v2/stages/boot_stage.h"
+#include "v2/stages/energy_stage.h"
 #include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
 #include "v2/stages/profile_picker_stage.h"

--- a/include/v2/events.h
+++ b/include/v2/events.h
@@ -51,6 +51,15 @@ namespace pocketpd {
         SensorSnapshot snapshot;
     };
 
-    using Event = tempo::Events<PdReadyEvent, ButtonEvent, EncoderEvent, SensorEvent>;
+    /**
+     * @brief Published by EnergyTask
+     */
+    struct EnergyEvent {
+        double accumulated_wh = 0.0;
+        double accumulated_ah = 0.0;
+        uint32_t total_seconds = 0;
+    };
+
+    using Event = tempo::Events<PdReadyEvent, ButtonEvent, EncoderEvent, SensorEvent, EnergyEvent>;
 
 } // namespace pocketpd

--- a/include/v2/hal/output_gate.h
+++ b/include/v2/hal/output_gate.h
@@ -14,6 +14,14 @@ namespace pocketpd {
         virtual void enable() = 0;
         virtual void disable() = 0;
         virtual bool is_enabled() const = 0;
+
+        void toggle() {
+            if (is_enabled()) {
+                disable();
+            } else {
+                enable();
+            }
+        }
     };
 
 } // namespace pocketpd

--- a/include/v2/hal/u8g2_display.h
+++ b/include/v2/hal/u8g2_display.h
@@ -39,7 +39,7 @@ namespace pocketpd {
                 m_u8g2.setFont(u8g2_font_profont12_tr);
                 break;
             case tempo::Font::LG:
-                m_u8g2.setFont(u8g2_font_profont15_tr);
+                m_u8g2.setFont(u8g2_font_profont17_tr);
                 break;
             case tempo::Font::XL:
                 m_u8g2.setFont(u8g2_font_profont22_tr);

--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -25,27 +25,11 @@ namespace pocketpd {
     constexpr uint32_t PROFILE_PICKER_REVIEW_TO_NORMAL_MS = 3000;
 
     /**
-     * @brief Which PD protocol the active charger speaks.
-     */
-    enum class Profile : uint8_t {
-        PPS,
-        PDO,
-    };
-
-    /**
      * @brief What the rotary encoder is currently editing.
      */
     enum class AdjustMode : uint8_t {
         VOLTAGE,
         CURRENT,
-    };
-
-    /**
-     * @brief Main output screen vs. energy/coulomb counter screen.
-     */
-    enum class OutputScreen : uint8_t {
-        NORMAL,
-        ENERGY,
     };
 
     /**

--- a/include/v2/stages/energy/energy_view.h
+++ b/include/v2/stages/energy/energy_view.h
@@ -1,0 +1,154 @@
+/**
+ * @file energy_view.h
+ * @brief View layer for the Energy display mode of NormalStage.
+ *
+ */
+#pragma once
+
+#include <tempo/hardware/display.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+
+#include "v2/images.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    /**
+     * @brief Frozen snapshot of everything EnergyView needs to draw one frame.
+     */
+    struct EnergyViewModel {
+        SensorSnapshot snapshot{};
+        double accumulated_wh = 0.0;
+        double accumulated_ah = 0.0;
+        uint32_t total_seconds = 0;
+        uint8_t arrow_frame = 0;
+        bool output_enabled = false;
+    };
+
+    class EnergyView {
+    private:
+        static constexpr uint8_t ROW1_Y = 10;
+        static constexpr uint8_t ROW2_Y = 35;
+        static constexpr uint8_t ROW3_Y = 55;
+
+        static constexpr uint8_t COL1_X = 4;
+        static constexpr uint8_t COL2_X = 70;
+
+        static constexpr uint8_t ROW1_V_X = 4;
+        static constexpr uint8_t ROW1_A_X = 48;
+
+        static constexpr uint8_t ARROW_X = 105;
+        static constexpr uint8_t ARROW_Y = 0;
+        static constexpr uint8_t ARROW_W = 20;
+        static constexpr uint8_t ARROW_H = 20;
+
+        static constexpr uint8_t UNIT_GAP_PX = 2;
+
+        using Display = tempo::Display;
+
+    public:
+        static void render(Display& display, const EnergyViewModel& vm) {
+            display.clear();
+            std::array<char, 16> buf{};
+
+            // The output arrow >>
+            if (vm.output_enabled) {
+                const auto frame = vm.arrow_frame % bitmap::ARROW_FRAMES.size();
+                const auto bitmap = bitmap::ARROW_FRAMES[frame];
+                display.draw_xbm(ARROW_X, ARROW_Y, ARROW_W, ARROW_H, bitmap);
+            }
+
+            // Top row — live V/A
+            display.set_font(tempo::Font::BASE);
+
+            format_milli(buf, vm.snapshot.vbus_mv, 'V');
+            display.draw_text(ROW1_V_X, ROW1_Y, buf.data());
+
+            format_milli(buf, vm.snapshot.current_ma, 'A');
+            display.draw_text(ROW1_A_X, ROW1_Y, buf.data());
+
+            // Mid — watts and watt-hours
+            display.set_font(tempo::Font::LG);
+            const double watts = (vm.snapshot.vbus_mv * vm.snapshot.current_ma) / 1'000'000.0;
+
+            format_auto(buf, watts);
+            draw_value(display, COL1_X, ROW2_Y, buf.data(), "W");
+
+            format_auto(buf, vm.accumulated_wh);
+            draw_value(display, COL2_X, ROW2_Y, buf.data(), "Wh");
+
+            // Bottom — time and amp-hours
+            format_time(buf, vm.total_seconds);
+            display.draw_text(COL1_X, ROW3_Y, buf.data());
+
+            format_auto(buf, vm.accumulated_ah);
+            draw_value(display, COL2_X, ROW3_Y, buf.data(), "Ah");
+
+            display.flush();
+        }
+
+    private:
+        /**
+         * @brief Render a value at (x,y) followed by a unit label 2 px to the right.
+         */
+        static void
+        draw_value(Display& display, uint8_t x, uint8_t y, const char* value, const char* unit) {
+            display.draw_text(x, y, value);
+            const auto w = display.text_width(value);
+            display.draw_text(static_cast<uint8_t>(x + w + UNIT_GAP_PX), y, unit);
+        }
+
+        /**
+         * @brief Format milli-units (mV / mA) as `X.YY<unit>` packed into one string.
+         */
+        static void format_milli(std::array<char, 16>& buf, uint32_t milli, char unit) {
+            std::snprintf(buf.data(), buf.size(), "%.2f%c", milli / 1000.0, unit);
+        }
+
+        /**
+         * @brief Auto-pick 2/1/0 decimal places by magnitude.
+         */
+        static void format_auto(std::array<char, 16>& buf, double value) {
+            if (value < 10.0) {
+                std::snprintf(buf.data(), buf.size(), "%.2f", value);
+            } else if (value < 100.0) {
+                std::snprintf(buf.data(), buf.size(), "%.1f", value);
+            } else {
+                std::snprintf(buf.data(), buf.size(), "%.0f", value);
+            }
+        }
+
+        /**
+         * @brief Format elapsed seconds as `MM:SS` (< 1 h), `HhMMm` (< 1 d), or `DdHHh` (≥ 1 d).
+         */
+        static void format_time(std::array<char, 16>& buf, uint32_t secs) {
+            constexpr uint32_t SEC_PER_MIN = 60;
+            constexpr uint32_t SEC_PER_HOUR = 3600;
+            constexpr uint32_t SEC_PER_DAY = 86400;
+
+            unsigned long lhs = 0;
+            unsigned long rhs = 0;
+            const char* fmt = nullptr;
+
+            if (secs < SEC_PER_HOUR) {
+                lhs = secs / SEC_PER_MIN;
+                rhs = secs % SEC_PER_MIN;
+                fmt = "%02lu:%02lu";
+            } else if (secs < SEC_PER_DAY) {
+                lhs = secs / SEC_PER_HOUR;
+                rhs = (secs % SEC_PER_HOUR) / SEC_PER_MIN;
+                fmt = "%luh%02lum";
+            } else {
+                lhs = secs / SEC_PER_DAY;
+                rhs = (secs % SEC_PER_DAY) / SEC_PER_HOUR;
+                fmt = "%lud%02luh";
+            }
+
+            std::snprintf(buf.data(), buf.size(), fmt, lhs, rhs);
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/energy_stage.h
+++ b/include/v2/stages/energy_stage.h
@@ -1,0 +1,131 @@
+/**
+ * @file energy_stage.h
+ * @brief Energy display stage.
+ *
+ * Entered via R LONG from `NormalStage`. Renders Wh / Ah / on-time alongside live V / A. The active
+ * PDO index is passed via `prepare(int8_t)` so R LONG returns to `NormalStage` with the same
+ * profile.
+ *
+ * Inputs handled:
+ *   - R SHORT: toggle `OutputGate` (output stays editable while viewing energy).
+ *   - R LONG:  return to `NormalStage(active_pdo_index)`.
+ *   - All other gestures + EncoderEvents are ignored.
+ */
+#pragma once
+
+#include <tempo/bus/visit.h>
+#include <tempo/core/time.h>
+#include <tempo/hardware/display.h>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/hal/output_gate.h"
+#include "v2/images.h"
+#include "v2/stages/energy/energy_view.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    class EnergyStage : public App::Stage, public App::UseLog<EnergyStage> {
+    private:
+        using Display = tempo::Display;
+
+        Display& m_display;
+        OutputGate& m_output_gate;
+        SensorSnapshot m_snapshot{};
+        bool m_snapshot_seeded = false;
+        EnergyEvent m_energy{};
+        int8_t m_active_pdo_index = -1;
+        tempo::IntervalTimer m_render_interval{40};
+        uint8_t m_arrow_frame = 0;
+
+        static constexpr uint32_t SENSOR_EMA_DEN = 4;
+
+    public:
+        static constexpr const char* LOG_TAG = "EnergyStage";
+
+        EnergyStage(Display& display, OutputGate& output_gate)
+            : m_display(display), m_output_gate(output_gate) {}
+
+        const char* name() const override {
+            return LOG_TAG;
+        }
+
+        int8_t active_pdo_index() const {
+            return m_active_pdo_index;
+        }
+
+        void prepare(int8_t pdo_index = -1) {
+            m_active_pdo_index = pdo_index;
+        }
+
+        void on_enter(Conductor&) override {
+            log.info("Entered Energy screen pdo_index={}", m_active_pdo_index);
+            draw();
+        }
+
+        void on_tick(Conductor&, uint32_t now_ms) override {
+            if (m_render_interval.tick(now_ms)) {
+                draw();
+            }
+        }
+
+        void on_event(Conductor& conductor, const Event& event, uint32_t) override {
+            auto handler = tempo::overloaded{
+                [&](const ButtonEvent& evt) {
+                    if (evt.id != ButtonId::R) {
+                        return;
+                    }
+                    if (evt.gesture == Gesture::SHORT) {
+                        m_output_gate.toggle();
+                        return;
+                    }
+                    if (evt.gesture == Gesture::LONG) {
+                        conductor.request<NormalStage>(m_active_pdo_index);
+                    }
+                },
+                [&](const SensorEvent& evt) { ema_filter(evt.snapshot); },
+                [&](const EnergyEvent& evt) { m_energy = evt; },
+                [](const auto&) {},
+            };
+
+            std::visit(handler, event);
+        }
+
+    private:
+        /**
+         * @brief Apply EMA smoothing to displayed mV / mA. Same shape as
+         * NormalStage so the readout is consistent across screens.
+         */
+        void ema_filter(const SensorSnapshot& s) {
+            if (!m_snapshot_seeded) {
+                m_snapshot = s;
+                m_snapshot_seeded = true;
+                return;
+            }
+            const uint32_t a = SENSOR_EMA_DEN - 1;
+            m_snapshot.vbus_mv = (m_snapshot.vbus_mv * a + s.vbus_mv) / SENSOR_EMA_DEN;
+            m_snapshot.current_ma = (m_snapshot.current_ma * a + s.current_ma) / SENSOR_EMA_DEN;
+            m_snapshot.timestamp_ms = s.timestamp_ms;
+        }
+
+        EnergyViewModel build_view_model() const {
+            return EnergyViewModel{
+                .snapshot = m_snapshot,
+                .accumulated_wh = m_energy.accumulated_wh,
+                .accumulated_ah = m_energy.accumulated_ah,
+                .total_seconds = m_energy.total_seconds,
+                .arrow_frame = m_arrow_frame,
+                .output_enabled = m_output_gate.is_enabled(),
+            };
+        }
+
+        void draw() {
+            EnergyView::render(m_display, build_view_model());
+            if (m_output_gate.is_enabled()) {
+                m_arrow_frame = (m_arrow_frame + 1) % pocketpd::bitmap::ARROW_FRAMES.size();
+            }
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -26,19 +26,25 @@ namespace pocketpd {
     class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
         using Display = tempo::Display;
+        using IntervalTimer = tempo::IntervalTimer;
 
         Display& m_display;
         PdSinkController& m_pd_sink;
         OutputGate& m_output_gate;
+
         SensorSnapshot m_snapshot{};
+        bool m_snapshot_init = false;
+
         int8_t m_active_pdo_index = -1;
         int8_t m_last_active_index = -1;
         Mode m_mode;
-        tempo::IntervalTimer m_render_interval{40};
-        uint8_t m_arrow_frame = 0;
 
+        IntervalTimer m_render_interval{40};
+        uint8_t m_arrow_frame = 0;
         uint32_t m_last_draw_ms = 0;
+
         static constexpr uint32_t SENSOR_EMA_DEN = 4;
+
     public:
         static constexpr const char* LOG_TAG = "Normal";
 
@@ -121,11 +127,12 @@ namespace pocketpd {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::R && evt.gesture == Gesture::SHORT) {
-                        if (m_output_gate.is_enabled()) {
-                            m_output_gate.disable();
-                        } else {
-                            m_output_gate.enable();
-                        }
+                        m_output_gate.toggle();
+                        return;
+                    }
+
+                    if (evt.id == ButtonId::R && evt.gesture == Gesture::LONG) {
+                        conductor.request<EnergyStage>(m_active_pdo_index);
                         return;
                     }
 
@@ -162,8 +169,9 @@ namespace pocketpd {
          * @brief Apply EMA smoothing to displayed mV / mA.
          */
         void ema_filter(const SensorSnapshot& s) {
-            if (!m_snapshot.valid) {
+            if (!m_snapshot_init) {
                 m_snapshot = s;
+                m_snapshot_init = true;
                 return;
             }
 
@@ -173,7 +181,6 @@ namespace pocketpd {
             m_snapshot.vbus_mv = (m_snapshot.vbus_mv * a + s.vbus_mv) / SENSOR_EMA_DEN;
             m_snapshot.current_ma = (m_snapshot.current_ma * a + s.current_ma) / SENSOR_EMA_DEN;
             m_snapshot.timestamp_ms = s.timestamp_ms;
-            m_snapshot.valid = s.valid;
         }
 
         /**

--- a/include/v2/state.h
+++ b/include/v2/state.h
@@ -1,17 +1,10 @@
 /**
  * @file state.h
- * @brief Shared runtime state structs and input enums.
- *
- * One `SensorSnapshot` and one `UiState` instance lives in main.cpp; both are
- * passed by reference into every Stage and Task. Stages may mutate UiState;
- * SensorTask is the only writer for SensorSnapshot. No globals.
- *
+ * @brief Shared input enums + sensor reading struct.
  */
 #pragma once
 
 #include <cstdint>
-
-#include "v2/pocketpd.h"
 
 namespace pocketpd {
 
@@ -32,62 +25,11 @@ namespace pocketpd {
 
     /**
      * @brief Latest sensor reading from INA226.
-     *
-     * Updated by SensorTask at 33 ms period inside Normal stages. Read-only
-     * for everything else. `valid` is false until the first successful read.
      */
     struct SensorSnapshot {
         uint32_t timestamp_ms = 0;
         uint32_t vbus_mv = 0;
         uint32_t current_ma = 0;
-        bool valid = false;
-    };
-
-    /**
-     * @brief Persistent UI / app state across stage transitions.
-     *
-     * Lifetime equals the lifetime of the app. EEPROM mirrors a subset
-     * (target_mv, target_ma, active_pdo_index).
-     */
-    struct UiState {
-        // —— PD request
-
-        int32_t target_mv = 5000; // issue #33: deterministic boot default
-        int32_t target_ma = 1000;
-        uint8_t active_pdo_index = 0;
-
-        // —— Encoder edit
-
-        uint8_t voltage_idx = 0;
-        uint8_t current_idx = 0;
-        AdjustMode adjust_mode = AdjustMode::VOLTAGE;
-
-        // —— Output
-
-        bool output_on = false;
-        OutputScreen screen = OutputScreen::NORMAL;
-
-        // —— Animation (driven by BlinkTask at 500 ms)
-
-        bool cursor_visible = true;
-        uint8_t arrow_frame = 0;
-
-        // —— Autosave bookkeeping (Normal stages only)
-
-        uint32_t last_edit_ms = 0;
-        bool dirty = false;
-        bool force_save = false;
-
-        // —— Energy accumulator (Normal stages, output enabled)
-
-        double accumulated_wh = 0.0;
-        double accumulated_ah = 0.0;
-        uint32_t output_session_start_ms = 0;
-        uint32_t historical_output_seconds = 0;
-
-        // —— Lock
-
-        bool input_locked = false; // issue #36 hook; always false in parity port
     };
 
 } // namespace pocketpd

--- a/include/v2/tasks/energy_task.h
+++ b/include/v2/tasks/energy_task.h
@@ -1,0 +1,103 @@
+/**
+ * @file energy_task.h
+ * @brief Calculate running total of energy outputs and publish them across the application
+ *
+ */
+#pragma once
+
+#include <cstdint>
+#include <variant>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/hal/output_gate.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    class EnergyTask : public App::StageScopedTask, public App::UsePublisher<EnergyTask> {
+    private:
+        OutputGate& m_output_gate;
+
+        double m_accumulated_wh = 0.0;
+        double m_accumulated_ah = 0.0;
+        uint32_t m_accumulated_ms = 0;
+
+        uint32_t m_last_update_ms = 0;
+        bool m_session_active = false;
+
+    public:
+        static constexpr uint32_t PERIOD_MS = 100;
+
+        EnergyTask(OutputGate& output_gate)
+            : App::StageScopedTask(
+                  PERIOD_MS, App::StageMask::of<NormalStage, EnergyStage, ProfilePickerStage>()),
+              m_output_gate(output_gate) {}
+
+        const char* name() const override {
+            return "EnergyTask";
+        }
+
+        double accumulated_wh() const {
+            return m_accumulated_wh;
+        }
+
+        double accumulated_ah() const {
+            return m_accumulated_ah;
+        }
+
+        uint32_t total_seconds() const {
+            return m_accumulated_ms / 1000;
+        }
+
+        void on_event(const Event& event, uint32_t) override {
+            if (const auto sensor = std::get_if<SensorEvent>(&event)) {
+                integrate(sensor->snapshot);
+            }
+        }
+
+        void on_tick(uint32_t) override {
+            const EnergyEvent event = {
+                m_accumulated_wh,
+                m_accumulated_ah,
+                total_seconds(),
+            };
+
+            publish(event);
+        }
+
+    private:
+        void integrate(const SensorSnapshot& s) {
+            if (!m_output_gate.is_enabled()) {
+                m_session_active = false;
+                return;
+            }
+
+            // Output just turned on so skipping integration (no prior delta) as we only want to
+            // integrate over a continuous range
+            if (!m_session_active) {
+                m_session_active = true;
+                m_last_update_ms = s.timestamp_ms;
+                return;
+            }
+
+            const uint32_t delta_ms = s.timestamp_ms - m_last_update_ms;
+            m_last_update_ms = s.timestamp_ms;
+
+            // Stall guard: if the sensor stopped firing for >= 1 s, the load may have changed
+            // during the gap — discard rather than attribute energy to a possibly stale V/I
+            // reading.
+            if (delta_ms >= 1000) {
+                return;
+            }
+
+            m_accumulated_ms += delta_ms;
+            const double voltage_v = s.vbus_mv / 1000.0;
+            const double current_a = s.current_ma / 1000.0;
+            const double delta_h = delta_ms / 3600000.0;
+            m_accumulated_wh += voltage_v * current_a * delta_h;
+            m_accumulated_ah += current_a * delta_h;
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/tasks/sensor_task.h
+++ b/include/v2/tasks/sensor_task.h
@@ -22,19 +22,18 @@ namespace pocketpd {
         static constexpr uint32_t PERIOD_MS = 33;
 
         explicit SensorTask(PowerMonitor& monitor)
-            : App::StageScopedTask(PERIOD_MS, App::StageMask::of<NormalStage>()),
+            : App::StageScopedTask(
+                  PERIOD_MS,
+                  App::StageMask::of<NormalStage, EnergyStage, ProfilePickerStage>()
+              ),
               m_monitor(monitor) {}
 
         void on_tick(uint32_t now_ms) override {
             const auto reading = m_monitor.read();
-            SensorSnapshot snapshot{
-                now_ms,
-                reading.mv,
-                reading.ma,
-                reading.valid,
-            };
-            
-            publish(SensorEvent{snapshot});
+            if (!reading.valid) {
+                return;
+            }
+            publish(SensorEvent{SensorSnapshot{now_ms, reading.mv, reading.ma}});
         }
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "v2/tasks/button_task.h"
 #include "v2/tasks/command_task.h"
 #include "v2/tasks/encoder_task.h"
+#include "v2/tasks/energy_task.h"
 #include "v2/tasks/sensor_task.h"
 #include <AP33772.h>
 #include <INA226.h>
@@ -55,12 +56,14 @@ namespace {
     pocketpd::ObtainStage obtain_stage(pd_sink);
     pocketpd::ProfilePickerStage profile_picker_stage(u8g2_display, pd_sink);
     pocketpd::NormalStage normal_stage(u8g2_display, pd_sink, output_gate);
+    pocketpd::EnergyStage energy_stage(u8g2_display, output_gate);
 
     // —— Tasks
 
     pocketpd::ButtonTask button_task(encoder_button, l_button, r_button);
     pocketpd::EncoderTask encoder_task(encoder);
     pocketpd::SensorTask sensor_task{power_monitor};
+    pocketpd::EnergyTask energy_task{output_gate};
     pocketpd::CommandTask command_task{arduino_stream_reader, arduino_stream_writer};
 
 } // namespace
@@ -82,10 +85,12 @@ void setup() {
     app.register_stage(obtain_stage);
     app.register_stage(profile_picker_stage);
     app.register_stage(normal_stage);
+    app.register_stage(energy_stage);
 
     app.add_task(button_task);
     app.add_task(encoder_task);
     app.add_task(sensor_task);
+    app.add_task(energy_task);
     app.add_task(command_task);
 
     app.start<pocketpd::BootStage>();

--- a/test/test_v2_energy/test.cpp
+++ b/test/test_v2_energy/test.cpp
@@ -1,0 +1,285 @@
+/**
+ * GoogleTest suite for EnergyTask + EnergyStage.
+ *
+ * EnergyTask: SensorEvent ingest, output-on/off transitions, Wh / Ah /
+ * total-seconds bookkeeping, EnergyEvent publication on tick.
+ * EnergyStage: entry from NormalStage on R LONG, render driven by EnergyEvent,
+ * R SHORT toggles output, R LONG returns to NormalStage with original profile,
+ * encoder + L gestures ignored.
+ */
+#define VERSION "\"test\""
+
+#include <MockDisplay.h>
+#include <MockOutputGate.h>
+#include <MockPdSink.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/bus/event_queue.h>
+#include <tempo/bus/publisher.h>
+#include <tempo/stage/conductor.h>
+
+#include "v2/app.h"
+#include "v2/stages/energy_stage.h"
+#include "v2/stages/normal_stage.h"
+#include "v2/tasks/energy_task.h"
+
+using namespace pocketpd;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+using TestQueue = tempo::EventQueue<Event, 16>;
+using TestPublisher = tempo::QueuePublisher<Event, 16>;
+using TestConductor = App::Conductor;
+
+namespace {
+
+    SensorEvent make_sensor(uint32_t ts_ms, uint32_t mv, uint32_t ma) {
+        return SensorEvent{SensorSnapshot{ts_ms, mv, ma}};
+    }
+
+    const EnergyEvent* drain_last_energy(TestQueue& q) {
+        static Event last;
+        const EnergyEvent* found = nullptr;
+        Event e;
+        while (q.pop(e)) {
+            if (std::get_if<EnergyEvent>(&e) != nullptr) {
+                last = e;
+                found = std::get_if<EnergyEvent>(&last);
+            }
+        }
+        return found;
+    }
+
+} // namespace
+
+// ——— EnergyTask ——————————————————————————————————————————————————————
+
+TEST(EnergyTask, OutputOffYieldsNoAccumulation) {
+    FakeOutputGate gate;
+    EnergyTask task(gate);
+    task.on_event(make_sensor(0, 5000, 1000), 0);
+    task.on_event(make_sensor(100, 5000, 1000), 100);
+    EXPECT_EQ(task.accumulated_wh(), 0.0);
+    EXPECT_EQ(task.accumulated_ah(), 0.0);
+    EXPECT_EQ(task.total_seconds(), 0u);
+}
+
+TEST(EnergyTask, FirstSampleArmsSessionWithoutAccumulating) {
+    FakeOutputGate gate;
+    gate.enable();
+    EnergyTask task(gate);
+    task.on_event(make_sensor(1000, 5000, 1000), 1000);
+    EXPECT_EQ(task.accumulated_wh(), 0.0);
+    EXPECT_EQ(task.accumulated_ah(), 0.0);
+}
+
+TEST(EnergyTask, SubsequentSampleAccumulatesWhAndAh) {
+    FakeOutputGate gate;
+    gate.enable();
+    EnergyTask task(gate);
+    task.on_event(make_sensor(0, 5000, 1000), 0);
+    task.on_event(make_sensor(100, 5000, 1000), 100);
+
+    const double expected_wh = 5.0 * 100.0 / 3600000.0;
+    const double expected_ah = 1.0 * 100.0 / 3600000.0;
+    EXPECT_NEAR(task.accumulated_wh(), expected_wh, 1e-9);
+    EXPECT_NEAR(task.accumulated_ah(), expected_ah, 1e-9);
+}
+
+TEST(EnergyTask, LargeDeltaSkippedToAvoidStartupAndJumps) {
+    FakeOutputGate gate;
+    gate.enable();
+    EnergyTask task(gate);
+    task.on_event(make_sensor(0, 5000, 1000), 0);
+    task.on_event(make_sensor(2000, 5000, 1000), 2000);
+    EXPECT_EQ(task.accumulated_wh(), 0.0);
+    EXPECT_EQ(task.accumulated_ah(), 0.0);
+}
+
+TEST(EnergyTask, ClosedSessionRetainsAccumulatedSeconds) {
+    FakeOutputGate gate;
+    EnergyTask task(gate);
+
+    gate.enable();
+    // 7 events 500 ms apart → 6 deltas of 500 ms = 3000 ms accumulated.
+    for (uint32_t t = 1000; t <= 4000; t += 500) {
+        task.on_event(make_sensor(t, 5000, 1000), t);
+    }
+
+    gate.disable();
+    task.on_event(make_sensor(4500, 5000, 1000), 4500);
+
+    EXPECT_EQ(task.total_seconds(), 3u);
+}
+
+TEST(EnergyTask, RestartedSessionAccumulatesAcrossClosure) {
+    FakeOutputGate gate;
+    EnergyTask task(gate);
+
+    // First session: 6 deltas of 500 ms = 3000 ms.
+    gate.enable();
+    for (uint32_t t = 0; t <= 3000; t += 500) {
+        task.on_event(make_sensor(t, 5000, 1000), t);
+    }
+
+    gate.disable();
+    task.on_event(make_sensor(3500, 5000, 1000), 3500);
+
+    // Second session: 4 deltas of 500 ms = 2000 ms. Joined with prior 3000 ms.
+    gate.enable();
+    for (uint32_t t = 10000; t <= 12000; t += 500) {
+        task.on_event(make_sensor(t, 5000, 1000), t);
+    }
+
+    EXPECT_EQ(task.total_seconds(), 5u);
+}
+
+TEST(EnergyTask, OnTickPublishesEnergyEvent) {
+    FakeOutputGate gate;
+    gate.enable();
+    EnergyTask task(gate);
+    TestQueue q;
+    TestPublisher pub(q);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
+
+    task.on_event(make_sensor(0, 5000, 1000), 0);
+    task.on_event(make_sensor(100, 5000, 1000), 100);
+    task.on_tick(2500);
+
+    const auto* evt = drain_last_energy(q);
+    ASSERT_NE(evt, nullptr);
+    const double expected_wh = 5.0 * 100.0 / 3600000.0;
+    EXPECT_NEAR(evt->accumulated_wh, expected_wh, 1e-9);
+    EXPECT_EQ(evt->total_seconds, 0u);
+}
+
+// ——— NormalStage → EnergyStage transition ————————————————————————————————
+
+TEST(NormalStageEnergy, RLongRequestsEnergyStageWithSamePdoIndex) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate gate;
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    EnergyStage energy(display, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    conductor.register_stage(energy);
+
+    normal.prepare(2);
+    conductor.start<NormalStage>();
+    normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<EnergyStage>());
+    EXPECT_EQ(energy.active_pdo_index(), 2);
+}
+
+// ——— EnergyStage ————————————————————————————————————————————————————————
+
+namespace {
+
+    struct EnergyStageHarness {
+        NiceMock<MockDisplay> display;
+        FakeOutputGate gate;
+        EnergyStage energy{display, gate};
+        TestConductor conductor;
+
+        EnergyStageHarness() {
+            conductor.register_stage(energy);
+            energy.prepare(1);
+            conductor.start<EnergyStage>();
+        }
+    };
+
+} // namespace
+
+TEST(EnergyStage, RShortTogglesOutput) {
+    EnergyStageHarness h;
+    EXPECT_FALSE(h.gate.is_enabled());
+
+    h.energy.on_event(h.conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
+    EXPECT_TRUE(h.gate.is_enabled());
+
+    h.energy.on_event(h.conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
+    EXPECT_FALSE(h.gate.is_enabled());
+}
+
+TEST(EnergyStage, RLongReturnsToNormalStageWithStoredProfile) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    FakeOutputGate gate;
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    EnergyStage energy(display, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    conductor.register_stage(energy);
+
+    energy.prepare(3);
+    conductor.start<EnergyStage>();
+    energy.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.active_pdo_index(), 3);
+}
+
+TEST(EnergyStage, EncoderAndLGesturesAreIgnored) {
+    EnergyStageHarness h;
+
+    h.energy.on_event(h.conductor, EncoderEvent{5}, 0);
+    EXPECT_FALSE(h.conductor.has_pending());
+
+    h.energy.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+    EXPECT_FALSE(h.conductor.has_pending());
+
+    h.energy.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    EXPECT_FALSE(h.conductor.has_pending());
+}
+
+TEST(EnergyStage, EnergyEventDriveDisplayedAccumulators) {
+    using ::testing::AtLeast;
+    using ::testing::HasSubstr;
+    using ::testing::StrEq;
+
+    NiceMock<MockDisplay> display;
+    FakeOutputGate gate;
+
+    EnergyStage energy(display, gate);
+    TestConductor conductor;
+    conductor.register_stage(energy);
+
+    energy.prepare(0);
+    conductor.start<EnergyStage>();
+
+    EnergyEvent ee{};
+    ee.accumulated_wh = 1.23;
+    ee.accumulated_ah = 0.45;
+    ee.total_seconds = 65;
+    energy.on_event(conductor, ee, 0);
+
+    // First on_tick arms the IntervalTimer; second fires the render.
+    energy.on_tick(conductor, 0);
+
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, ::testing::_))
+        .Times(::testing::AnyNumber());
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, StrEq("Wh"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, StrEq("Ah"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, HasSubstr("01:05")))
+        .Times(AtLeast(1));
+    EXPECT_CALL(display, flush()).Times(AtLeast(1));
+
+    energy.on_tick(conductor, 100);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -359,7 +359,7 @@ TEST(NormalStage, OnEnterPdoBranchRendersVAReadoutAndPdoIndex) {
     TestConductor conductor;
     conductor.register_stage(normal);
     normal.prepare(2);
-    normal.on_event(conductor, SensorEvent{SensorSnapshot{0, 5000, 1234, true}}, 0);
+    normal.on_event(conductor, SensorEvent{SensorSnapshot{0, 5000, 1234}}, 0);
     conductor.start<NormalStage>();
 }
 

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -580,7 +580,6 @@ TEST(NormalStage, IgnoresOtherButtonsAndShortPressOnL) {
     conductor.start<NormalStage>();
 
     normal.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
-    normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
     normal.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
 
     EXPECT_FALSE(conductor.has_pending());

--- a/test/test_v2_sensor/test.cpp
+++ b/test/test_v2_sensor/test.cpp
@@ -50,10 +50,9 @@ TEST(SensorTask, OnTickPublishesSensorEventWithTimestampAndValues) {
     EXPECT_EQ(evt->snapshot.timestamp_ms, 42u);
     EXPECT_EQ(evt->snapshot.vbus_mv, 5000u);
     EXPECT_EQ(evt->snapshot.current_ma, 1234u);
-    EXPECT_TRUE(evt->snapshot.valid);
 }
 
-TEST(SensorTask, InvalidReadingPropagatesValidFalse) {
+TEST(SensorTask, InvalidReadingDoesNotPublish) {
     FakePowerMonitor monitor;
     TestQueue q;
     TestPublisher pub(q);
@@ -63,9 +62,7 @@ TEST(SensorTask, InvalidReadingPropagatesValidFalse) {
     monitor.push({0, 0, false});
     task.on_tick(99);
 
-    const auto* evt = pop_sensor(q);
-    ASSERT_NE(evt, nullptr);
-    EXPECT_FALSE(evt->snapshot.valid);
+    EXPECT_EQ(pop_sensor(q), nullptr);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary
Adds an Energy screen plus an `EnergyTask` that integrates V/I over time.

- **Navigation.** R LONG toggles `NormalStage` ↔ `EnergyStage` carrying the active PDO. R SHORT toggles output (matches `NormalStage`).
- **Integration.** `EnergyTask` accumulates Wh / Ah / total seconds from `SensorEvent` while `OutputGate` is enabled.
- **Stall guard.** Sensor gaps ≥ 1 s discard the delta so a missed tick can't credit stale V/I across a load change.
- **Cleanup.** Drops unused `UiState`, `Profile`, `OutputScreen`, and `SensorSnapshot.valid`; `SensorTask` skips publishing on invalid reads instead.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested: `pio test -e native` passes including new `test_v2_energy`. On-device verification still pending.


<img width="3024" height="4032" alt="IMG_3085 2" src="https://github.com/user-attachments/assets/064c914e-c0dc-43e5-ae5e-dfb35929d75a" />


## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details: R LONG on `NormalStage` now goes to the Energy screen.

## Notes
- `OutputGate::toggle()` helper added so both stages share the enable/disable branch.
- `Font::LG` bumped from `profont15` to `profont17` for the Energy layout.