### PR TITLE
feat(v2): USB-A non-PD passthrough mode

### DIFF
--- a/include/v2/pocketpd.h
+++ b/include/v2/pocketpd.h
@@ -22,6 +22,7 @@ namespace pocketpd {
      */
     constexpr uint32_t BOOT_TO_OBTAIN_MS = 500;
     constexpr uint32_t OBTAIN_TO_PROFILE_PICKER_MS = 1500;
+    constexpr uint32_t PICKER_PASSTHROUGH_AUTO_MS = 3000;
 
     /**
      * @brief What the rotary encoder is currently editing.

--- a/include/v2/stages/normal/fixed_mode.h
+++ b/include/v2/stages/normal/fixed_mode.h
@@ -1,13 +1,16 @@
 /**
  * @file fixed_mode.h
- * @brief Fixed-PDO sub-mode marker for NormalStage.
- *
- * Empty tag struct. The fixed-PDO branch carry no per-mode state.
+ * @brief Fixed-PDO sub-mode for NormalStage.
  */
 #pragma once
 
+#include <cstdint>
+
 namespace pocketpd {
 
-    struct FixedMode {};
+    struct FixedMode {
+        int32_t pdo_max_mv = 0;
+        int32_t pdo_max_ma = 0;
+    };
 
 } // namespace pocketpd

--- a/include/v2/stages/normal/mode.h
+++ b/include/v2/stages/normal/mode.h
@@ -1,0 +1,17 @@
+/**
+ * @file mode.h
+ * @brief NormalStage sub-mode variant.
+ */
+#pragma once
+
+#include <variant>
+
+#include "v2/stages/normal/fixed_mode.h"
+#include "v2/stages/normal/passthrough_mode.h"
+#include "v2/stages/normal/pps_mode.h"
+
+namespace pocketpd {
+
+    using Mode = std::variant<PassthroughMode, FixedMode, PPSMode>;
+
+} // namespace pocketpd

--- a/include/v2/stages/normal/normal_view.h
+++ b/include/v2/stages/normal/normal_view.h
@@ -7,41 +7,30 @@
 #include <array>
 #include <cstdint>
 #include <cstdio>
+#include <variant>
 
+#include <tempo/bus/visit.h>
 #include <tempo/hardware/display.h>
 
 #include "v2/events.h"
 #include "v2/images.h"
 #include "v2/pocketpd.h"
+#include "v2/stages/normal/mode.h"
 
 namespace pocketpd {
 
     /**
      * @brief Frozen snapshot of everything NormalView needs to draw one frame.
-     *
      */
     struct NormalViewModel {
         int8_t active_pdo_index = -1;
-        bool has_profile = false;
-        bool is_pps = false;
         bool output_enabled = false;
         bool readout_visible = true;
         bool locked = false;
         uint8_t arrow_frame = 0;
         LoadReading load_reading{};
         SupplyReading supply_reading{};
-
-        // —— PPS branch (valid when has_profile && is_pps)
-
-        int32_t target_mv = 0;
-        int32_t target_ma = 0;
-        AdjustMode adjust_mode = AdjustMode::VOLTAGE;
-        uint8_t cursor_idx = 0;
-
-        // —— Fixed branch (valid when has_profile && !is_pps)
-
-        int32_t pdo_max_mv = 0;
-        int32_t pdo_max_ma = 0;
+        Mode mode = PassthroughMode{};
     };
 
     class NormalView {
@@ -70,13 +59,6 @@ namespace pocketpd {
         static void render(tempo::Display& d, const NormalViewModel& vm) {
             d.clear();
 
-            if (!vm.has_profile) {
-                d.set_font(tempo::Font::BASE);
-                d.draw_text(8, 34, "No Profile Selected");
-                d.flush();
-                return;
-            }
-
             std::array<char, 32> buf{};
 
             d.set_font(tempo::Font::XL);
@@ -87,29 +69,17 @@ namespace pocketpd {
             );
 
             d.set_font(tempo::Font::BASE);
-            std::snprintf(buf.data(), buf.size(), "[%u]", vm.active_pdo_index);
 
-            const auto INDEX_X = STATUS_X - d.text_width(buf.data()) - 2;
-            d.draw_text(INDEX_X, 63, buf.data());
-            d.draw_text(STATUS_X, 64, vm.is_pps ? "PPS" : "PDO");
+            std::visit(
+                tempo::overloaded{
+                    [&](const PassthroughMode&) { draw_passthrough(d); },
+                    [&](const FixedMode& mode) { draw_fixed(d, vm, mode, buf); },
+                    [&](const PPSMode& mode) { draw_pps(d, vm, mode, buf); },
+                },
+                vm.mode
+            );
 
-            if (vm.is_pps) {
-                draw_target_pps(d, vm, buf);
-            } else {
-                draw_target_fixed(d, vm, buf);
-            }
-
-            if (vm.output_enabled) {
-                const uint8_t frame = vm.arrow_frame % bitmap::ARROW_FRAMES.size();
-                d.draw_xbm(ARROW_X, ARROW_Y, ARROW_W, ARROW_H, bitmap::ARROW_FRAMES.at(frame));
-            }
-
-            if (vm.locked) {
-                d.draw_text(INDEX_X + 2, 8, vm.output_enabled ? "ON" : "OFF");
-                d.draw_xbm(PADLOCK_X, PADLOCK_Y, PADLOCK_W, PADLOCK_H, bitmap::PADLOCK.data());
-            } else {
-                d.draw_text(PADLOCK_X - 6, 8, vm.output_enabled ? "ON" : "OFF");
-            }
+            draw_output_indicator(d, vm);
 
             d.flush();
         }
@@ -134,30 +104,73 @@ namespace pocketpd {
             d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - width), y, buf.data());
         }
 
-        static void
-        draw_target_fixed(tempo::Display& d, const NormalViewModel& vm, std::array<char, 32>& buf) {
-            std::snprintf(buf.data(), buf.size(), "%ld mV", static_cast<long>(vm.pdo_max_mv));
+        static void draw_passthrough(tempo::Display& d) {
+            const char* label = "Passthrough";
+            const auto label_w = d.text_width(label);
+            const auto label_x = static_cast<uint8_t>((128 - label_w) / 2);
+            d.draw_text(label_x, 63, label);
+        }
+
+        static void draw_pdo_badge(
+            tempo::Display& d, const NormalViewModel& vm, std::array<char, 32>& buf, const char* tag
+        ) {
+            std::snprintf(buf.data(), buf.size(), "[%u]", vm.active_pdo_index);
+            const auto index_x = STATUS_X - d.text_width(buf.data()) - 2;
+            d.draw_text(index_x, 63, buf.data());
+            d.draw_text(STATUS_X, 64, tag);
+        }
+
+        static void draw_fixed(
+            tempo::Display& d,
+            const NormalViewModel& vm,
+            const FixedMode& mode,
+            std::array<char, 32>& buf
+        ) {
+            draw_pdo_badge(d, vm, buf, "PDO");
+
+            std::snprintf(buf.data(), buf.size(), "%ld mV", static_cast<long>(mode.pdo_max_mv));
             auto w = d.text_width(buf.data());
             d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), V_TARGET_Y, buf.data());
 
-            std::snprintf(buf.data(), buf.size(), "%ld mA", static_cast<long>(vm.pdo_max_ma));
+            std::snprintf(buf.data(), buf.size(), "%ld mA", static_cast<long>(mode.pdo_max_ma));
             w = d.text_width(buf.data());
             d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), A_TARGET_Y, buf.data());
         }
 
