### PR TITLE
feat(v2): tune PPS increment order and long-press threshold

### DIFF
--- a/include/v2/input/button_gesture.h
+++ b/include/v2/input/button_gesture.h
@@ -15,7 +15,7 @@
 namespace pocketpd {
 
     struct ButtonGestureConfig {
-        uint32_t long_press_ms = 750;
+        uint32_t long_press_ms = 500;
     };
 
     class ButtonGestureDetector {

--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -37,8 +37,8 @@ namespace pocketpd {
      * Short-press encoder cycles the active index. Mirrors v1
      * voltageIncrement[3] / currentIncrement[3] in StateMachine.
      */
-    constexpr std::array<uint16_t, 3> VOLTAGE_INCREMENTS_MV = {20, 100, 1000};
-    constexpr std::array<uint16_t, 3> CURRENT_INCREMENTS_MA = {50, 100, 1000};
+    constexpr std::array<uint16_t, 3> VOLTAGE_INCREMENTS_MV = {1000, 100, 20};
+    constexpr std::array<uint16_t, 3> CURRENT_INCREMENTS_MA = {1000, 100, 50};
 
     // PPS RDO stepping per USB-PD 3.0 spec.
     constexpr int32_t PPS_VOLTAGE_STEP_MV = 20;

--- a/include/v2/stages/normal/normal_view.h
+++ b/include/v2/stages/normal/normal_view.h
@@ -44,8 +44,8 @@ namespace pocketpd {
     class NormalView {
     private:
         static constexpr uint8_t V_MEASURED_Y = 14;
-        static constexpr uint8_t A_MEASURED_Y = 47;
-        static constexpr uint8_t V_TARGET_Y = 27;
+        static constexpr uint8_t A_MEASURED_Y = 48;
+        static constexpr uint8_t V_TARGET_Y = 28;
         static constexpr uint8_t A_TARGET_Y = 62;
         static constexpr uint8_t TARGET_RIGHT_X = 75;
         static constexpr uint8_t STATUS_X = 110;
@@ -54,8 +54,8 @@ namespace pocketpd {
         static constexpr uint8_t ARROW_Y = 0;
         static constexpr uint8_t ARROW_W = 20;
         static constexpr uint8_t ARROW_H = 20;
-        static constexpr std::array<uint8_t, 3> CURSOR_X = {45, 39, 33};
-        static constexpr uint8_t CURSOR_W = 6;
+        static constexpr std::array<uint8_t, 3> CURSOR_X = {33, 39, 45};
+        static constexpr uint8_t CURSOR_W = 7;
 
     public:
         static void render(tempo::Display& d, const NormalViewModel& vm) {

--- a/include/v2/stages/normal/pps_mode.h
+++ b/include/v2/stages/normal/pps_mode.h
@@ -23,15 +23,11 @@ namespace pocketpd {
         AdjustMode adjust_mode = AdjustMode::VOLTAGE;
 
         /**
-         * @brief Bind to a PD sink + PDO index and seed targets.
-         *
-         * Set `target_mv` to PDO minimum voltage. `target_ma` defaults to 1 A.
+         * @brief Bind to a PD sink + PDO index. Targets initializes at 5 V / 1 A, then clamp into
+         * the PDO's advertised range.
          */
         PPSMode(PdSinkController& sink, int8_t pdo_idx) : m_sink(&sink), m_pdo_idx(pdo_idx) {
-            const int v_lo = sink.pdo_min_voltage_mv(pdo_idx);
-            if (v_lo > 0) {
-                target_mv = v_lo;
-            }
+            clamp_to_pdo();
         }
 
         /**

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -52,7 +52,7 @@ TEST(NormalStage, OnEnterPpsProfileResetsTargetsToDefaults) {
     EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(11000));
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
     EXPECT_CALL(sink, set_pdo).Times(0);
-    EXPECT_CALL(sink, set_pps_pdo(1, 3300, 1000)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(sink, set_pps_pdo(1, 5000, 1000)).Times(1).WillOnce(Return(true));
 
     NormalStage normal(display, sink, gate);
     TestConductor conductor;
@@ -60,7 +60,7 @@ TEST(NormalStage, OnEnterPpsProfileResetsTargetsToDefaults) {
 
     normal.prepare(1);
     conductor.start<NormalStage>();
-    EXPECT_EQ(normal.target_mv(), 3300);
+    EXPECT_EQ(normal.target_mv(), 5000);
     EXPECT_EQ(normal.target_ma(), 1000);
 }
 
@@ -80,12 +80,12 @@ TEST(NormalStage, ReEnteringSamePpsProfilePreservesEdits) {
     normal.prepare(1);
     conductor.start<NormalStage>();
 
-    normal.on_event(conductor, EncoderEvent{-100}, 0);
-    ASSERT_EQ(normal.target_mv(), 5300);
+    normal.on_event(conductor, EncoderEvent{-2}, 0);
+    ASSERT_EQ(normal.target_mv(), 7000);
 
     normal.prepare(1);
     normal.on_enter(conductor);
-    EXPECT_EQ(normal.target_mv(), 5300);
+    EXPECT_EQ(normal.target_mv(), 7000);
     EXPECT_EQ(normal.target_ma(), 1000);
 }
 
@@ -230,9 +230,9 @@ namespace {
 
 TEST(NormalStage, EncoderDeltaInVoltageModeAdjustsTargetMv) {
     PpsHarness h;
-    EXPECT_CALL(h.sink, set_pps_pdo(1, 3360, 1000)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 8000, 1000)).Times(1).WillOnce(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-3}, 0);
-    EXPECT_EQ(h.normal.target_mv(), 3360);
+    EXPECT_EQ(h.normal.target_mv(), 8000);
     EXPECT_EQ(h.normal.adjust_mode(), AdjustMode::VOLTAGE);
 }
 
@@ -241,9 +241,9 @@ TEST(NormalStage, EncoderDeltaInCurrentModeAdjustsTargetMa) {
     h.normal.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
     ASSERT_EQ(h.normal.adjust_mode(), AdjustMode::CURRENT);
 
-    EXPECT_CALL(h.sink, set_pps_pdo(1, 3300, 1200)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 5000, 3000)).Times(1).WillOnce(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-4}, 0);
-    EXPECT_EQ(h.normal.target_ma(), 1200);
+    EXPECT_EQ(h.normal.target_ma(), 3000);
 }
 
 TEST(NormalStage, EncoderShortPressCyclesIncrementIndex) {
@@ -266,19 +266,15 @@ TEST(NormalStage, EncoderShortPressCyclesIncrementIndex) {
 
 TEST(NormalStage, EncoderEditUsesActiveIncrementMagnitude) {
     PpsHarness h;
-    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
-    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
-    ASSERT_EQ(h.normal.voltage_increment_index(), 2);
+    ASSERT_EQ(h.normal.voltage_increment_index(), 0);
 
-    EXPECT_CALL(h.sink, set_pps_pdo(1, 4300, 1000)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 6000, 1000)).Times(1).WillOnce(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-1}, 0);
-    EXPECT_EQ(h.normal.target_mv(), 4300);
+    EXPECT_EQ(h.normal.target_mv(), 6000);
 }
 
 TEST(NormalStage, EncoderEditClampsTargetVoltageToPdoBounds) {
     PpsHarness h(1, 3300, 11000, 3000);
-    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
-    h.normal.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
 
     EXPECT_CALL(h.sink, set_pps_pdo(1, 11000, ::testing::_)).WillRepeatedly(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-20}, 0);
@@ -295,7 +291,7 @@ TEST(NormalStage, EncoderEditClampsCurrentAtZero) {
 
     EXPECT_CALL(h.sink, set_pps_pdo).WillRepeatedly(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-20}, 0);
-    ASSERT_EQ(h.normal.target_ma(), 2000);
+    ASSERT_EQ(h.normal.target_ma(), 3000);
     h.normal.on_event(h.conductor, EncoderEvent{50}, 0);
     EXPECT_EQ(h.normal.target_ma(), 0);
 }
@@ -346,8 +342,8 @@ TEST(NormalStage, OnEnterPdoBranchRendersVAReadoutAndPdoIndex) {
         .Times(::testing::AnyNumber());
     EXPECT_CALL(display, clear()).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(1, 14, StrEq("V"))).Times(AtLeast(1));
-    EXPECT_CALL(display, draw_text(1, 47, StrEq("A"))).Times(AtLeast(1));
-    EXPECT_CALL(display, draw_text(::testing::_, 27, HasSubstr("20000 mV"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(1, 48, StrEq("A"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, 28, HasSubstr("20000 mV"))).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(::testing::_, 62, HasSubstr("5000 mA"))).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(110, 50, HasSubstr("[2]"))).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(110, 64, StrEq("PDO"))).Times(AtLeast(1));


### PR DESCRIPTION
## Summary

UX tuning.

- PPS increment tables run coarse to fine: `{1000, 100, 20}` mV and `{1000, 100, 50}` mA. `NormalView::CURSOR_X` mirrors the new order so the underline sits under the digit the encoder will move.
- `PPSMode` ctor now defaults targets to 5 V / 1 A and clamps into the PDO range, instead of seeding `target_mv` to the PDO minimum. 5V is a more stable default on most chargers as some don't respect the min V on the profile.
- Normal target row shifts down one pixel (`V_TARGET_Y` 27 to 28, `A_MEASURED_Y` 47 to 48) and `CURSOR_W` widens from 6 to 7 px for better visibility.
- `ButtonGestureConfig::long_press_ms` drops from 750 to 500 ms to match smartphone experience. This should  make the long press feels more natural and snappier.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested: `pio test -e native -f test_v2_normal`, 17/17 pass. Render asserts updated for the new y-offsets and cursor indices, and default-target asserts updated for the 5 V seed. Tested on device to validate the UX.

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details: On first entry into a PPS profile the target now sits at 5 V instead of the PDO minimum. First encoder short-press in PPS mode moves the cursor toward the finer digit instead of the coarser one. L-LONG feels snappier.

## Notes