### PR TITLE
build(make): add command to copy uf2 to dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .cache
 .worktrees
 compile_commands.json
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,21 @@
-.PHONY: test test-root test-tempo build-v1 build-v2 clean
+.PHONY: test test-root test-tempo build-v1 build-v2 build-hw1_0 build-hw1_1 build-hw1_3 build-all clean dist-clean
+
+.DEFAULT_GOAL := test
+
+DIST_DIR := dist
+
+# Pull firmware_version from [common] section in platformio.ini —
+# single source of truth shared with the build envs.
+FIRMWARE_VERSION := $(shell awk -F'=' '/^\[common\]/{f=1;next} /^\[/{f=0} \
+	f && $$1 ~ /^[[:space:]]*firmware_version[[:space:]]*$$/ {gsub(/[[:space:]]/,"",$$2); print $$2; exit}' platformio.ini)
+
+# $(1) = pio env name (e.g. HW1_0_V2); _V2 stripped for dist label.
+# $(2) = version
+define copy_uf2
+	@mkdir -p $(DIST_DIR)
+	@cp .pio/build/$(1)/firmware.uf2 $(DIST_DIR)/PocketPD_$(subst _V2,,$(1))-v$(2).uf2
+	@echo "→ $(DIST_DIR)/PocketPD_$(subst _V2,,$(1))-v$(2).uf2"
+endef
 
 test: test-root test-tempo
 
@@ -10,9 +27,28 @@ test-tempo:
 
 build-v1:
 	pio run -e HW1_3
+	$(call copy_uf2,HW1_3,1.0.0)
 
 build-v2:
 	pio run -e HW1_3_V2
+	$(call copy_uf2,HW1_3_V2,$(FIRMWARE_VERSION))
+
+build-hw1_0:
+	pio run -e HW1_0_V2
+	$(call copy_uf2,HW1_0_V2,$(FIRMWARE_VERSION))
+
+build-hw1_1:
+	pio run -e HW1_1_V2
+	$(call copy_uf2,HW1_1_V2,$(FIRMWARE_VERSION))
+
+build-hw1_3:
+	pio run -e HW1_3_V2
+	$(call copy_uf2,HW1_3_V2,$(FIRMWARE_VERSION))
+
+build-all: build-hw1_0 build-hw1_1 build-hw1_3
 
 clean:
 	pio run -t clean
+
+dist-clean:
+	rm -rf $(DIST_DIR)

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,10 @@
 default_envs = HW1_3, HW1_3_V2
 extra_configs = scripts/fmt_flags.ini
 
+; Shared values. Use as ${common.xx}.
+[common]
+firmware_version = 2.0.1
+
 [pico_base]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = pico
@@ -65,7 +69,7 @@ build_flags =
 	${pico_base.build_flags}
 	-DHW_VERSION_MAJOR=1
 	-DHW_VERSION_MINOR=0
-	-DVERSION="\"2.0.0\""
+	-DVERSION="\"${common.firmware_version}\""
 build_src_filter =
 	-<*>
 	+<main.cpp>
@@ -80,7 +84,7 @@ build_flags =
 	${pico_base.build_flags}
 	-DHW_VERSION_MAJOR=1
 	-DHW_VERSION_MINOR=1
-	-DVERSION="\"2.0.0\""
+	-DVERSION="\"${common.firmware_version}\""
 build_src_filter =
 	-<*>
 	+<main.cpp>
@@ -95,7 +99,7 @@ build_flags =
 	${pico_base.build_flags}
 	-DHW_VERSION_MAJOR=1
 	-DHW_VERSION_MINOR=3
-	-DVERSION="\"2.0.0\""
+	-DVERSION="\"${common.firmware_version}\""
 build_src_filter =
 	-<*>
 	+<main.cpp>


### PR DESCRIPTION
## Summary
Adds `make build-hw1_0`, `build-hw1_1`, `build-hw1_3` (and `build-all`) targets that build the matching `HW1_x_V2` env and copies versioned `.uf2` into `dist/`. Firmware version moves to a single `[common] firmware_version` key in `platformio.ini`.

## Linked issues

## Hardware tested
- [x] None (no hardware change)

How tested: `make build-all` produces three uf2 files in `dist/` with expected names. `pio test -e native` 132/132 on the PR branch.

## Breaking change / migration
Details:

## Notes