-        static void
-        draw_target_pps(tempo::Display& d, const NormalViewModel& vm, std::array<char, 32>& buf) {
-            std::snprintf(buf.data(), buf.size(), "%ld mV", static_cast<long>(vm.target_mv));
+        static void draw_pps(
+            tempo::Display& d,
+            const NormalViewModel& vm,
+            const PPSMode& mode,
+            std::array<char, 32>& buf
+        ) {
+            draw_pdo_badge(d, vm, buf, "PPS");
+
+            std::snprintf(buf.data(), buf.size(), "%ld mV", static_cast<long>(mode.target_mv));
             auto w = d.text_width(buf.data());
             d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), V_TARGET_Y, buf.data());
 
-            std::snprintf(buf.data(), buf.size(), "%ld mA", static_cast<long>(vm.target_ma));
+            std::snprintf(buf.data(), buf.size(), "%ld mA", static_cast<long>(mode.target_ma));
             w = d.text_width(buf.data());
             d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), A_TARGET_Y, buf.data());
 
             const uint8_t cursor_y =
-                ((vm.adjust_mode == AdjustMode::VOLTAGE) ? V_TARGET_Y : A_TARGET_Y) + 1;
-            d.draw_box(CURSOR_X.at(vm.cursor_idx), cursor_y, CURSOR_W, 1);
+                ((mode.adjust_mode == AdjustMode::VOLTAGE) ? V_TARGET_Y : A_TARGET_Y) + 1;
+            d.draw_box(CURSOR_X.at(mode.cursor_index()), cursor_y, CURSOR_W, 1);
+        }
+
+        static void draw_output_indicator(tempo::Display& d, const NormalViewModel& vm) {
+            const char* state = vm.output_enabled ? "ON" : "OFF";
+            if (vm.locked) {
+                d.draw_text(OUTPUT_LABEL_X, 8, state);
+                d.draw_xbm(PADLOCK_X, PADLOCK_Y, PADLOCK_W, PADLOCK_H, bitmap::PADLOCK.data());
+            } else {
+                d.draw_text(PADLOCK_X - 6, 8, state);
+            }
+
+            if (vm.output_enabled) {
+                const uint8_t frame = vm.arrow_frame % bitmap::ARROW_FRAMES.size();
+                d.draw_xbm(ARROW_X, ARROW_Y, ARROW_W, ARROW_H, bitmap::ARROW_FRAMES.at(frame));
+            }
         }
     };
 

