### PR TITLE
feat(v2): require profile pick before Normal

### DIFF
--- a/include/v2/app.h
+++ b/include/v2/app.h
@@ -26,11 +26,6 @@ namespace pocketpd {
 
     // —— Define common types
 
-    enum class ProfilePickerMode : uint8_t {
-        REVIEW,
-        SELECT,
-    };
-
     // —— Define the application alias which is a combination of Events and Stages
 
     using App = tempo::Application<

--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -22,7 +22,6 @@ namespace pocketpd {
      */
     constexpr uint32_t BOOT_TO_OBTAIN_MS = 500;
     constexpr uint32_t OBTAIN_TO_PROFILE_PICKER_MS = 1500;
-    constexpr uint32_t PROFILE_PICKER_REVIEW_TO_NORMAL_MS = 3000;
 
     /**
      * @brief What the rotary encoder is currently editing.

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -137,7 +137,7 @@ namespace pocketpd {
                     }
 
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
-                        conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
+                        conductor.request<ProfilePickerStage>();
                         return;
                     }
 

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -3,10 +3,9 @@
  * @brief Stage that runs PD negotiation, learns the source PDO list, and
  * announces the result to the rest of the app via `PdReadyEvent`.
  *
- * After the announce, ObtainStage acts as a short window to handle user input:
- *  1. a short button press resumes Normal operation immediately,
- *  2. encoder rotation jumps to ProfilePicker in SELECT mode, and
- *  3. otherwise the stage times out into ProfilePicker REVIEW so the PDO list can be reviewed.
+ * After the announce, ObtainStage waits a short window then transitions to ProfilePicker so
+ * the user can choose a profile. Short button press or encoder rotation jumps to ProfilePicker
+ * immediately.
  *
  * Issue #33: ObtainStage must NOT issue an RDO request. The first request runs later
  * (NormalPpsStage / NormalPdoStage) once EEPROM has been consulted. Until then the AP33772 holds
@@ -83,7 +82,7 @@ namespace pocketpd {
             }
 
             if (m_timeout.reached(now_ms)) {
-                conductor.request<ProfilePickerStage>(ProfilePickerMode::REVIEW);
+                conductor.request<ProfilePickerStage>();
             }
         }
 
@@ -92,12 +91,12 @@ namespace pocketpd {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
                     if (evt.gesture == Gesture::SHORT && m_pd_ready) {
-                        conductor.request<NormalStage>(static_cast<int8_t>(-1));
+                        conductor.request<ProfilePickerStage>();
                     }
                 },
                 [&](const EncoderEvent& evt) {
                     if (evt.delta != 0) {
-                        conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
+                        conductor.request<ProfilePickerStage>();
                     }
                 },
                 [](const auto&) {

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -1,9 +1,8 @@
 /**
  * @file profile_picker_stage.h
- * @brief Profile-selection / capability-list stage. Two modes via payload-passing transition:
- * - REVIEW renders the source PDO list and waits for input;
- * - SELECT renders the same list with an encoder-driven cursor. The user commits a profile by
- * long-pressing the encoder button.
+ * @brief Profile-selection stage. Renders the source PDO list with an encoder-driven cursor.
+ * The user commits a profile by long-pressing the encoder, or exits without changing by long-
+ * pressing L. There is no auto-transition to Normal — the user must choose.
  */
 #pragma once
 
@@ -20,7 +19,6 @@
 #include "v2/app.h"
 #include "v2/events.h"
 #include "v2/hal/pd_sink_controller.h"
-#include "v2/pocketpd.h"
 #include "v2/state.h"
 
 namespace pocketpd {
@@ -28,20 +26,14 @@ namespace pocketpd {
     void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor = -1);
 
     class ProfilePickerStage : public App::Stage, public App::UseLog<ProfilePickerStage> {
-    public:
-        using Mode = ProfilePickerMode;
-
     private:
         using Display = tempo::Display;
 
         Display& m_display;
         PdSinkController& m_pd_sink;
 
-        Mode m_mode = Mode::REVIEW;
         int m_cursor = 0;
         int m_pending_cursor = 0;
-
-        tempo::TimeoutTimer m_review_timeout;
 
         void commit(Conductor& conductor) {
             if (m_pd_sink.pdo_count() <= 0) {
@@ -61,87 +53,18 @@ namespace pocketpd {
             return "PROFILE_PICKER";
         }
 
-        Mode mode() const {
-            return m_mode;
-        }
-
         int cursor_index() const {
             return m_cursor;
         }
 
-        void prepare(Mode mode) {
-            m_mode = mode;
-        }
-
         void on_enter(Conductor&) override {
-            m_review_timeout.disarm();
-
-            switch (m_mode) {
-            case Mode::REVIEW:
-                render_pdo_list(m_display, m_pd_sink);
-                break;
-            case Mode::SELECT:
-                m_pending_cursor = m_cursor;
-                render_pdo_list(m_display, m_pd_sink, m_pending_cursor);
-                break;
-            }
+            m_pending_cursor = m_cursor;
+            render_pdo_list(m_display, m_pd_sink, m_pending_cursor);
         }
 
-        void on_tick(Conductor& conductor, uint32_t now_ms) override {
-            if (m_mode != Mode::REVIEW) {
-                return;
-            }
-
-            if (!m_review_timeout.armed()) {
-                m_review_timeout.set(now_ms, PROFILE_PICKER_REVIEW_TO_NORMAL_MS);
-                return;
-            }
-
-            if (m_review_timeout.reached(now_ms)) {
-                if (m_pd_sink.pdo_count() <= 0) {
-                    return; // stay in REVIEW until a charger is detected
-                }
-                conductor.request<NormalStage>(static_cast<int8_t>(-1));
-                return;
-            }
-        }
+        void on_tick(Conductor&, uint32_t) override {}
 
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
-            switch (m_mode) {
-            case Mode::REVIEW:
-                handle_review_event(conductor, event);
-                break;
-            case Mode::SELECT:
-                handle_select_event(conductor, event);
-                break;
-            }
-        }
-
-    private:
-        void handle_review_event(Conductor& conductor, const Event& event) {
-            auto handler = tempo::overloaded{
-                [&](const ButtonEvent& evt) {
-                    if (evt.gesture == Gesture::SHORT && m_pd_sink.pdo_count() > 0) {
-                        conductor.request<NormalStage>(static_cast<int8_t>(-1));
-                    }
-                },
-                /**
-                 * @brief In review mode, turning the encoder auto-enters the SELECT mode
-                 *
-                 * @param evt incoming EncoderEvent
-                 */
-                [&](const EncoderEvent& evt) {
-                    if (evt.delta != 0) {
-                        conductor.request<ProfilePickerStage>(ProfilePickerMode::SELECT);
-                    }
-                },
-                [](const auto&) {},
-            };
-
-            std::visit(handler, event);
-        }
-
-        void handle_select_event(Conductor& conductor, const Event& event) {
             auto handler = tempo::overloaded{
                 [&](const EncoderEvent& evt) {
                     const int count = m_pd_sink.pdo_count();
@@ -158,7 +81,6 @@ namespace pocketpd {
                     render_pdo_list(m_display, m_pd_sink, m_pending_cursor);
                 },
                 [&](const ButtonEvent& evt) {
-                    // Exit — do nothing
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
                         conductor.request<NormalStage>();
                         return;

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -161,7 +161,7 @@ TEST(NormalStage, RShortToggleEnablesAndDisablesOutput) {
     EXPECT_FALSE(enabled);
 }
 
-TEST(NormalStage, LLongRequestsProfilePickerSelect) {
+TEST(NormalStage, LLongRequestsProfilePicker) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     NiceMock<MockOutputGate> gate;
@@ -181,7 +181,6 @@ TEST(NormalStage, LLongRequestsProfilePickerSelect) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
-    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::SELECT);
 }
 
 TEST(NormalStage, EncoderEventsIgnoredInPdoBranch) {

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -122,7 +122,7 @@ TEST(ObtainStage, OnEnterIssuesNoRdoRequest) {
     conductor.start<ObtainStage>();
 }
 
-TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
+TEST(ObtainStage, ShortButtonJumpsToProfilePickerAfterPdReady) {
     NiceMock<MockPdSink> sink;
     TestQueue queue;
     TestPublisher publisher(queue);
@@ -132,46 +132,18 @@ TEST(ObtainStage, ShortButtonResumesNormalInPpsProfileAfterPdReady) {
 
     ObtainStage stage(sink);
     stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    NiceMock<MockDisplay> normal_display;
-    NiceMock<MockOutputGate> normal_gate;
-    NormalStage normal(normal_display, sink, normal_gate);
+    NiceMock<MockDisplay> picker_display;
+    ProfilePickerStage picker(picker_display, sink);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.register_stage(normal);
+    conductor.register_stage(picker);
     conductor.start<ObtainStage>();
 
     stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.active_pdo_index(), -1);
-}
-
-TEST(ObtainStage, ShortButtonResumesNormalInPdoProfileWhenNoPps) {
-    NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
-    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
-
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    NiceMock<MockDisplay> normal_display;
-    NiceMock<MockOutputGate> normal_gate;
-    NormalStage normal(normal_display, sink, normal_gate);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.register_stage(normal);
-    conductor.start<ObtainStage>();
-
-    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
-
-    EXPECT_TRUE(conductor.has_pending());
-    EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.active_pdo_index(), -1);
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
 }
 
 TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {
@@ -190,7 +162,7 @@ TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {
     EXPECT_FALSE(conductor.has_pending());
 }
 
-TEST(ObtainStage, EncoderRotationJumpsToProfilePickerInSelectMode) {
+TEST(ObtainStage, EncoderRotationJumpsToProfilePicker) {
     NiceMock<MockPdSink> sink;
     TestQueue queue;
     TestPublisher publisher(queue);
@@ -212,10 +184,9 @@ TEST(ObtainStage, EncoderRotationJumpsToProfilePickerInSelectMode) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
-    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::SELECT);
 }
 
-TEST(ObtainStage, TimeoutTransitionsToProfilePickerInReviewMode) {
+TEST(ObtainStage, TimeoutTransitionsToProfilePicker) {
     NiceMock<MockPdSink> sink;
     TestQueue queue;
     TestPublisher publisher(queue);
@@ -240,7 +211,6 @@ TEST(ObtainStage, TimeoutTransitionsToProfilePickerInReviewMode) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
-    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::REVIEW);
 }
 
 TEST(BootStage, RequestsObtainAfterTimeout) {

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -26,7 +26,7 @@ using ::testing::StrEq;
 
 using TestConductor = App::Conductor;
 
-TEST(ProfilePickerStage, ReviewEmptyListRendersFallback) {
+TEST(ProfilePickerStage, EmptyListRendersFallback) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
@@ -38,13 +38,12 @@ TEST(ProfilePickerStage, ReviewEmptyListRendersFallback) {
     EXPECT_CALL(display, draw_text(::testing::Ne(1), ::testing::_, ::testing::_)).Times(0);
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
 }
 
-TEST(ProfilePickerStage, ReviewRendersSingleFixedPdo) {
+TEST(ProfilePickerStage, RendersSingleFixedPdo) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
@@ -54,17 +53,17 @@ TEST(ProfilePickerStage, ReviewRendersSingleFixedPdo) {
     EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
 
     EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(0, ::testing::_, StrEq(">"))).Times(::testing::AnyNumber());
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
 }
 
-TEST(ProfilePickerStage, ReviewRendersFixedAndPpsLines) {
+TEST(ProfilePickerStage, RendersFixedAndPpsLines) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
@@ -80,17 +79,17 @@ TEST(ProfilePickerStage, ReviewRendersFixedAndPpsLines) {
     EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(21000));
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
 
+    EXPECT_CALL(display, draw_text(0, ::testing::_, StrEq(">"))).Times(::testing::AnyNumber());
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 9V @ 2A"))).Times(1);
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 3A"))).Times(1);
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
 }
 
-TEST(ProfilePickerStage, ReviewRendersMultiplePpsLines) {
+TEST(ProfilePickerStage, RendersMultiplePpsLines) {
     // issue #24: chargers can advertise multiple PPS APDOs; each must render.
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
@@ -108,17 +107,17 @@ TEST(ProfilePickerStage, ReviewRendersMultiplePpsLines) {
     EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(21000));
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(5000));
 
+    EXPECT_CALL(display, draw_text(0, ::testing::_, StrEq(">"))).Times(::testing::AnyNumber());
     EXPECT_CALL(display, draw_text(5, 9, StrEq("PPS: 3.3V~11.0V @ 3A"))).Times(1);
     EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 5A"))).Times(1);
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
 }
 
-TEST(ProfilePickerStage, SelectEntryDrawsCursorAtFirstRow) {
+TEST(ProfilePickerStage, EntryDrawsCursorAtFirstRow) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
@@ -139,13 +138,12 @@ TEST(ProfilePickerStage, SelectEntryDrawsCursorAtFirstRow) {
     EXPECT_CALL(display, flush()).Times(1);
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
 }
 
-TEST(ProfilePickerStage, SelectEncoderMovesCursorAndRerenders) {
+TEST(ProfilePickerStage, EncoderMovesCursorAndRerenders) {
     using ::testing::_;
     using ::testing::AnyNumber;
 
@@ -160,7 +158,6 @@ TEST(ProfilePickerStage, SelectEncoderMovesCursorAndRerenders) {
     }
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
@@ -177,7 +174,7 @@ TEST(ProfilePickerStage, SelectEncoderMovesCursorAndRerenders) {
     stage.on_event(conductor, EncoderEvent{1}, 0);
 }
 
-TEST(ProfilePickerStage, SelectEncoderClampsAtTopAndBottom) {
+TEST(ProfilePickerStage, EncoderClampsAtTopAndBottom) {
     using ::testing::_;
     using ::testing::AnyNumber;
 
@@ -192,7 +189,6 @@ TEST(ProfilePickerStage, SelectEncoderClampsAtTopAndBottom) {
     }
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
@@ -216,13 +212,12 @@ TEST(ProfilePickerStage, SelectEncoderClampsAtTopAndBottom) {
     stage.on_event(conductor, EncoderEvent{4}, 0);
 }
 
-TEST(ProfilePickerStage, SelectEmptyListIgnoresEncoder) {
+TEST(ProfilePickerStage, EmptyListIgnoresEncoder) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
@@ -233,106 +228,7 @@ TEST(ProfilePickerStage, SelectEmptyListIgnoresEncoder) {
     stage.on_event(conductor, EncoderEvent{1}, 0);
 }
 
-TEST(ProfilePickerStage, ReviewEncoderRequestsSelectModeReentry) {
-    NiceMock<MockDisplay> display;
-    NiceMock<MockPdSink> sink;
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
-    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
-    EXPECT_CALL(sink, is_index_pps(0)).WillRepeatedly(Return(false));
-    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
-    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
-    EXPECT_CALL(sink, is_index_fixed(1)).WillRepeatedly(Return(true));
-    EXPECT_CALL(sink, is_index_pps(1)).WillRepeatedly(Return(false));
-    EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(9000));
-    EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(2000));
-
-    ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.start<ProfilePickerStage>();
-
-    stage.on_event(conductor, EncoderEvent{1}, 0);
-
-    EXPECT_TRUE(conductor.has_pending());
-    EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
-    EXPECT_EQ(stage.mode(), ProfilePickerStage::Mode::SELECT);
-}
-
-TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPpsWhenChargerHasPps) {
-    NiceMock<MockDisplay> display;
-    NiceMock<MockPdSink> sink;
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
-
-    ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NiceMock<MockOutputGate> normal_gate;
-    NormalStage normal(display, sink, normal_gate);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.register_stage(normal);
-    conductor.start<ProfilePickerStage>();
-
-    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
-
-    EXPECT_TRUE(conductor.has_pending());
-    EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.active_pdo_index(), -1);
-}
-
-TEST(ProfilePickerStage, ReviewShortButtonRequestsNormalPdoWhenNoPps) {
-    NiceMock<MockDisplay> display;
-    NiceMock<MockPdSink> sink;
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
-
-    ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NiceMock<MockOutputGate> normal_gate;
-    NormalStage normal(display, sink, normal_gate);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.register_stage(normal);
-    conductor.start<ProfilePickerStage>();
-
-    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
-
-    EXPECT_TRUE(conductor.has_pending());
-    EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.active_pdo_index(), -1);
-}
-
-TEST(ProfilePickerStage, ReviewTimeoutTransitionsToNormal) {
-    NiceMock<MockDisplay> display;
-    NiceMock<MockPdSink> sink;
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
-
-    ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
-    NiceMock<MockOutputGate> normal_gate;
-    NormalStage normal(display, sink, normal_gate);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.register_stage(normal);
-    conductor.start<ProfilePickerStage>();
-
-    conductor.tick(0);
-    conductor.tick(PROFILE_PICKER_REVIEW_TO_NORMAL_MS - 1);
-    EXPECT_FALSE(conductor.has_pending());
-
-    conductor.tick(PROFILE_PICKER_REVIEW_TO_NORMAL_MS);
-    EXPECT_TRUE(conductor.has_pending());
-    EXPECT_TRUE(conductor.apply_pending_transition());
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.active_pdo_index(), -1);
-}
-
-TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
+TEST(ProfilePickerStage, LongPressCommitsPpsWhenCursorOnPps) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
@@ -347,7 +243,6 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
@@ -364,7 +259,7 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPpsWhenCursorOnPps) {
     EXPECT_EQ(normal.active_pdo_index(), 1);
 }
 
-TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
+TEST(ProfilePickerStage, LongPressCommitsPdoWhenCursorOnFixed) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
@@ -374,7 +269,6 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
     EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
@@ -392,13 +286,12 @@ TEST(ProfilePickerStage, SelectLongPressCommitsPdoWhenCursorOnFixed) {
     EXPECT_EQ(normal.active_pdo_index(), 0);
 }
 
-TEST(ProfilePickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
+TEST(ProfilePickerStage, LongPressIgnoredWhenEmptyPdoList) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
@@ -410,7 +303,7 @@ TEST(ProfilePickerStage, SelectLongPressIgnoredWhenEmptyPdoList) {
     EXPECT_FALSE(conductor.has_pending());
 }
 
-TEST(ProfilePickerStage, SelectIgnoresRLongPressAndEncoderShortPress) {
+TEST(ProfilePickerStage, IgnoresRLongPressAndEncoderShortPress) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
@@ -420,7 +313,6 @@ TEST(ProfilePickerStage, SelectIgnoresRLongPressAndEncoderShortPress) {
     EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
@@ -433,7 +325,7 @@ TEST(ProfilePickerStage, SelectIgnoresRLongPressAndEncoderShortPress) {
     EXPECT_FALSE(conductor.has_pending());
 }
 
-TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
+TEST(ProfilePickerStage, LongPressLExitsToNormalWithoutChangingProfile) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
@@ -444,7 +336,6 @@ TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     normal.prepare(7); // simulate prior session
@@ -461,7 +352,7 @@ TEST(ProfilePickerStage, SelectLongPressLExitsToNormalWithoutChangingProfile) {
     EXPECT_EQ(normal.active_pdo_index(), 7); // unchanged
 }
 
-TEST(ProfilePickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
+TEST(ProfilePickerStage, ClearsBeforeDrawingAndFlushesAfter) {
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
     EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
@@ -473,18 +364,18 @@ TEST(ProfilePickerStage, ReviewClearsBeforeDrawingAndFlushesAfter) {
     {
         InSequence seq;
         EXPECT_CALL(display, clear());
+        EXPECT_CALL(display, draw_text(0, 9, StrEq(">")));
         EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A")));
         EXPECT_CALL(display, flush());
     }
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::REVIEW);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ProfilePickerStage>();
 }
 
-TEST(ProfilePickerStage, SelectCommitPromotesPendingCursorAndPreservesAcrossReentry) {
+TEST(ProfilePickerStage, CommitPromotesPendingCursorAndPreservesAcrossReentry) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
@@ -496,7 +387,6 @@ TEST(ProfilePickerStage, SelectCommitPromotesPendingCursorAndPreservesAcrossReen
     }
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
@@ -511,13 +401,12 @@ TEST(ProfilePickerStage, SelectCommitPromotesPendingCursorAndPreservesAcrossReen
     stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
     EXPECT_EQ(stage.cursor_index(), 2);
 
-    // Re-enter SELECT — committed cursor must persist.
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
+    // Re-enter — committed cursor must persist.
     stage.on_enter(conductor);
     EXPECT_EQ(stage.cursor_index(), 2);
 }
 
-TEST(ProfilePickerStage, SelectExitViaLDoesNotPromotePendingCursor) {
+TEST(ProfilePickerStage, ExitViaLDoesNotPromotePendingCursor) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
@@ -529,7 +418,6 @@ TEST(ProfilePickerStage, SelectExitViaLDoesNotPromotePendingCursor) {
     }
 
     ProfilePickerStage stage(display, sink);
-    stage.prepare(ProfilePickerStage::Mode::SELECT);
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
@@ -562,7 +450,6 @@ TEST(NormalStage, LongPressLReturnsToProfilePicker) {
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition());
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
-    EXPECT_EQ(picker.mode(), ProfilePickerStage::Mode::SELECT);
 }
 
 TEST(NormalStage, IgnoresOtherButtonsAndShortPressOnL) {


### PR DESCRIPTION
## Summary
Drops ProfilePicker REVIEW mode and its 3 s auto-transition to Normal. The user has to commit a profile from the picker before reaching Normal.

Obtain routes short-press, encoder rotation, and the post-negotiation timeout all to the picker. In the picker, encoder long-press commits the highlighted profile, and L-long returns to Normal without changing it. Empty PDO list ignores both buttons.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested: flashed HW1_3_V2, walked through Boot → Obtain → ProfilePicker → encoder long-press → Normal, and Normal → L-long → ProfilePicker. Native suite (`pio test -e native`) passes 98/98.

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details: Obtain no longer falls through to Normal on its own. Short-press on Obtain used to go straight to Normal. It now goes to the picker. `ProfilePickerMode` enum and `PROFILE_PICKER_REVIEW_TO_NORMAL_MS` are gone.

## Notes
Stacks on #83 (AP33772 STATUS fix). Merge that first.