### PR TITLE
refactor(v2): UI refinement and energy_view redesign

### DIFF
--- a/include/v2/events.h
+++ b/include/v2/events.h
@@ -34,6 +34,22 @@ namespace pocketpd {
     struct ButtonEvent {
         ButtonId id = ButtonId::ENCODER;
         Gesture gesture = Gesture::SHORT;
+
+        bool r_short() const {
+            return id == ButtonId::R && gesture == Gesture::SHORT;
+        }
+
+        bool r_long() const {
+            return id == ButtonId::R && gesture == Gesture::LONG;
+        }
+
+        bool l_long() const {
+            return id == ButtonId::L && gesture == Gesture::LONG;
+        }
+
+        bool l_short() const {
+            return id == ButtonId::L && gesture == Gesture::SHORT;
+        }
     };
 
     /**

--- a/include/v2/hal/u8g2_display.h
+++ b/include/v2/hal/u8g2_display.h
@@ -8,6 +8,7 @@
 
 #include <tempo/hardware/display.h>
 
+#include "clib/u8g2.h"
 #include <U8g2lib.h>
 
 namespace pocketpd {
@@ -33,16 +34,16 @@ namespace pocketpd {
         void set_font(tempo::Font font) override {
             switch (font) {
             case tempo::Font::SM:
-                m_u8g2.setFont(u8g2_font_profont11_tr);
+                m_u8g2.setFont(u8g2_font_profont11_mr);
                 break;
             case tempo::Font::BASE:
-                m_u8g2.setFont(u8g2_font_profont12_tr);
+                m_u8g2.setFont(u8g2_font_profont12_mr);
                 break;
             case tempo::Font::LG:
-                m_u8g2.setFont(u8g2_font_profont17_tr);
+                m_u8g2.setFont(u8g2_font_profont17_mr);
                 break;
             case tempo::Font::XL:
-                m_u8g2.setFont(u8g2_font_profont22_tr);
+                m_u8g2.setFont(u8g2_font_profont22_mr);
                 break;
             }
         }

--- a/include/v2/stages/energy/energy_view.h
+++ b/include/v2/stages/energy/energy_view.h
@@ -30,18 +30,19 @@ namespace pocketpd {
 
     class EnergyView {
     private:
-        static constexpr uint8_t ROW1_Y = 10;
-        static constexpr uint8_t ROW2_Y = 35;
-        static constexpr uint8_t ROW3_Y = 55;
+        static constexpr uint8_t ROW1_Y = 8;
+        static constexpr uint8_t ROW2_Y = 36;
+        static constexpr uint8_t ROW3_Y = 64;
 
         static constexpr uint8_t COL1_X = 4;
-        static constexpr uint8_t COL2_X = 70;
+        static constexpr uint8_t COL2_X = 90;
 
-        static constexpr uint8_t ROW1_V_X = 4;
-        static constexpr uint8_t ROW1_A_X = 48;
+        static constexpr uint8_t V_X = 72;
+        static constexpr uint8_t A_X = 72;
+        static constexpr uint8_t T_X = 50;
 
-        static constexpr uint8_t ARROW_X = 105;
-        static constexpr uint8_t ARROW_Y = 0;
+        static constexpr uint8_t ARROW_X = 108;
+        static constexpr uint8_t ARROW_Y = 20;
         static constexpr uint8_t ARROW_W = 20;
         static constexpr uint8_t ARROW_H = 20;
 
@@ -65,27 +66,27 @@ namespace pocketpd {
             display.set_font(tempo::Font::BASE);
 
             format_milli(buf, vm.snapshot.vbus_mv, 'V');
-            display.draw_text(ROW1_V_X, ROW1_Y, buf.data());
+            display.draw_text(V_X, ROW2_Y - 10, buf.data());
 
             format_milli(buf, vm.snapshot.current_ma, 'A');
-            display.draw_text(ROW1_A_X, ROW1_Y, buf.data());
+            display.draw_text(A_X, ROW2_Y + 5, buf.data());
+
+            format_time(buf, vm.total_seconds);
+            display.draw_text(T_X, ROW3_Y, buf.data());
+
+
+            format_auto(buf, vm.accumulated_wh);
+            draw_value(display, COL1_X, ROW3_Y, buf.data(), "Wh");
+
+            format_auto(buf, vm.accumulated_ah);
+            draw_value(display, COL2_X, ROW3_Y, buf.data(), "Ah");
 
             // Mid — watts and watt-hours
-            display.set_font(tempo::Font::LG);
+            display.set_font(tempo::Font::XL);
             const double watts = (vm.snapshot.vbus_mv * vm.snapshot.current_ma) / 1'000'000.0;
 
             format_auto(buf, watts);
             draw_value(display, COL1_X, ROW2_Y, buf.data(), "W");
-
-            format_auto(buf, vm.accumulated_wh);
-            draw_value(display, COL2_X, ROW2_Y, buf.data(), "Wh");
-
-            // Bottom — time and amp-hours
-            format_time(buf, vm.total_seconds);
-            display.draw_text(COL1_X, ROW3_Y, buf.data());
-
-            format_auto(buf, vm.accumulated_ah);
-            draw_value(display, COL2_X, ROW3_Y, buf.data(), "Ah");
 
             display.flush();
         }

--- a/include/v2/stages/energy_stage.h
+++ b/include/v2/stages/energy_stage.h
@@ -73,14 +73,12 @@ namespace pocketpd {
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
-                    if (evt.id != ButtonId::R) {
-                        return;
-                    }
-                    if (evt.gesture == Gesture::SHORT) {
+                    if (evt.r_short()) {
                         m_output_gate.toggle();
                         return;
                     }
-                    if (evt.gesture == Gesture::LONG) {
+
+                    if (evt.r_long()) {
                         conductor.request<NormalStage>(m_active_pdo_index);
                     }
                 },

--- a/include/v2/stages/normal/normal_view.h
+++ b/include/v2/stages/normal/normal_view.h
@@ -50,8 +50,9 @@ namespace pocketpd {
         static constexpr uint8_t TARGET_RIGHT_X = 75;
         static constexpr uint8_t STATUS_X = 110;
         static constexpr uint8_t OUTPUT_LABEL_X = 90;
-        static constexpr uint8_t ARROW_X = 105;
-        static constexpr uint8_t ARROW_Y = 0;
+
+        static constexpr uint8_t ARROW_X = 108;
+        static constexpr uint8_t ARROW_Y = 20;
         static constexpr uint8_t ARROW_W = 20;
         static constexpr uint8_t ARROW_H = 20;
         static constexpr std::array<uint8_t, 3> CURSOR_X = {33, 39, 45};
@@ -76,9 +77,11 @@ namespace pocketpd {
 
             d.set_font(tempo::Font::BASE);
             std::snprintf(buf.data(), buf.size(), "[%u]", vm.active_pdo_index);
-            d.draw_text(STATUS_X, 50, buf.data());
+
+            const auto INDEX_X = STATUS_X - d.text_width(buf.data()) - 2;
+            d.draw_text(INDEX_X, 63, buf.data());
             d.draw_text(STATUS_X, 64, vm.is_pps ? "PPS" : "PDO");
-            d.draw_text(OUTPUT_LABEL_X, 14, vm.output_enabled ? "ON" : "OFF");
+            d.draw_text(INDEX_X + 2, 8, vm.output_enabled ? "ON" : "OFF");
 
             if (vm.is_pps) {
                 draw_target_pps(d, vm, buf);

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -126,17 +126,17 @@ namespace pocketpd {
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
-                    if (evt.id == ButtonId::R && evt.gesture == Gesture::SHORT) {
+                    if (evt.r_short()) {
                         m_output_gate.toggle();
                         return;
                     }
 
-                    if (evt.id == ButtonId::R && evt.gesture == Gesture::LONG) {
+                    if (evt.r_long()) {
                         conductor.request<EnergyStage>(m_active_pdo_index);
                         return;
                     }
 
-                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                    if (evt.l_long()) {
                         conductor.request<ProfilePickerStage>();
                         return;
                     }

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -345,7 +345,7 @@ TEST(NormalStage, OnEnterPdoBranchRendersVAReadoutAndPdoIndex) {
     EXPECT_CALL(display, draw_text(1, 48, StrEq("A"))).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(::testing::_, 28, HasSubstr("20000 mV"))).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(::testing::_, 62, HasSubstr("5000 mA"))).Times(AtLeast(1));
-    EXPECT_CALL(display, draw_text(110, 50, HasSubstr("[2]"))).Times(AtLeast(1));
+    EXPECT_CALL(display, draw_text(::testing::_, 63, HasSubstr("[2]"))).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(110, 64, StrEq("PDO"))).Times(AtLeast(1));
     EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, StrEq("OFF"))).Times(AtLeast(1));
     EXPECT_CALL(display, flush()).Times(AtLeast(1));


### PR DESCRIPTION
## Summary
NormalView and EnergyView layout tuning. The index marker, ON/OFF label, and arrow no longer crowd the right edge. EnergyView gets a bigger watts readout and a reordered row layout: live V/A and time on one tier, Wh/Ah on the row below.

Adds `r_short()` / `r_long()` / `l_long()` / `l_short()` predicates on `ButtonEvent`. NormalStage and EnergyStage use them at the call sites instead of inline `id == X && gesture == Y` checks.

Display fonts switch from proportional `_tr` to monospaced `_mr` so digit columns stay aligned as values change.

## Linked issues

## Hardware tested
- [x] None (no hardware change)

How tested: `pio test -e native` (103 cases pass). `pio run -e HW1_3_V2` and `pio run -e HW1_3` both build clean.

![image](https://github.com/user-attachments/assets/91087aa6-4289-433a-ae10-c51d16c1673d)

![image](https://github.com/user-attachments/assets/5ba41538-f85b-4b49-a2ac-b65a3e9569ef)

## Breaking change / migration

Details:

## Notes
UI only, no behaviour change to button mapping, output toggling, or PD negotiation.