--- a/include/v2/stages/normal/passthrough_mode.h
+++ b/include/v2/stages/normal/passthrough_mode.h
@@ -1,0 +1,11 @@
+/**
+ * @file passthrough_mode.h
+ * @brief Passthrough sub-mode for NormalStage.
+ */
+#pragma once
+
+namespace pocketpd {
+
+    struct PassthroughMode {};
+
+} // namespace pocketpd

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -15,13 +15,10 @@
 #include "v2/hal/output_gate.h"
 #include "v2/hal/pd_sink_controller.h"
 #include "v2/pocketpd.h"
-#include "v2/stages/normal/fixed_mode.h"
+#include "v2/stages/normal/mode.h"
 #include "v2/stages/normal/normal_view.h"
-#include "v2/stages/normal/pps_mode.h"
 
 namespace pocketpd {
-
-    using Mode = std::variant<FixedMode, PPSMode>;
 
     class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
     private:
@@ -39,14 +36,14 @@ namespace pocketpd {
 
         int8_t m_active_pdo_index = -1;
         int8_t m_last_active_index = -1;
-        bool m_locked = false;
         Mode m_mode;
-
+        
         IntervalTimer m_render_interval{40};
         uint8_t m_arrow_frame = 0;
         uint32_t m_last_draw_ms = 0;
         bool m_blink_visible = true;
-
+        
+        bool m_locked = false;
         // After OFF->ON, the first INA226 read returns a stale conversion (latched while FET
         // was off; observed ~200 mV instead of true VBUS). Discard N load samples and hold the
         // seeded supply value until the sensor has a fresh conversion in hand.
@@ -84,18 +81,22 @@ namespace pocketpd {
             const auto* p = std::get_if<PPSMode>(&m_mode);
             return p ? p->target_mv : 0;
         }
+
         int32_t target_ma() const {
             const auto* p = std::get_if<PPSMode>(&m_mode);
             return p ? p->target_ma : 0;
         }
+
         AdjustMode adjust_mode() const {
             const auto* p = std::get_if<PPSMode>(&m_mode);
             return p ? p->adjust_mode : AdjustMode::VOLTAGE;
         }
+
         uint8_t voltage_increment_index() const {
             const auto* p = std::get_if<PPSMode>(&m_mode);
             return p ? p->voltage_idx : 0;
         }
+
         uint8_t current_increment_index() const {
             const auto* p = std::get_if<PPSMode>(&m_mode);
             return p ? p->current_idx : 0;
@@ -108,16 +109,21 @@ namespace pocketpd {
         void on_enter(Conductor&) override {
             m_locked = false;
 
+            int count = m_pd_sink.pdo_count();
+            if (count == 0) {
+                m_mode = PassthroughMode{};
+                draw();
+                return;
+            }
+
+            // Set active PDO index to 0 if it has not been set before
+            if (m_active_pdo_index < 0) {
+                m_active_pdo_index = 0;
+            }
+
             // Turns off output if the profile has changed
             if (m_active_pdo_index != m_last_active_index) {
                 m_output_gate.disable();
-            }
-
-            if (m_active_pdo_index < 0) {
-                m_last_active_index = -1;
-                log.info("Entered with no profile selected");
-                draw();
-                return;
             }
 
             if (m_pd_sink.is_index_pps(m_active_pdo_index)) {
@@ -232,10 +238,8 @@ namespace pocketpd {
          * mode switch; otherwise preserve the user's prior target edits and reissue.
          */
         void enter_pps_profile() {
-            const bool same_profile = (m_active_pdo_index == m_last_active_index);
-            const bool reusable = same_profile && std::holds_alternative<PPSMode>(m_mode);
-
-            if (!reusable) {
+            bool same_profile = m_active_pdo_index == m_last_active_index;
+            if (!same_profile) {
                 PPSMode pps{m_pd_sink, m_active_pdo_index};
                 m_mode = pps;
 
@@ -254,9 +258,10 @@ namespace pocketpd {
          * @brief Enter a fixed PDO profile. Trigger `set_pdo` on every entry.
          */
         void enter_fixed_profile() {
-            if (!std::holds_alternative<FixedMode>(m_mode)) {
-                m_mode = FixedMode{};
-            }
+            m_mode = FixedMode{
+                .pdo_max_mv = m_pd_sink.pdo_max_voltage_mv(m_active_pdo_index),
+                .pdo_max_ma = m_pd_sink.pdo_max_current_ma(m_active_pdo_index),
+            };
 
             log.info("Entered PDO profile pdo_index={}", m_active_pdo_index);
             if (!m_pd_sink.set_pdo(m_active_pdo_index)) {
@@ -265,37 +270,16 @@ namespace pocketpd {
         }
 
         NormalViewModel build_view_model() const {
-            NormalViewModel vm = {
+            return NormalViewModel{
                 .active_pdo_index = m_active_pdo_index,
-                .has_profile = m_active_pdo_index >= 0,
                 .output_enabled = m_output_gate.is_enabled(),
                 .readout_visible = m_blink_visible,
                 .locked = m_locked,
                 .arrow_frame = m_arrow_frame,
                 .load_reading = m_load_reading,
                 .supply_reading = m_supply_reading,
+                .mode = m_mode,
             };
-
-            if (!vm.has_profile) {
-                return vm;
-            }
-
-            auto handle_mode = tempo::overloaded{
-                [&](const FixedMode& mode) {
-                    vm.pdo_max_mv = m_pd_sink.pdo_max_voltage_mv(m_active_pdo_index);
-                    vm.pdo_max_ma = m_pd_sink.pdo_max_current_ma(m_active_pdo_index);
-                },
-                [&](const PPSMode& mode) {
-                    vm.is_pps = true;
-                    vm.target_mv = mode.target_mv;
-                    vm.target_ma = mode.target_ma;
-                    vm.adjust_mode = mode.adjust_mode;
-                    vm.cursor_idx = mode.cursor_index();
-                },
-            };
-
-            std::visit(handle_mode, m_mode);
-            return vm;
         }
 
         void draw() {

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -1,20 +1,18 @@
 /**
  * @file profile_picker_stage.h
- * @brief Profile-selection stage. Renders the source PDO list with an encoder-driven cursor.
- * The user commits a profile by long-pressing the encoder, or exits without changing by long-
- * pressing L. There is no auto-transition to Normal — the user must choose.
+ * @brief Profile-selection stage for NormalStage entry.
  */
 #pragma once
-
-#include <tempo/bus/visit.h>
-#include <tempo/core/time.h>
-#include <tempo/hardware/display.h>
 
 #include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdio>
 #include <variant>
+
+#include <tempo/bus/visit.h>
+#include <tempo/core/time.h>
+#include <tempo/hardware/display.h>
 
 #include "v2/app.h"
 #include "v2/events.h"
@@ -23,10 +21,10 @@
 
 namespace pocketpd {
 
-    void render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor = -1);
-
     class ProfilePickerStage : public App::Stage, public App::UseLog<ProfilePickerStage> {
     private:
+        enum class PowerSourceType : uint8_t { NON_PD, PD };
+
         using Display = tempo::Display;
 
         Display& m_display;
@@ -34,6 +32,7 @@ namespace pocketpd {
 
         int m_cursor = 0;
         int m_pending_cursor = 0;
+        tempo::TimeoutTimer m_passthrough_timeout;
 
         void commit(Conductor& conductor) {
             if (m_pd_sink.pdo_count() <= 0) {
@@ -57,28 +56,53 @@ namespace pocketpd {
             return m_cursor;
         }
 
-        void on_enter(Conductor&) override {
-            m_pending_cursor = m_cursor;
-            render_pdo_list(m_display, m_pd_sink, m_pending_cursor);
+        PowerSourceType power_source_type() const {
+            return (m_pd_sink.pdo_count() > 0) ? PowerSourceType::PD : PowerSourceType::NON_PD;
         }
 
-        void on_tick(Conductor&, uint32_t) override {}
+        void on_enter(Conductor&) override {
+            m_pending_cursor = m_cursor;
+            m_passthrough_timeout.disarm();
+            render_pdo_list();
+        }
+
+        void on_tick(Conductor& conductor, uint32_t now_ms) override {
+            if (power_source_type() != PowerSourceType::NON_PD) {
+                return;
+            }
+
+            if (!m_passthrough_timeout.armed()) {
+                m_passthrough_timeout.set(now_ms, PICKER_PASSTHROUGH_AUTO_MS);
+                return;
+            }
+
+            if (m_passthrough_timeout.reached(now_ms)) {
+                conductor.request<NormalStage>(static_cast<int8_t>(-1));
+            }
+        }
 
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
+            // Passthrough-only screen: any user input drops to NormalStage in passthrough.
+            if (power_source_type() == PowerSourceType::NON_PD) {
+                auto pass_handler = tempo::overloaded{
+                    [&](const ButtonEvent&) { conductor.request<NormalStage>(-1); },
+                    [&](const EncoderEvent& evt) { conductor.request<NormalStage>(-1); },
+                    [](const auto&) {},
+                };
+                std::visit(pass_handler, event);
+                return;
+            }
+
             auto handler = tempo::overloaded{
                 [&](const EncoderEvent& evt) {
                     const int count = m_pd_sink.pdo_count();
-                    if (count <= 0 || evt.delta == 0) {
-                        return;
-                    }
-
                     int next = std::clamp(m_pending_cursor + evt.delta, 0, count - 1);
                     if (next == m_pending_cursor) {
                         return;
                     }
 
                     m_pending_cursor = next;
-                    render_pdo_list(m_display, m_pd_sink, m_pending_cursor);
+                    render_pdo_list();
                 },
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
@@ -95,59 +119,68 @@ namespace pocketpd {
 
             std::visit(handler, event);
         }
+
+        void render_pdo_list() {
+            m_display.clear();
+
+            if (power_source_type() == PowerSourceType::NON_PD) {
+                const char* line1 = "Non-PD Source";
+                const char* line2 = "Passthrough Mode";
+                const auto x1 = static_cast<uint8_t>((128 - m_display.text_width(line1)) / 2);
+                const auto x2 = static_cast<uint8_t>((128 - m_display.text_width(line2)) / 2);
+                m_display.draw_text(x1, 28, line1);
+                m_display.draw_text(x2, 44, line2);
+                m_display.flush();
+                return;
+            }
+
+            std::array<char, 32> buffer{};
+
+            const int count = m_pd_sink.pdo_count();
+            for (int row_index = 0; row_index < count; row_index++) {
+                const auto y = static_cast<uint8_t>(9 * (row_index + 1));
+
+                if (row_index == m_pending_cursor) {
+                    m_display.draw_text(0, y, ">");
+                }
+
+                std::array<char, 12> vbuf{};
+                if (m_pd_sink.is_index_fixed(row_index)) {
+                    const int v = m_pd_sink.pdo_max_voltage_mv(row_index) / 1000;
+                    const int a = m_pd_sink.pdo_max_current_ma(row_index) / 1000;
+
+                    std::snprintf(vbuf.data(), vbuf.size(), "%7d.0V", v);
+                    std::snprintf(
+                        buffer.data(), buffer.size(), "PDO %-12s%dA", vbuf.data(), a
+                    );
+
+                    m_display.draw_text(10, y, buffer.data());
+                } else if (m_pd_sink.is_index_pps(row_index)) {
+                    const int min_mv = m_pd_sink.pdo_min_voltage_mv(row_index);
+                    const int max_mv = m_pd_sink.pdo_max_voltage_mv(row_index);
+
+                    const int min_v = min_mv / 1000;
+                    const int min_dv = (min_mv % 1000) / 100;
+
+                    const int max_v = max_mv / 1000;
+                    const int max_dv = (max_mv % 1000) / 100;
+
+                    const int a = m_pd_sink.pdo_max_current_ma(row_index) / 1000;
+
+                    std::snprintf(
+                        vbuf.data(), vbuf.size(), "%2d.%d-%2d.%dV",
+                        min_v, min_dv, max_v, max_dv
+                    );
+                    std::snprintf(
+                        buffer.data(), buffer.size(), "PPS %-12s%dA", vbuf.data(), a
+                    );
+
+                    m_display.draw_text(10, y, buffer.data());
+                }
+            }
+
+            m_display.flush();
+        }
     };
-
-    inline void
-    render_pdo_list(tempo::Display& display, const PdSinkController& pd_sink, int cursor) {
-        display.clear();
-
-        const int count = pd_sink.pdo_count();
-        if (count == 0) {
-            const char* msg = "[No Profile Detected]";
-            const auto w = display.text_width(msg);
-            const auto x = static_cast<uint8_t>((128 - w) / 2);
-            display.draw_text(x, 34, msg);
-            display.flush();
-            return;
-        }
-
-        std::array<char, 32> buffer{};
-
-        for (int row_index = 0; row_index < count; row_index++) {
-            const auto y = static_cast<uint8_t>(9 * (row_index + 1));
-
-            if (row_index == cursor) {
-                display.draw_text(0, y, ">");
-            }
-
-            if (pd_sink.is_index_fixed(row_index)) {
-                const int v = pd_sink.pdo_max_voltage_mv(row_index) / 1000;
-                const int a = pd_sink.pdo_max_current_ma(row_index) / 1000;
-
-                const char* fmt = "PDO: %dV @ %dA";
-                std::snprintf(buffer.data(), buffer.size(), fmt, v, a);
-
-                display.draw_text(5, y, buffer.data());
-            } else if (pd_sink.is_index_pps(row_index)) {
-                const int min_mv = pd_sink.pdo_min_voltage_mv(row_index);
-                const int max_mv = pd_sink.pdo_max_voltage_mv(row_index);
-
-                const int min_v = min_mv / 1000;
-                const int min_dv = (min_mv % 1000) / 100;
-
-                const int max_v = max_mv / 1000;
-                const int max_dv = (max_mv % 1000) / 100;
-
-                const int a = pd_sink.pdo_max_current_ma(row_index) / 1000;
-
-                const char* fmt = "PPS: %d.%dV~%d.%dV @ %dA";
-                std::snprintf(buffer.data(), buffer.size(), fmt, min_v, min_dv, max_v, max_dv, a);
-
-                display.draw_text(5, y, buffer.data());
-            }
-        }
-
-        display.flush();
-    }
 
 } // namespace pocketpd

--- a/test/mocks/MockPdSink.h
+++ b/test/mocks/MockPdSink.h
@@ -8,6 +8,10 @@ namespace pocketpd {
 
     class MockPdSink : public PdSinkController {
     public:
+        MockPdSink() {
+            ON_CALL(*this, pdo_count()).WillByDefault(::testing::Return(8));
+        }
+
         MOCK_METHOD(bool, begin, (), (override));
         MOCK_METHOD(int, pdo_count, (), (const, override));
         MOCK_METHOD(int, pps_count, (), (const, override));

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -118,16 +118,20 @@ TEST(NormalStage, SwitchingPpsProfilesResetsTargetsToNewMinimum) {
     EXPECT_EQ(normal.target_ma(), 1000);
 }
 
-TEST(NormalStage, OnEnterWithNegativeIndexRendersNoProfileSelected) {
+TEST(NormalStage, OnEnterWithNegativeIndexRendersPassthrough) {
+    using ::testing::_;
+    using ::testing::AnyNumber;
     using ::testing::HasSubstr;
 
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
     EXPECT_CALL(sink, set_pdo).Times(0);
     EXPECT_CALL(sink, set_pps_pdo).Times(0);
     EXPECT_CALL(display, clear()).Times(::testing::AtLeast(1));
-    EXPECT_CALL(display, draw_text(::testing::_, ::testing::_, HasSubstr("No Profile Selected")))
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(_, _, HasSubstr("Passthrough")))
         .Times(::testing::AtLeast(1));
     EXPECT_CALL(display, flush()).Times(::testing::AtLeast(1));
 
@@ -377,8 +381,7 @@ TEST(NormalView, LockedRendersPadlock) {
     ).Times(1);
 
     NormalViewModel vm{};
-    vm.has_profile = true;
-    vm.is_pps = false;
+    vm.mode = FixedMode{};
     vm.output_enabled = false;
     vm.locked = true;
     vm.active_pdo_index = 0;
@@ -396,8 +399,7 @@ TEST(NormalView, UnlockedDoesNotDrawPadlock) {
     ).Times(0);
 
     NormalViewModel vm{};
-    vm.has_profile = true;
-    vm.is_pps = false;
+    vm.mode = FixedMode{};
     vm.output_enabled = false;
     vm.locked = false;
     vm.active_pdo_index = 0;
@@ -419,8 +421,7 @@ TEST(NormalView, ReadoutHiddenKeepsLabelsHidesValues) {
     EXPECT_CALL(display, draw_text(_, 48, HasSubstr("1."))).Times(0);
 
     NormalViewModel vm{};
-    vm.has_profile = true;
-    vm.is_pps = false;
+    vm.mode = FixedMode{};
     vm.output_enabled = false;
     vm.readout_visible = false;
     vm.active_pdo_index = 0;

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -30,12 +30,13 @@ TEST(ProfilePickerStage, EmptyListRendersFallback) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
-    EXPECT_CALL(display, text_width(StrEq("[No Profile Detected]"))).WillRepeatedly(Return(126));
+    EXPECT_CALL(display, text_width(StrEq("Non-PD Source"))).WillRepeatedly(Return(78));
+    EXPECT_CALL(display, text_width(StrEq("Passthrough Mode"))).WillRepeatedly(Return(96));
 
     EXPECT_CALL(display, clear()).Times(1);
-    EXPECT_CALL(display, draw_text(1, 34, StrEq("[No Profile Detected]"))).Times(1);
+    EXPECT_CALL(display, draw_text(25, 28, StrEq("Non-PD Source"))).Times(1);
+    EXPECT_CALL(display, draw_text(16, 44, StrEq("Passthrough Mode"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
-    EXPECT_CALL(display, draw_text(::testing::Ne(1), ::testing::_, ::testing::_)).Times(0);
 
     ProfilePickerStage stage(display, sink);
     TestConductor conductor;
@@ -54,7 +55,7 @@ TEST(ProfilePickerStage, RendersSingleFixedPdo) {
 
     EXPECT_CALL(display, clear()).Times(1);
     EXPECT_CALL(display, draw_text(0, ::testing::_, StrEq(">"))).Times(::testing::AnyNumber());
-    EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 9, StrEq("PDO       5.0V  3A"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
 
     ProfilePickerStage stage(display, sink);
@@ -80,8 +81,8 @@ TEST(ProfilePickerStage, RendersFixedAndPpsLines) {
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
 
     EXPECT_CALL(display, draw_text(0, ::testing::_, StrEq(">"))).Times(::testing::AnyNumber());
-    EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 9V @ 2A"))).Times(1);
-    EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 3A"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 9, StrEq("PDO       9.0V  2A"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 18, StrEq("PPS  3.3-21.0V  3A"))).Times(1);
 
     ProfilePickerStage stage(display, sink);
     TestConductor conductor;
@@ -108,8 +109,8 @@ TEST(ProfilePickerStage, RendersMultiplePpsLines) {
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(5000));
 
     EXPECT_CALL(display, draw_text(0, ::testing::_, StrEq(">"))).Times(::testing::AnyNumber());
-    EXPECT_CALL(display, draw_text(5, 9, StrEq("PPS: 3.3V~11.0V @ 3A"))).Times(1);
-    EXPECT_CALL(display, draw_text(5, 18, StrEq("PPS: 3.3V~21.0V @ 5A"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 9, StrEq("PPS  3.3-11.0V  3A"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 18, StrEq("PPS  3.3-21.0V  5A"))).Times(1);
 
     ProfilePickerStage stage(display, sink);
     TestConductor conductor;
@@ -133,8 +134,8 @@ TEST(ProfilePickerStage, EntryDrawsCursorAtFirstRow) {
     EXPECT_CALL(display, clear()).Times(1);
     EXPECT_CALL(display, draw_text(0, 9, StrEq(">"))).Times(1);
     EXPECT_CALL(display, draw_text(0, 18, StrEq(">"))).Times(0);
-    EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A"))).Times(1);
-    EXPECT_CALL(display, draw_text(5, 18, StrEq("PDO: 9V @ 2A"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 9, StrEq("PDO       5.0V  3A"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 18, StrEq("PDO       9.0V  2A"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
 
     ProfilePickerStage stage(display, sink);
@@ -165,7 +166,7 @@ TEST(ProfilePickerStage, EncoderMovesCursorAndRerenders) {
     ::testing::Mock::VerifyAndClearExpectations(&display);
 
     EXPECT_CALL(display, clear()).Times(1);
-    EXPECT_CALL(display, draw_text(5, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(10, _, _)).Times(AnyNumber());
     EXPECT_CALL(display, draw_text(0, 9, StrEq(">"))).Times(0);
     EXPECT_CALL(display, draw_text(0, 18, StrEq(">"))).Times(1);
     EXPECT_CALL(display, draw_text(0, 27, StrEq(">"))).Times(0);
@@ -200,7 +201,7 @@ TEST(ProfilePickerStage, EncoderClampsAtTopAndBottom) {
     ::testing::Mock::VerifyAndClearExpectations(&display);
 
     EXPECT_CALL(display, clear()).Times(1);
-    EXPECT_CALL(display, draw_text(5, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(10, _, _)).Times(AnyNumber());
     EXPECT_CALL(display, draw_text(0, 9, StrEq(">"))).Times(0);
     EXPECT_CALL(display, draw_text(0, 18, StrEq(">"))).Times(1);
     EXPECT_CALL(display, flush()).Times(1);
@@ -212,20 +213,25 @@ TEST(ProfilePickerStage, EncoderClampsAtTopAndBottom) {
     stage.on_event(conductor, EncoderEvent{4}, 0);
 }
 
-TEST(ProfilePickerStage, EmptyListIgnoresEncoder) {
+TEST(ProfilePickerStage, EmptyListEncoderRotationTransitionsToNormal) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
 
     ProfilePickerStage stage(display, sink);
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
     TestConductor conductor;
     conductor.register_stage(stage);
+    conductor.register_stage(normal);
     conductor.start<ProfilePickerStage>();
-    ::testing::Mock::VerifyAndClearExpectations(&display);
 
-    EXPECT_CALL(display, clear()).Times(0);
-    EXPECT_CALL(display, flush()).Times(0);
     stage.on_event(conductor, EncoderEvent{1}, 0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.active_pdo_index(), -1);
 }
 
 TEST(ProfilePickerStage, LongPressCommitsPpsWhenCursorOnPps) {
@@ -286,7 +292,54 @@ TEST(ProfilePickerStage, LongPressCommitsPdoWhenCursorOnFixed) {
     EXPECT_EQ(normal.active_pdo_index(), 0);
 }
 
-TEST(ProfilePickerStage, LongPressIgnoredWhenEmptyPdoList) {
+TEST(ProfilePickerStage, EmptyListAutoTransitionsAfterTimeout) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+
+    ProfilePickerStage stage(display, sink);
+    NiceMock<MockOutputGate> normal_gate;
+    NormalStage normal(display, sink, normal_gate);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<ProfilePickerStage>();
+
+    // Arms the timeout on the first tick.
+    stage.on_tick(conductor, 0);
+    EXPECT_FALSE(conductor.has_pending());
+
+    // Just before the timeout elapses, still no transition.
+    stage.on_tick(conductor, PICKER_PASSTHROUGH_AUTO_MS - 1);
+    EXPECT_FALSE(conductor.has_pending());
+
+    // At/after the timeout, transition fires.
+    stage.on_tick(conductor, PICKER_PASSTHROUGH_AUTO_MS);
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.active_pdo_index(), -1);
+}
+
+TEST(ProfilePickerStage, NonEmptyListDoesNotAutoTransition) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
+    EXPECT_CALL(sink, is_index_fixed(0)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+    EXPECT_CALL(sink, pdo_max_current_ma(0)).WillRepeatedly(Return(3000));
+
+    ProfilePickerStage stage(display, sink);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.start<ProfilePickerStage>();
+
+    stage.on_tick(conductor, 0);
+    stage.on_tick(conductor, PICKER_PASSTHROUGH_AUTO_MS * 10);
+    EXPECT_FALSE(conductor.has_pending());
+}
+
+TEST(ProfilePickerStage, EmptyListAnyButtonTransitionsToNormal) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
@@ -300,7 +353,11 @@ TEST(ProfilePickerStage, LongPressIgnoredWhenEmptyPdoList) {
     conductor.start<ProfilePickerStage>();
 
     stage.on_event(conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
-    EXPECT_FALSE(conductor.has_pending());
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+    EXPECT_EQ(normal.active_pdo_index(), -1);
 }
 
 TEST(ProfilePickerStage, IgnoresRLongPressAndEncoderShortPress) {
@@ -365,7 +422,7 @@ TEST(ProfilePickerStage, ClearsBeforeDrawingAndFlushesAfter) {
         InSequence seq;
         EXPECT_CALL(display, clear());
         EXPECT_CALL(display, draw_text(0, 9, StrEq(">")));
-        EXPECT_CALL(display, draw_text(5, 9, StrEq("PDO: 5V @ 3A")));
+        EXPECT_CALL(display, draw_text(10, 9, StrEq("PDO       5.0V  3A")));
         EXPECT_CALL(display, flush());
     }
 


### PR DESCRIPTION
## Summary

Adds passthrough handling for USB-A and other non-PD sources. When the AP33772 reports no source PDOs, ProfilePicker shows a centered "Non-PD Source / Passthrough Mode" screen instead of an empty list, then navigates to NormalStage on any button or encoder input, or after a 3 second auto-transition. NormalStage now gets a `PassthroughMode` variant that renders live V/I from the dedicated VBUS sense path plus a "Passthrough" label, and the existing OutputGate toggle still flips the 5V rail on or off.

- NormalView dispatches via `std::variant<PassthroughMode, FixedMode, PPSMode>` instead of `has_profile`/`is_pps` flags, so each mode owns its render branch and `FixedMode` carries its own PDO max V/I snapshot.
- `NormalStage::on_enter` now sets default profile `m_active_pdo_index = 0` when the index is `-1` but PDOs are advertised. Passthrough only activates when no PD source is present.
- Minor redesigned ProfilePicker PDO/PPS rows

## Linked issues

- resolve #99 

## Hardware tested
- [x] HW1_3

How tested: flashed HW1_3 and exercised the passthrough path on a USB-A source (Anker A121C). Picker shows the passthrough screen, auto-transitions, and NormalStage reports the source's 5V rail with the OutputGate toggle working.

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details: ProfilePicker no longer shows a stub empty-list screen when the source advertises no PDOs. It shows a passthrough message and exits to NormalStage automatically. NormalStage replaces the old "No Profile Selected" placeholder with a live passthrough readout when entered without a PD profile.

## Notes

https://github.com/user-attachments/assets/b887a6f8-3641-48e4-a385-01d8264e61fb

<img width="3024" height="4032" alt="IMG_3323" src="https://github.com/user-attachments/assets/94cd0c08-3f37-42d6-ba81-4e44e10c24be" />
<img width="3024" height="4032" alt="IMG_3324" src="https://github.com/user-attachments/assets/3460642e-9c27-45dc-ade0-a941e46e682e" />
