### PR TITLE
feat(v2): add TwoButtonsGestureDetector for L+R long-press

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ ColumnLimit: 100
 IndentWidth: 4
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveMacros: Consecutive
 AlignOperands: AlignAfterOperator
 AllowShortFunctionsOnASingleLine: Empty

--- a/include/v2/input/button_gesture.h
+++ b/include/v2/input/button_gesture.h
@@ -23,16 +23,37 @@ namespace pocketpd {
         enum class State : uint8_t {
             IDLE,
             PRESSED,  
-            POST_LONG,
+            LATCHED,
         };
         
         State m_state = State::IDLE;
+        State m_prev_state = State::IDLE;
 
         ButtonGestureConfig m_config;
         tempo::TimeoutTimer m_long_timeout;
 
+
     public:
         explicit ButtonGestureDetector(ButtonGestureConfig config = {}) : m_config(config) {}
+
+        /** @brief True while the button is held (PRESSED or LATCHED). */
+        bool is_holding() const {
+            return m_state != State::IDLE;
+        }
+
+        /** @brief True only on the tick the press started (IDLE → PRESSED). */
+        bool is_pressed() const {
+            return m_prev_state == State::IDLE && m_state == State::PRESSED;
+        }
+
+        /** @brief Timestamp captured at IDLE → PRESSED. Undefined before first press. */
+        uint32_t pressed_at_ms() const {
+            return m_long_timeout.set_ms();
+        }
+
+        uint32_t duration(uint32_t now_ms) const {
+            return now_ms - pressed_at_ms();
+        }
 
         /**
          * @brief Feed one sample. Returns a gesture on the tick it is recognized, otherwise
@@ -43,15 +64,17 @@ namespace pocketpd {
          *
          * State diagram:
          * @verbatim
-         *     ┌──────┐  hold / arm timer   ┌─────────┐  reached / LONG    ┌───────────┐
-         *     │ IDLE │ ───────────────────▶│ PRESSED │ ──────────────────▶│ POST_LONG │
-         *     └──────┘                     └────┬────┘                    └─────┬─────┘
-         *         ▲                             │                               │
-         *         │       release / SHORT       │            release            │
-         *         └─────────────────────────────┴───────────────────────────────┘
+         *     ┌──────┐  hold / arm timer   ┌─────────┐  reached / LONG  ┌─────────┐
+         *     │ IDLE │ ───────────────────▶│ PRESSED │ ────────────────▶│ LATCHED │
+         *     └──────┘                     └────┬────┘                  └────┬────┘
+         *         ▲                             │                            │
+         *         │       release / SHORT       │           release          │
+         *         └─────────────────────────────┴────────────────────────────┘
          * @endverbatim
          */
-        std::optional<Gesture> update(bool is_holding, uint32_t now_ms) {
+        std::optional<Gesture> update(uint32_t now_ms, bool is_holding) {
+            m_prev_state = m_state;
+
             switch (m_state) {
             case State::IDLE:
                 if (is_holding) {
@@ -69,14 +92,14 @@ namespace pocketpd {
                 }
 
                 if (m_long_timeout.reached(now_ms)) {
-                    m_state = State::POST_LONG;
+                    m_state = State::LATCHED;
                     m_long_timeout.disarm();
                     return Gesture::LONG;
                 }
 
                 return std::nullopt;
 
-            case State::POST_LONG:
+            case State::LATCHED:
                 if (!is_holding) {
                     m_state = State::IDLE;
                 }

--- a/include/v2/input/two_buttons_gesture.h
+++ b/include/v2/input/two_buttons_gesture.h
@@ -1,0 +1,99 @@
+/**
+ * @file two_buttons_gesture.h
+ * @brief Pure state machine that recognizes a two-button long-press sample stream.
+ */
+#pragma once
+
+#include <tempo/core/time.h>
+
+#include <cstdint>
+#include <optional>
+
+#include "v2/input/button_gesture.h"
+#include "v2/state.h"
+
+namespace pocketpd {
+
+    class TwoButtonsGestureDetector {
+    private:
+        enum class TwoButtonsState : uint8_t {
+            IDLE,
+            ARMED,
+            LATCHED,
+        };
+
+        TwoButtonsState m_state = TwoButtonsState::IDLE;
+        ButtonGestureConfig m_config;
+        tempo::TimeoutTimer m_long_timeout;
+
+    public:
+        explicit TwoButtonsGestureDetector(ButtonGestureConfig config = {}) : m_config(config) {}
+
+        /** @brief True while a two-button gesture is in progress (ARMED) or holding suppression
+         * (LATCHED).
+         */
+        bool is_active() const {
+            return m_state != TwoButtonsState::IDLE;
+        }
+
+        /**
+         * @brief Feed one sample of each button's holding state. Returns `Gesture::LONG` on the
+         * tick the two-button gesture fires, otherwise `std::nullopt`.
+         *
+         * LONG fires once at the threshold while both are still held. Releasing either button
+         * before the threshold aborts without emit. Release wins ties against timer expiry on
+         * the same tick. LATCHED holds until BOTH release, so callers use `is_active()` as the
+         * suppression predicate for individual L/R gestures.
+         *
+         * State diagram:
+         * @verbatim
+         *    ┌──────┐ both held / arm   ┌───────┐  timer / LONG  ┌─────────┐
+         *    │ IDLE │ ─────────────────▶│ ARMED │ ──────────────▶│ LATCHED │
+         *    └──────┘                   └───────┘                └────┬────┘
+         *        ▲                                                    │
+         *        │                                                    │
+         *        │                   both released                    │
+         *        └────────────────────────────────────────────────────┘
+         *
+         *    ARMED + one released ─▶ LATCHED (abort, no emit).
+         * @endverbatim
+         */
+        std::optional<Gesture> update(uint32_t now_ms, bool is_holding_l, bool is_holding_r) {
+            const bool both_holding = is_holding_l && is_holding_r;
+            const bool none_holding = !is_holding_l && !is_holding_r;
+
+            switch (m_state) {
+            case TwoButtonsState::IDLE:
+                if (both_holding) {
+                    m_state = TwoButtonsState::ARMED;
+                    m_long_timeout.set(now_ms, m_config.long_press_ms);
+                }
+
+                return std::nullopt;
+            case TwoButtonsState::ARMED:
+                if (!both_holding) {
+                    m_state = TwoButtonsState::LATCHED;
+                    m_long_timeout.disarm();
+                    return std::nullopt;
+                }
+
+                if (m_long_timeout.reached(now_ms)) {
+                    m_state = TwoButtonsState::LATCHED;
+                    m_long_timeout.disarm();
+                    return Gesture::LONG;
+                }
+
+                return std::nullopt;
+            case TwoButtonsState::LATCHED:
+                if (none_holding) {
+                    m_state = TwoButtonsState::IDLE;
+                }
+
+                return std::nullopt;
+            }
+
+            return std::nullopt;
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/state.h
+++ b/include/v2/state.h
@@ -9,19 +9,46 @@
 namespace pocketpd {
 
     /**
-     * @brief Identifier for the three physical buttons. `L` and `R` denote
-     * the left and right side buttons; `ENCODER` is the rotary push.
+     * @brief Identifier for the three physical buttons plus a synthetic L_R combo.
+     * `L` and `R` denote the left and right side buttons; `ENCODER` is the rotary push.
      */
     enum class ButtonId : uint8_t {
         ENCODER,
         R,
         L,
+        L_R,
     };
+
+    inline const char* to_string(ButtonId btn_id) {
+        switch (btn_id) {
+        case ButtonId::ENCODER:
+            return "ENCODER_BTN";
+        case ButtonId::L:
+            return "L_BTN";
+        case ButtonId::R:
+            return "R_BTN";
+        case ButtonId::L_R:
+            return "L_R_SYNTHETIC";
+        default:
+            return "UNKNOWN";
+        }
+    }
 
     enum class Gesture : uint8_t {
         SHORT,
         LONG,
     };
+
+    inline const char* to_string(Gesture g) {
+        switch (g) {
+        case Gesture::SHORT:
+            return "SHORT";
+        case Gesture::LONG:
+            return "LONG";
+        default:
+            return "UNKNOWN";
+        }
+    }
 
     /**
      * @brief Latest sensor reading from INA226.

--- a/include/v2/tasks/button_task.h
+++ b/include/v2/tasks/button_task.h
@@ -1,8 +1,6 @@
 /**
  * @file button_task.h
- * @brief Polls 3 buttons at 5 ms and feeds each into its own ButtonGestureDetector. Publishes a
- * `ButtonEvent` whenever a detector recognizes a SHORT or LONG gesture. `poll(now_ms)`
- * is public so native tests drive the task directly.
+ * @brief Run guesture recognition on 3 buttons at 5 ms interval.
  */
 #pragma once
 
@@ -10,10 +8,12 @@
 #include <tempo/hardware/button_input.h>
 
 #include <cstdint>
+#include <optional>
 
 #include "v2/app.h"
 #include "v2/events.h"
 #include "v2/input/button_gesture.h"
+#include "v2/input/two_buttons_gesture.h"
 #include "v2/state.h"
 
 namespace pocketpd {
@@ -26,15 +26,16 @@ namespace pocketpd {
             ButtonId id;
             tempo::ButtonInput* input;
             ButtonGestureDetector detector;
-            bool was_held = false;
-            uint32_t pressed_at_ms = 0;
 
             DetectorRef() = delete;
         };
-
-        std::array<DetectorRef, 3> m_detectors;
+        std::array<DetectorRef, 3> m_detector_refs;
+        TwoButtonsGestureDetector m_combo_detector;
 
         static constexpr uint32_t POLL_PERIOD_MS = 5;
+        static constexpr size_t IDX_ENCODER = 0;
+        static constexpr size_t IDX_L = 1;
+        static constexpr size_t IDX_R = 2;
 
     public:
         static constexpr const char* LOG_TAG = "ButtonTask";
@@ -46,7 +47,7 @@ namespace pocketpd {
             ButtonGestureConfig gesture_config = {}
         )
             : App::BackgroundTask(POLL_PERIOD_MS),
-              m_detectors{
+              m_detector_refs{
                   DetectorRef{
                       ButtonId::ENCODER,
                       &btn_encoder,
@@ -62,49 +63,60 @@ namespace pocketpd {
                       &btn_r,
                       ButtonGestureDetector{gesture_config},
                   },
-              } {}
+              },
+              m_combo_detector(gesture_config) {}
 
         const char* name() const override {
             return "ButtonTask";
         }
 
-        const char* button_name(ButtonId id) {
-            switch (id) {
-            case ButtonId::ENCODER:
-                return "ENCODER_BTN";
-            case ButtonId::L:
-                return "L_BTN";
-            case ButtonId::R:
-                return "R_BTN";
-            default:
-                return "UNKNOWN";
-            }
-        }
-
         void poll(uint32_t now_ms) {
-            for (DetectorRef& ref : m_detectors) {
+            // Update each button detector and capture the gesture.
+            std::array<std::optional<Gesture>, 3> gestures{};
+
+            for (size_t i = 0; i < m_detector_refs.size(); ++i) {
+                DetectorRef& ref = m_detector_refs[i];
                 ref.input->update();
+                gestures[i] = ref.detector.update(now_ms, ref.input->is_held());
 
-                
-                // Debug button latency (including debounce time)
-                const bool is_held = ref.input->is_held();
-                if (is_held && !ref.was_held) {
-                    ref.pressed_at_ms = now_ms;
-                    log.debug("button={} press_start_at={}ms", button_name(ref.id), now_ms);
+                if (ref.detector.is_pressed()) {
+                    log.debug("button={} press_start_at={}ms", to_string(ref.id), now_ms);
                 }
-                ref.was_held = is_held;
+            }
 
-                const std::optional<Gesture> gesture = ref.detector.update(is_held, now_ms);
-                if (gesture.has_value()) {
-                    const uint32_t duration = now_ms - ref.pressed_at_ms;
-                    log.debug(
-                        "button={} gesture={} hold_duration={}",
-                        button_name(ref.id),
-                        gesture.value() == Gesture::SHORT ? "SHORT" : "LONG",
-                        duration
-                    );
-                    publish(ButtonEvent{ref.id, gesture.value()});
+            // Run the combo detector. It stays active until both buttons are released. The combo
+            // active state suppresses L/R singles.
+            const auto combo_gesture = m_combo_detector.update(
+                now_ms,
+                m_detector_refs[IDX_L].detector.is_holding(),
+                m_detector_refs[IDX_R].detector.is_holding()
+            );
+
+            // If the combo detector fired, publish the combo gesture.
+            if (combo_gesture.has_value()) {
+                log.debug("combo={} gesture={}", to_string(ButtonId::L_R), "LONG");
+                publish(ButtonEvent{ButtonId::L_R, combo_gesture.value()});
+            }
+
+            // Publish each button gesture that is not suppressed by the combo detector.
+            for (size_t i = 0; i < m_detector_refs.size(); ++i) {
+                DetectorRef& ref = m_detector_refs[i];
+                const std::optional<Gesture>& gesture = gestures[i];
+
+                if (!gesture.has_value()) {
+                    continue;
                 }
+
+                // Suppress the gesture if it is an L or R single and the combo detector is active.
+                const bool is_LR = (ref.id == ButtonId::L) || (ref.id == ButtonId::R);
+                if (is_LR && m_combo_detector.is_active()) {
+                    continue;
+                }
+
+                const uint32_t duration = ref.detector.duration(now_ms);
+                const char* msg = "button={} gesture={} hold_duration={}";
+                log.debug(msg, to_string(ref.id), to_string(gesture.value()), duration);
+                publish(ButtonEvent{ref.id, gesture.value()});
             }
         }
 

--- a/lib/tempo/include/tempo/core/time.h
+++ b/lib/tempo/include/tempo/core/time.h
@@ -122,6 +122,7 @@ namespace tempo {
      */
     class TimeoutTimer {
     private:
+        uint32_t m_set_ms = 0;
         uint32_t m_due_ms = 0;
         bool m_armed = false;
 
@@ -131,8 +132,14 @@ namespace tempo {
          * `now_ms + duration_ms` is observed. Calling `set` again replaces any prior arm.
          */
         void set(uint32_t now_ms, uint32_t duration_ms) {
+            m_set_ms = now_ms;
             m_due_ms = now_ms + duration_ms;
             m_armed = true;
+        }
+
+        /** @brief Timestamp passed to the most recent `set()`. Undefined if never set. */
+        uint32_t set_ms() const {
+            return m_set_ms;
         }
 
         /**

--- a/test/test_v2_inputs/test.cpp
+++ b/test/test_v2_inputs/test.cpp
@@ -16,9 +16,9 @@
 
 #include <variant>
 
-#include "v2/app.h"
 #include "v2/events.h"
 #include "v2/input/button_gesture.h"
+#include "v2/input/two_buttons_gesture.h"
 #include "v2/state.h"
 #include "v2/tasks/button_task.h"
 #include "v2/tasks/encoder_task.h"
@@ -43,39 +43,47 @@ namespace {
 
 } // namespace
 
+// —— ButtonId
+
+TEST(ButtonId, LRComboValueIsDistinct) {
+    EXPECT_NE(static_cast<int>(ButtonId::L_R), static_cast<int>(ButtonId::L));
+    EXPECT_NE(static_cast<int>(ButtonId::L_R), static_cast<int>(ButtonId::R));
+    EXPECT_NE(static_cast<int>(ButtonId::L_R), static_cast<int>(ButtonId::ENCODER));
+}
+
 // —— ButtonGestureDetector
 
 TEST(ButtonGestureDetector, ShortFiresOnRelease) {
     ButtonGestureDetector d;
-    EXPECT_FALSE(d.update(true, 0).has_value());
+    EXPECT_FALSE(d.update(0, true).has_value());
 
-    auto g = d.update(false, 50);
+    auto g = d.update(50, false);
     ASSERT_TRUE(g.has_value());
     EXPECT_EQ(*g, Gesture::SHORT);
 }
 
 TEST(ButtonGestureDetector, LongFiresAtThresholdWhileHeld) {
     ButtonGestureDetector d;
-    EXPECT_FALSE(d.update(true, 0).has_value());
-    EXPECT_FALSE(d.update(true, kDefaultCfg.long_press_ms - 1).has_value());
+    EXPECT_FALSE(d.update(0, true).has_value());
+    EXPECT_FALSE(d.update(kDefaultCfg.long_press_ms - 1, true).has_value());
 
-    auto g = d.update(true, kDefaultCfg.long_press_ms);
+    auto g = d.update(kDefaultCfg.long_press_ms, true);
     ASSERT_TRUE(g.has_value());
     EXPECT_EQ(*g, Gesture::LONG);
 
-    EXPECT_FALSE(d.update(true, kDefaultCfg.long_press_ms + 500).has_value());
-    EXPECT_FALSE(d.update(false, kDefaultCfg.long_press_ms + 600).has_value());
+    EXPECT_FALSE(d.update(kDefaultCfg.long_press_ms + 500, true).has_value());
+    EXPECT_FALSE(d.update(kDefaultCfg.long_press_ms + 600, false).has_value());
 }
 
 TEST(ButtonGestureDetector, ConsecutivePressesEachEmitShort) {
     ButtonGestureDetector d;
-    d.update(true, 0);
-    auto first = d.update(false, 30);
+    d.update(0, true);
+    auto first = d.update(30, false);
     ASSERT_TRUE(first.has_value());
     EXPECT_EQ(*first, Gesture::SHORT);
 
-    d.update(true, 100);
-    auto second = d.update(false, 130);
+    d.update(100, true);
+    auto second = d.update(130, false);
     ASSERT_TRUE(second.has_value());
     EXPECT_EQ(*second, Gesture::SHORT);
 }
@@ -218,6 +226,229 @@ TEST(EncoderTask, NegativeDelta) {
     const auto* ev = pop_as<EncoderEvent>(q);
     ASSERT_NE(ev, nullptr);
     EXPECT_EQ(ev->delta, -3);
+}
+
+// —— ButtonTask combo
+
+TEST(ButtonTask, BriefSimultaneousTapDropsBothShorts) {
+    FakeButtonInput encoder, l, r;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(encoder, l, r);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
+
+    l.set_held(true);
+    r.set_held(true);
+    task.poll(0);
+    task.poll(50);
+    l.set_held(false);
+    r.set_held(false);
+    task.poll(100);
+
+    Event tmp;
+    EXPECT_FALSE(q.pop(tmp));
+}
+
+TEST(ButtonTask, ComboLongAtThresholdEmitsLRSuppressesIndividuals) {
+    FakeButtonInput encoder, l, r;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(encoder, l, r);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
+
+    l.set_held(true);
+    r.set_held(true);
+    task.poll(0);
+    task.poll(kDefaultCfg.long_press_ms - 1);
+    Event mid;
+    EXPECT_FALSE(q.pop(mid));
+
+    task.poll(kDefaultCfg.long_press_ms);
+
+    const auto* btn = pop_as<ButtonEvent>(q);
+    ASSERT_NE(btn, nullptr);
+    EXPECT_EQ(btn->id, ButtonId::L_R);
+    EXPECT_EQ(btn->gesture, Gesture::LONG);
+
+    Event leftover;
+    EXPECT_FALSE(q.pop(leftover));
+
+    l.set_held(false);
+    r.set_held(false);
+    task.poll(kDefaultCfg.long_press_ms + 100);
+    EXPECT_FALSE(q.pop(leftover));
+}
+
+TEST(ButtonTask, AbortedComboCancelsRemainingSingles) {
+    // Once a combo arms, the chord lifetime owns L+R suppression until BOTH are released.
+    // A failed combo attempt (one finger lifted early) must not leak a single LONG on the
+    // finger that is still held — releasing both is required before per-finger gestures
+    // resume.
+    FakeButtonInput encoder, l, r;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(encoder, l, r);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
+
+    l.set_held(true);
+    task.poll(0);
+    r.set_held(true);
+    task.poll(200);
+    r.set_held(false);
+    task.poll(240);
+
+    Event before;
+    EXPECT_FALSE(q.pop(before));
+
+    task.poll(kDefaultCfg.long_press_ms);
+    Event leftover;
+    EXPECT_FALSE(q.pop(leftover));
+
+    l.set_held(false);
+    task.poll(kDefaultCfg.long_press_ms + 50);
+    EXPECT_FALSE(q.pop(leftover));
+}
+
+TEST(ButtonTask, EncoderButtonNotSuppressedByCombo) {
+    FakeButtonInput encoder, l, r;
+    TestQueue q;
+    TestPublisher pub(q);
+    ButtonTask task(encoder, l, r);
+    task.attach_publisher_INTERNAL_DO_NOT_USE(pub);
+
+    l.set_held(true);
+    r.set_held(true);
+    task.poll(0);
+
+    encoder.set_held(true);
+    task.poll(20);
+    encoder.set_held(false);
+    task.poll(70);
+
+    const auto* btn = pop_as<ButtonEvent>(q);
+    ASSERT_NE(btn, nullptr);
+    EXPECT_EQ(btn->id, ButtonId::ENCODER);
+    EXPECT_EQ(btn->gesture, Gesture::SHORT);
+}
+
+// —— TwoButtonsGestureDetector
+
+TEST(TwoButtonsGestureDetector, IdleUntilBothHeld) {
+    TwoButtonsGestureDetector d;
+    auto out = d.update(0, false, false);
+    EXPECT_FALSE(d.is_active());
+    EXPECT_FALSE(out.has_value());
+}
+
+TEST(TwoButtonsGestureDetector, OneAloneStaysIdle) {
+    TwoButtonsGestureDetector d;
+    auto out = d.update(0, true, false);
+    EXPECT_FALSE(d.is_active());
+    EXPECT_FALSE(out.has_value());
+}
+
+TEST(TwoButtonsGestureDetector, ArmsWhenBothHeld) {
+    TwoButtonsGestureDetector d;
+    auto out = d.update(100, true, true);
+    EXPECT_TRUE(d.is_active());
+    EXPECT_FALSE(out.has_value());
+}
+
+TEST(TwoButtonsGestureDetector, FiresLongAtThreshold) {
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    auto mid = d.update(kDefaultCfg.long_press_ms - 1, true, true);
+    EXPECT_TRUE(d.is_active());
+    EXPECT_FALSE(mid.has_value());
+
+    auto fire = d.update(kDefaultCfg.long_press_ms, true, true);
+    EXPECT_TRUE(d.is_active());
+    ASSERT_TRUE(fire.has_value());
+    EXPECT_EQ(*fire, Gesture::LONG);
+}
+
+TEST(TwoButtonsGestureDetector, NoSecondEmitWhileStillHeldAfterFire) {
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    d.update(kDefaultCfg.long_press_ms, true, true);
+    auto out = d.update(kDefaultCfg.long_press_ms + 200, true, true);
+    EXPECT_TRUE(d.is_active());
+    EXPECT_FALSE(out.has_value());
+}
+
+TEST(TwoButtonsGestureDetector, AbortsWhenOneReleasedBeforeThreshold) {
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    auto out = d.update(200, true, false);
+    EXPECT_TRUE(d.is_active());
+    EXPECT_FALSE(out.has_value());
+}
+
+TEST(TwoButtonsGestureDetector, ReleaseExactlyAtThresholdAborts) {
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    auto out = d.update(kDefaultCfg.long_press_ms, true, false);
+    EXPECT_TRUE(d.is_active());
+    EXPECT_FALSE(out.has_value());
+}
+
+TEST(TwoButtonsGestureDetector, AbortedPersistsWhileOneHeld) {
+    // LATCHED must stick until BOTH buttons release, so callers can use
+    // `is_active()` as the L/R suppression predicate for the whole chord lifetime.
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    d.update(100, true, false);
+    ASSERT_TRUE(d.is_active());
+
+    d.update(200, true, false);
+    EXPECT_TRUE(d.is_active());
+}
+
+TEST(TwoButtonsGestureDetector, AbortClearsOnlyAfterBothReleased) {
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    d.update(100, true, false);  // latched (aborted)
+    d.update(110, true, false);
+    EXPECT_TRUE(d.is_active());
+
+    d.update(200, false, false);
+    EXPECT_FALSE(d.is_active());
+
+    auto rearm = d.update(300, true, true);
+    EXPECT_TRUE(d.is_active());
+    EXPECT_FALSE(rearm.has_value());
+}
+
+TEST(TwoButtonsGestureDetector, FiredPersistsWhileOneHeld) {
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    d.update(kDefaultCfg.long_press_ms, true, true);  // fired → LATCHED
+    d.update(kDefaultCfg.long_press_ms + 50, true, false);
+    EXPECT_TRUE(d.is_active());
+}
+
+TEST(TwoButtonsGestureDetector, FiredClearsOnlyAfterBothReleased) {
+    TwoButtonsGestureDetector d;
+    d.update(0, true, true);
+    d.update(kDefaultCfg.long_press_ms, true, true);
+    d.update(kDefaultCfg.long_press_ms + 50, false, false);
+    EXPECT_FALSE(d.is_active());
+}
+
+TEST(TwoButtonsGestureDetector, SecondPressArmsAtSecondPressTime) {
+    // L pressed at t=0, R pressed at t=80; chord timer should start at t=80
+    // and fire at t=80 + long_press_ms.
+    TwoButtonsGestureDetector d;
+    d.update(0, true, false);   // only L held
+    d.update(80, true, true);
+    EXPECT_TRUE(d.is_active());
+
+    auto pre = d.update(80 + kDefaultCfg.long_press_ms - 1, true, true);
+    EXPECT_FALSE(pre.has_value());
+
+    auto fire = d.update(80 + kDefaultCfg.long_press_ms, true, true);
+    ASSERT_TRUE(fire.has_value());
+    EXPECT_EQ(*fire, Gesture::LONG);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

Add `TwoButtonsGestureDetector` that fires on L+R simultaneous long-press and publishes `ButtonEvent{ButtonId::L_R, Gesture::LONG}` so callers can reuse the existing variant. `tempo::TimeoutTimer` gains `set_ms()` so detectors read the arming timestamp from the timer. Also renames `POST_LONG` to `LATCHED` for parity, updates state diagrams, and switches `.clang-format` `AlignAfterOpenBracket` to `BlockIndent`.

## Linked issues

## Hardware tested
- [x] None (no hardware change)

How tested: `pio test -e native` (115 cases pass). `pio run -e HW1_3_V2` builds clean.

## Breaking change / migration
- [x] Public lib API (`lib/*` headers)

Details: `tempo::TimeoutTimer` gains a `set_ms()` accessor. Additive, no existing callers affected.

## Notes