### PR TITLE
feat(v2): add Menu/Settings stages + PreferencesStore

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: "
   -cppcoreguidelines-pro-type-union-access,
   -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard
   "

--- a/include/v2/app.h
+++ b/include/v2/app.h
@@ -21,6 +21,8 @@ namespace pocketpd {
     class ProfilePickerStage;
     class NormalStage;
     class EnergyStage;
+    class MenuStage;
+    class SettingsStage;
 
     // —— Can also define events here as well
 
@@ -29,7 +31,8 @@ namespace pocketpd {
     // —— Define the application alias which is a combination of Events and Stages
 
     using App = tempo::Application<
-        Event, BootStage, ObtainStage, ProfilePickerStage, NormalStage, EnergyStage>;
+        Event, BootStage, ObtainStage, ProfilePickerStage, NormalStage, EnergyStage,
+        MenuStage, SettingsStage>;
 } // namespace pocketpd
 
 /*
@@ -56,6 +59,8 @@ namespace pocketpd {
  */
 #include "v2/stages/boot_stage.h"
 #include "v2/stages/energy_stage.h"
+#include "v2/stages/menu_stage.h"
 #include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
 #include "v2/stages/profile_picker_stage.h"
+#include "v2/stages/settings_stage.h"

--- a/include/v2/hal/arduino_eeprom.h
+++ b/include/v2/hal/arduino_eeprom.h
@@ -1,0 +1,67 @@
+/**
+ * @file arduino_eeprom.h
+ * @brief Arduino `EEPROM` (flash-emulated on RP2040) implementation of `Eeprom`.
+ */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include <EEPROM.h>
+
+#include "v2/hal/eeprom.h"
+
+namespace pocketpd {
+
+    class ArduinoEeprom : public Eeprom {
+    private:
+        bool m_began = false;
+
+    public:
+        static constexpr size_t MAX_SIZE = 4096;
+        
+        /**
+         * @brief Reserve `bytes` of emulated EEPROM. Must be called from `setup()`
+         * before any load/save. Idempotent.
+         */
+        void begin(size_t bytes = MAX_SIZE) {
+            if (m_began) {
+                return;
+            }
+
+            EEPROM.begin(bytes);
+            m_began = true;
+        }
+
+        bool load(Preferences& out) override {
+            std::array<uint8_t, EEPROM_PREFERENCES_BYTES> buf{};
+            for (size_t i = 0; i < buf.size(); ++i) {
+                buf[i] = EEPROM.read(static_cast<int>(i));
+            }
+
+            return decode_preferences(buf.data(), out);
+        }
+
+        bool save(const Preferences& in) override {
+            std::array<uint8_t, EEPROM_PREFERENCES_BYTES> buf{};
+            encode_preferences(in, buf.data());
+
+            bool changed = false;
+            for (size_t i = 0; i < buf.size(); ++i) {
+                const uint8_t cur = EEPROM.read(static_cast<int>(i));
+                if (cur != buf[i]) {
+                    EEPROM.write(static_cast<int>(i), buf[i]);
+                    changed = true;
+                }
+            }
+
+            if (changed) {
+                return EEPROM.commit();
+            }
+
+            return true;
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/hal/eeprom.h
+++ b/include/v2/hal/eeprom.h
@@ -1,0 +1,79 @@
+/**
+ * @file eeprom.h
+ * @brief Persistent preferences HAL: Preferences POD, codec, and abstract interface.
+ *
+ * Wire layout at storage offset 0:
+ *   [0]            uint8_t  version  (= PREFERENCES_LAYOUT_VERSION)
+ *   [1 .. N]       payload  (sizeof(Preferences) bytes)
+ *   [N+1]          uint8_t  crc8     (over version byte + payload)
+ *
+ * Codec helpers (`encode_preferences`, `decode_preferences`) are free functions so they
+ * are testable.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace pocketpd {
+
+    struct Preferences {
+        bool skip_picker_on_boot = false;
+    };
+
+    static constexpr uint8_t PREFERENCES_LAYOUT_VERSION = 1;
+    static constexpr size_t SIZE = sizeof(Preferences);
+    static constexpr size_t EEPROM_PREFERENCES_BYTES = 1 + SIZE + 1;
+
+    inline uint8_t crc8(const uint8_t* data, size_t len) {
+        uint8_t crc = 0;
+        for (size_t i = 0; i < len; ++i) {
+            crc ^= data[i];
+            for (int b = 0; b < 8; ++b) {
+                crc = (crc & 0x80) ? static_cast<uint8_t>((crc << 1) ^ 0x07)
+                                   : static_cast<uint8_t>(crc << 1);
+            }
+        }
+        return crc;
+    }
+
+
+    inline void encode_preferences(const Preferences& payload, uint8_t* out) {
+        out[0] = PREFERENCES_LAYOUT_VERSION;
+        std::memcpy(out + 1, &payload, SIZE);
+        out[1 + SIZE] = crc8(out, 1 + SIZE);
+    }
+
+    inline bool decode_preferences(const uint8_t* payload, Preferences& out) {
+        if (payload[0] != PREFERENCES_LAYOUT_VERSION) {
+            return false;
+        }
+
+        const uint8_t expected = crc8(payload, 1 + SIZE);
+        if (expected != payload[1 + SIZE]) {
+            return false;
+        }
+
+        std::memcpy(&out, payload + 1, SIZE);
+        return true;
+    }
+
+    class Eeprom {
+    public:
+        virtual ~Eeprom() = default;
+
+        /**
+         * @brief Read persisted bytes and decode into `out`.
+         * @return true on success; false if version/CRC mismatch (out left at defaults).
+         */
+        virtual bool load(Preferences& out) = 0;
+
+        /**
+         * @brief Encode `in` and persist. Implementations are free to skip flash writes
+         * when bytes already match.
+         */
+        virtual bool save(const Preferences& in) = 0;
+    };
+
+} // namespace pocketpd

--- a/include/v2/preferences_store.h
+++ b/include/v2/preferences_store.h
@@ -1,0 +1,63 @@
+/**
+ * @file preferences_store.h
+ * @brief Application-level wrapper around the `Preferences` POD + `Eeprom` HAL.
+ *
+ */
+#pragma once
+
+#include "v2/hal/eeprom.h"
+
+namespace pocketpd {
+
+    class PreferencesStore {
+    private:
+        Preferences m_preferences;
+        Eeprom& m_eeprom;
+        bool m_dirty = false;
+
+    public:
+        explicit PreferencesStore(Eeprom& eeprom, Preferences initial = {})
+            : m_preferences(initial), m_eeprom(eeprom) {}
+
+        bool load() {
+            if (m_eeprom.load(m_preferences)) {
+                return true;
+            }
+            m_eeprom.save(m_preferences);
+            return false;
+        }
+
+        bool commit() {
+            if (!m_dirty) {
+                return true;
+            }
+
+            if (!m_eeprom.save(m_preferences)) {
+                return false;
+            }
+            
+            m_dirty = false;
+            return true;
+        }
+
+        bool dirty() const {
+            return m_dirty;
+        }
+
+        // —— Per-field accessors
+
+        bool skip_picker_on_boot() const {
+            return m_preferences.skip_picker_on_boot;
+        }
+
+        void set_skip_picker_on_boot(bool v) {
+            if (m_preferences.skip_picker_on_boot == v) {
+                return;
+            }
+
+            m_preferences.skip_picker_on_boot = v;
+            m_dirty = true;
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/menu_stage.h
+++ b/include/v2/stages/menu_stage.h
@@ -1,0 +1,104 @@
+/**
+ * @file menu_stage.h
+ * @brief Top-level menu stage.
+ *
+ */
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <variant>
+
+#include <tempo/bus/visit.h>
+#include <tempo/hardware/display.h>
+
+#include "v2/app.h"
+#include "v2/events.h"
+
+namespace pocketpd {
+
+    class MenuStage : public App::Stage, public App::UseLog<MenuStage> {
+    private:
+        using Display = tempo::Display;
+
+        enum class Item : uint8_t {
+            PROFILE_PICKER = 0,
+            SETTINGS = 1,
+        };
+
+        static constexpr std::array<const char*, 2> ITEM_LABELS = {
+            "Profile Picker",
+            "Settings",
+        };
+
+        Display& m_display;
+        uint8_t m_cursor = 0;
+
+        int count() const {
+            return ITEM_LABELS.size();
+        }
+
+        Item current_item() const {
+            return static_cast<Item>(m_cursor);
+        }
+
+        void draw() {
+            m_display.clear();
+            
+            for (int i = 0; i < count(); i++) {
+                const auto y = (12 * (i + 1));
+                if (i == m_cursor) {
+                    m_display.draw_text(0, y, ">");
+                }
+
+                m_display.draw_text(10, y, ITEM_LABELS[i]);
+            }
+
+            m_display.flush();
+        }
+
+    public:
+        explicit MenuStage(Display& display) : m_display(display) {}
+
+        void on_enter(Conductor&, uint32_t) override {
+            m_cursor = 0;
+            draw();
+        }
+
+        void on_event(Conductor& conductor, const Event& event, uint32_t) override {
+            auto handler = tempo::overloaded{
+                [&](const EncoderEvent& evt) {
+                    if (evt.delta == 0) {
+                        return;
+                    }
+
+                    const int max_idx = count() - 1;
+                    int next = std::clamp(m_cursor + evt.delta, 0, max_idx);
+                    if (next == m_cursor) {
+                        return;
+                    }
+
+                    m_cursor = next;
+                    draw();
+                },
+                [&](const ButtonEvent& evt) {
+                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                        conductor.request<NormalStage>();
+                        return;
+                    }
+                    if (evt.id == ButtonId::ENCODER && evt.gesture == Gesture::LONG) {
+                        if (current_item() == Item::PROFILE_PICKER) {
+                            conductor.request<ProfilePickerStage>();
+                        } else {
+                            conductor.request<SettingsStage>();
+                        }
+                    }
+                },
+                [](const auto&) {},
+            };
+            std::visit(handler, event);
+        }
+    };
+
+} // namespace pocketpd

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -184,7 +184,7 @@ namespace pocketpd {
                     }
 
                     if (event.l_long()) {
-                        conductor.request<ProfilePickerStage>();
+                        conductor.request<MenuStage>();
                         return;
                     }
 

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -1,15 +1,6 @@
 /**
  * @file obtain_stage.h
- * @brief Stage that runs PD negotiation, learns the source PDO list, and
- * announces the result to the rest of the app via `PdReadyEvent`.
- *
- * After the announce, ObtainStage waits a short window then transitions to ProfilePicker so
- * the user can choose a profile. Short button press or encoder rotation jumps to ProfilePicker
- * immediately.
- *
- * Issue #33: ObtainStage must NOT issue an RDO request. The first request runs later
- * (NormalPpsStage / NormalPdoStage) once EEPROM has been consulted. Until then the AP33772 holds
- * whatever default profile the source negotiated at begin().
+ * @brief Stage that runs PD negotiation and learns PDO list
  */
 #pragma once
 
@@ -23,6 +14,7 @@
 
 #include "AP33772_debug.h"
 #include "v2/app.h"
+#include "v2/preferences_store.h"
 #include "v2/events.h"
 #include "v2/hal/pd_sink_controller.h"
 #include "v2/pocketpd.h"
@@ -34,7 +26,7 @@ namespace pocketpd {
                         public App::UsePublisher<ObtainStage> {
     private:
         PdSinkController& m_pd_sink;
-        bool m_pd_ready = false;
+        const PreferencesStore& m_prefs;
 
         tempo::IntervalTimer m_dump_timer{500};
         tempo::TimeoutTimer m_timeout;
@@ -48,27 +40,23 @@ namespace pocketpd {
     public:
         static constexpr const char* LOG_TAG = "Obtain";
 
-        explicit ObtainStage(PdSinkController& pd_sink) : m_pd_sink(pd_sink) {}
+        ObtainStage(PdSinkController& pd_sink, const PreferencesStore& prefs)
+            : m_pd_sink(pd_sink), m_prefs(prefs) {}
 
         const char* name() const override {
             return "OBTAIN";
         }
 
-        void on_enter(Conductor&, uint32_t now_ms) override {
+        void on_enter(Conductor& conductor, uint32_t now_ms) override {
             m_timeout.set(now_ms, OBTAIN_TO_PROFILE_PICKER_MS);
-            m_pd_ready = false;
 
             if (!m_pd_sink.begin()) {
                 log.error("PD negotiation failed");
-                return;
             }
 
-            m_pd_ready = true;
-            const auto pdo_n = static_cast<uint8_t>(m_pd_sink.pdo_count());
-            const auto pps_n = static_cast<uint8_t>(m_pd_sink.pps_count());
-            publish(PdReadyEvent{pdo_n, pps_n});
-
-            log.info("PD ready: {} PDO ({} PPS)", pdo_n, pps_n);
+            if (m_prefs.skip_picker_on_boot()) {
+                conductor.request<NormalStage>();
+            }
         }
 
         void on_tick(Conductor& conductor, uint32_t now_ms) override {
@@ -86,7 +74,7 @@ namespace pocketpd {
 
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
-                    if (evt.gesture == Gesture::SHORT && m_pd_ready) {
+                    if (evt.gesture == Gesture::SHORT) {
                         conductor.request<ProfilePickerStage>();
                     }
                 },

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -14,6 +14,7 @@
 #include <tempo/core/time.h>
 #include <tempo/hardware/display.h>
 
+#include "menu_stage.h"
 #include "v2/app.h"
 #include "v2/events.h"
 #include "v2/hal/pd_sink_controller.h"
@@ -102,7 +103,7 @@ namespace pocketpd {
                 },
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
-                        conductor.request<NormalStage>();
+                        conductor.request<MenuStage>();
                         return;
                     }
 

--- a/include/v2/stages/settings_stage.h
+++ b/include/v2/stages/settings_stage.h
@@ -1,0 +1,124 @@
+/**
+ * @file settings_stage.h
+ * @brief Boolean settings list stage.
+ *
+ */
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <variant>
+
+#include <tempo/bus/visit.h>
+#include <tempo/hardware/display.h>
+
+#include "v2/app.h"
+#include "v2/preferences_store.h"
+#include "v2/events.h"
+
+namespace pocketpd {
+
+    class SettingsStage : public App::Stage, public App::UseLog<SettingsStage> {
+    private:
+        using Display = tempo::Display;
+
+        enum class Item : uint8_t { SKIP_PICKER = 0 };
+
+        static constexpr std::array<const char*, 1> ITEM_LABELS = {
+            "Skip picker",
+        };
+
+        Display& m_display;
+        PreferencesStore& m_prefs;
+        uint8_t m_cursor = 0;
+
+        int count() const {
+            return ITEM_LABELS.size();
+        }
+
+        bool value_at(Item item) const {
+            switch (item) {
+            case Item::SKIP_PICKER:
+                return m_prefs.skip_picker_on_boot();
+            }
+            return false;
+        }
+
+        void toggle_current() {
+            switch (static_cast<Item>(m_cursor)) {
+            case Item::SKIP_PICKER:
+                m_prefs.set_skip_picker_on_boot(!m_prefs.skip_picker_on_boot());
+                break;
+            }
+
+            draw();
+        }
+
+        void draw() {
+            m_display.clear();
+
+            std::array<char, 32> buffer{};
+            for (int i = 0; i < count(); ++i) {
+                const int y = 9 * (i + 1);
+                if (i == m_cursor) {
+                    m_display.draw_text(0, y, ">");
+                }
+
+                const char mark = value_at(static_cast<Item>(i)) ? 'x' : ' ';
+                std::snprintf(buffer.data(), buffer.size(), "[%c] %s", mark, ITEM_LABELS[i]);
+                m_display.draw_text(10, y, buffer.data());
+            }
+
+            m_display.flush();
+        }
+
+    public:
+        static constexpr const char* LOG_TAG = "Settings";
+
+        SettingsStage(Display& display, PreferencesStore& prefs)
+            : m_display(display), m_prefs(prefs) {}
+
+        const char* name() const override {
+            return "SETTINGS";
+        }
+
+        void on_enter(Conductor&, uint32_t) override {
+            m_cursor = 0;
+            draw();
+        }
+
+        void on_exit(Conductor&, uint32_t) override {
+            if (!m_prefs.commit()) {
+                log.error("settings save failed");
+            }
+        }
+
+        void on_event(Conductor& conductor, const Event& event, uint32_t) override {
+            auto handler = tempo::overloaded{
+                [&](const EncoderEvent& evt) {
+                    if (evt.delta == 0) return;
+                    const int max_idx = count() - 1;
+                    int next = std::clamp(static_cast<int>(m_cursor) + evt.delta, 0, max_idx);
+                    if (next == m_cursor) return;
+                    m_cursor = static_cast<uint8_t>(next);
+                    draw();
+                },
+                [&](const ButtonEvent& evt) {
+                    if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
+                        conductor.request<MenuStage>();
+                        return;
+                    }
+                    if (evt.id == ButtonId::ENCODER && evt.gesture == Gesture::LONG) {
+                        toggle_current();
+                    }
+                },
+                [](const auto&) {},
+            };
+
+            std::visit(handler, event);
+        }
+    };
+
+} // namespace pocketpd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,10 +6,12 @@
 #include <tempo/tempo.h>
 
 #include "v2/app.h"
+#include "v2/preferences_store.h"
 #include "v2/hal/adc_supply_voltage_source.h"
 #include "v2/hal/ap33772_pd_sink.h"
 #include "v2/hal/ap33772_supply_voltage_source.h"
 #include "v2/hal/arduino_clock.h"
+#include "v2/hal/arduino_eeprom.h"
 #include "v2/hal/arduino_output_gate.h"
 #include "v2/hal/arduino_stream_reader.h"
 #include "v2/hal/arduino_stream_writer.h"
@@ -49,6 +51,9 @@ namespace pocketpd {
 
     ArduinoOutputGate output_gate{pin_output_Enable};
 
+    ArduinoEeprom eeprom;
+    PreferencesStore prefs{eeprom};
+
     EzButtonInput encoder_button{pin_encoder_SW};
     EzButtonInput r_button{pin_button_outputSW};
     EzButtonInput l_button{pin_button_selectVI};
@@ -57,10 +62,12 @@ namespace pocketpd {
     // —— Stages
 
     BootStage boot_stage(u8g2_display);
-    ObtainStage obtain_stage(pd_sink);
+    ObtainStage obtain_stage(pd_sink, prefs);
     ProfilePickerStage profile_picker_stage(u8g2_display, pd_sink);
     NormalStage normal_stage(u8g2_display, pd_sink, output_gate);
     EnergyStage energy_stage(u8g2_display, output_gate);
+    MenuStage menu_stage(u8g2_display);
+    SettingsStage settings_stage(u8g2_display, prefs);
 
     // —— Tasks
 
@@ -86,6 +93,11 @@ void setup() {
     supply_voltage_source.begin();
     u8g2_display.begin();
     output_gate.begin();
+    eeprom.begin();
+
+    if (!prefs.load()) {
+        Serial.println("[main] preferences load failed; defaults restored");
+    }
     encoder.begin();
 
     app.register_stage(boot_stage);
@@ -93,6 +105,8 @@ void setup() {
     app.register_stage(profile_picker_stage);
     app.register_stage(normal_stage);
     app.register_stage(energy_stage);
+    app.register_stage(menu_stage);
+    app.register_stage(settings_stage);
 
     app.add_task(button_task);
     app.add_task(encoder_task);

--- a/test/mocks/MockEeprom.h
+++ b/test/mocks/MockEeprom.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "v2/hal/eeprom.h"
+
+namespace pocketpd {
+
+    class MockEeprom : public Eeprom {
+    public:
+        MOCK_METHOD(bool, load, (Preferences & out), (override));
+        MOCK_METHOD(bool, save, (const Preferences& in), (override));
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_eeprom/test.cpp
+++ b/test/test_v2_eeprom/test.cpp
@@ -1,0 +1,53 @@
+#define VERSION "\"test\""
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+#include "v2/hal/eeprom.h"
+
+using namespace pocketpd;
+
+TEST(EepromCodec, RoundTripDefaultsThenCustom) {
+    std::array<uint8_t, EEPROM_PREFERENCES_BYTES> buf{};
+
+    Preferences in_defaults{};
+    encode_preferences(in_defaults, buf.data());
+
+    Preferences out{};
+    EXPECT_TRUE(decode_preferences(buf.data(), out));
+    EXPECT_EQ(out.skip_picker_on_boot, false);
+
+    Preferences in_custom{ .skip_picker_on_boot = true };
+    encode_preferences(in_custom, buf.data());
+    EXPECT_TRUE(decode_preferences(buf.data(), out));
+    EXPECT_EQ(out.skip_picker_on_boot, true);
+}
+
+TEST(EepromCodec, VersionMismatchFailsDecode) {
+    std::array<uint8_t, EEPROM_PREFERENCES_BYTES> buf{};
+    Preferences in{ .skip_picker_on_boot = true };
+    encode_preferences(in, buf.data());
+
+    buf[0] = PREFERENCES_LAYOUT_VERSION + 1;
+
+    Preferences out{};
+    EXPECT_FALSE(decode_preferences(buf.data(), out));
+}
+
+TEST(EepromCodec, CrcCorruptionFailsDecode) {
+    std::array<uint8_t, EEPROM_PREFERENCES_BYTES> buf{};
+    Preferences in{ .skip_picker_on_boot = true };
+    encode_preferences(in, buf.data());
+
+    buf[1] ^= 0xFF;
+
+    Preferences out{};
+    EXPECT_FALSE(decode_preferences(buf.data(), out));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_v2_menu/test.cpp
+++ b/test/test_v2_menu/test.cpp
@@ -1,0 +1,143 @@
+#define VERSION "\"test\""
+
+#include <MockDisplay.h>
+#include <MockEeprom.h>
+#include <MockOutputGate.h>
+#include <MockPdSink.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/stage/conductor.h>
+
+#include "v2/app.h"
+#include "v2/preferences_store.h"
+#include "v2/events.h"
+
+using namespace pocketpd;
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::_;
+
+using TestConductor = App::Conductor;
+
+namespace {
+
+    struct Harness {
+        NiceMock<MockDisplay> display;
+        NiceMock<MockPdSink> sink;
+        NiceMock<MockOutputGate> gate;
+        NiceMock<MockEeprom> eeprom;
+        PreferencesStore prefs{eeprom};
+        MenuStage menu{display};
+        ProfilePickerStage picker{display, sink};
+        SettingsStage settings_stage{display, prefs};
+        NormalStage normal{display, sink, gate};
+        TestConductor conductor;
+
+        Harness() {
+            conductor.register_stage(menu);
+            conductor.register_stage(picker);
+            conductor.register_stage(settings_stage);
+            conductor.register_stage(normal);
+        }
+    };
+
+} // namespace
+
+TEST(MenuStage, RendersTwoItemsWithCursorAtTop) {
+    Harness h;
+    {
+        InSequence seq;
+        EXPECT_CALL(h.display, clear());
+        EXPECT_CALL(h.display, draw_text(0, 12, StrEq(">")));
+        EXPECT_CALL(h.display, draw_text(10, 12, StrEq("Profile Picker")));
+        EXPECT_CALL(h.display, draw_text(10, 24, StrEq("Settings")));
+        EXPECT_CALL(h.display, flush());
+    }
+    h.conductor.start<MenuStage>(0);
+}
+
+TEST(MenuStage, EncoderMovesCursorAndRerenders) {
+    Harness h;
+    h.conductor.start<MenuStage>(0);
+    ::testing::Mock::VerifyAndClearExpectations(&h.display);
+
+    EXPECT_CALL(h.display, clear()).Times(1);
+    EXPECT_CALL(h.display, draw_text(10, _, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(h.display, draw_text(0, 12, StrEq(">"))).Times(0);
+    EXPECT_CALL(h.display, draw_text(0, 24, StrEq(">"))).Times(1);
+    EXPECT_CALL(h.display, flush()).Times(1);
+
+    h.menu.on_event(h.conductor, EncoderEvent{1}, 0);
+}
+
+TEST(MenuStage, EncoderClampsAtTopAndBottom) {
+    Harness h;
+    h.conductor.start<MenuStage>(0);
+    ::testing::Mock::VerifyAndClearExpectations(&h.display);
+
+    EXPECT_CALL(h.display, clear()).Times(0);
+    h.menu.on_event(h.conductor, EncoderEvent{-5}, 0);
+    ::testing::Mock::VerifyAndClearExpectations(&h.display);
+
+    EXPECT_CALL(h.display, clear()).Times(1);
+    h.menu.on_event(h.conductor, EncoderEvent{5}, 0);
+    ::testing::Mock::VerifyAndClearExpectations(&h.display);
+
+    EXPECT_CALL(h.display, clear()).Times(0);
+    h.menu.on_event(h.conductor, EncoderEvent{1}, 0);
+}
+
+TEST(MenuStage, EncoderLongOnProfilePickerRequestsPicker) {
+    Harness h;
+    h.conductor.start<MenuStage>(0);
+
+    h.menu.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(h.conductor.has_pending());
+    EXPECT_TRUE(h.conductor.apply_pending_transition(0));
+    EXPECT_EQ(h.conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+}
+
+TEST(MenuStage, EncoderLongOnSettingsRequestsSettings) {
+    Harness h;
+    h.conductor.start<MenuStage>(0);
+
+    h.menu.on_event(h.conductor, EncoderEvent{1}, 0);
+    h.menu.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(h.conductor.has_pending());
+    EXPECT_TRUE(h.conductor.apply_pending_transition(0));
+    EXPECT_EQ(h.conductor.current_index(), TestConductor::index_of<SettingsStage>());
+}
+
+TEST(MenuStage, LLongReturnsToNormalStage) {
+    Harness h;
+    EXPECT_CALL(h.sink, is_index_pps(_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(h.sink, set_pdo(_)).WillRepeatedly(Return(true));
+    h.conductor.start<MenuStage>(0);
+
+    h.menu.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(h.conductor.has_pending());
+    EXPECT_TRUE(h.conductor.apply_pending_transition(0));
+    EXPECT_EQ(h.conductor.current_index(), TestConductor::index_of<NormalStage>());
+}
+
+TEST(MenuStage, IgnoresUnboundButtonsAndShortPresses) {
+    Harness h;
+    h.conductor.start<MenuStage>(0);
+
+    h.menu.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
+    h.menu.on_event(h.conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
+    h.menu.on_event(h.conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
+    h.menu.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+
+    EXPECT_FALSE(h.conductor.has_pending());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -166,7 +166,7 @@ TEST(NormalStage, RShortToggleEnablesAndDisablesOutput) {
     EXPECT_FALSE(enabled);
 }
 
-TEST(NormalStage, LLongRequestsProfilePicker) {
+TEST(NormalStage, LLongRequestsMenu) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     NiceMock<MockOutputGate> gate;
@@ -174,10 +174,10 @@ TEST(NormalStage, LLongRequestsProfilePicker) {
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
 
     NormalStage normal(display, sink, gate);
-    ProfilePickerStage picker(display, sink);
+    MenuStage menu(display);
     TestConductor conductor;
     conductor.register_stage(normal);
-    conductor.register_stage(picker);
+    conductor.register_stage(menu);
     normal.prepare(0);
     conductor.start<NormalStage>(0);
 
@@ -185,7 +185,7 @@ TEST(NormalStage, LLongRequestsProfilePicker) {
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition(0));
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<MenuStage>());
 }
 
 TEST(NormalStage, EncoderEventsIgnoredInPdoBranch) {

--- a/test/test_v2_obtain/test.cpp
+++ b/test/test_v2_obtain/test.cpp
@@ -1,26 +1,20 @@
 /**
  * GoogleTest suite for ObtainStage.
- *
- * Drives Conductor<...> with scripted MockPdSink and a real EventQueue /
- * QueuePublisher so PdReadyEvent payload can be inspected. Also covers the
- * input-driven exits (short button → resume, encoder → ProfilePicker SELECT,
- * timeout → ProfilePicker REVIEW).
  */
 #define VERSION "\"test\""
 
 #include <MockDisplay.h>
+#include <MockEeprom.h>
 #include <MockOutputGate.h>
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <tempo/bus/event_queue.h>
-#include <tempo/bus/publisher.h>
 #include <tempo/stage/conductor.h>
 
-#include <variant>
-
 #include "v2/app.h"
+#include "v2/preferences_store.h"
 #include "v2/events.h"
+#include "v2/hal/eeprom.h"
 #include "v2/stages/boot_stage.h"
 #include "v2/stages/normal_stage.h"
 #include "v2/stages/obtain_stage.h"
@@ -31,107 +25,44 @@ using ::testing::NiceMock;
 using ::testing::Return;
 
 using TestConductor = App::Conductor;
-using TestQueue = tempo::EventQueue<Event, 8>;
-using TestPublisher = tempo::QueuePublisher<Event, 8>;
 
-namespace {
-
-    PdReadyEvent expect_pd_ready(TestQueue& q) {
-        Event e;
-        EXPECT_TRUE(q.pop(e));
-        const auto* ready = std::get_if<PdReadyEvent>(&e);
-        EXPECT_NE(ready, nullptr);
-        return ready ? *ready : PdReadyEvent{};
-    }
-
-} // namespace
-
-TEST(ObtainStage, OnEnterCallsBeginAndPublishesCount) {
+TEST(ObtainStage, OnEnterCallsBegin) {
     NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore default_prefs{mock_eeprom};
 
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(3));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
 
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+    ObtainStage stage(sink, default_prefs);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>(0);
-
-    const auto ready = expect_pd_ready(queue);
-    EXPECT_EQ(ready.num_pdo, 3);
-    EXPECT_EQ(ready.pps_count, 1);
-}
-
-TEST(ObtainStage, MultiPpsChargerReportsBothPps) {
-    NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
-
-    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(5));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(2));
-
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.start<ObtainStage>(0);
-
-    const auto ready = expect_pd_ready(queue);
-    EXPECT_EQ(ready.num_pdo, 5);
-    EXPECT_EQ(ready.pps_count, 2);
-}
-
-TEST(ObtainStage, BeginFailureSuppressesPdReady) {
-    NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
-
-    EXPECT_CALL(sink, begin()).WillOnce(Return(false));
-
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.start<ObtainStage>(0);
-
-    Event e;
-    EXPECT_FALSE(queue.pop(e));
 }
 
 TEST(ObtainStage, OnEnterIssuesNoRdoRequest) {
     // Issue #33: charger-dependent default voltage. Obtain must not pick a PDO.
     NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore default_prefs{mock_eeprom};
 
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
-    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
     EXPECT_CALL(sink, set_pdo).Times(0);
     EXPECT_CALL(sink, set_pps_pdo).Times(0);
 
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+    ObtainStage stage(sink, default_prefs);
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.start<ObtainStage>(0);
 }
 
-TEST(ObtainStage, ShortButtonJumpsToProfilePickerAfterPdReady) {
+TEST(ObtainStage, ShortButtonJumpsToProfilePicker) {
     NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore default_prefs{mock_eeprom};
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(1));
 
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+    ObtainStage stage(sink, default_prefs);
     NiceMock<MockDisplay> picker_display;
     ProfilePickerStage picker(picker_display, sink);
     TestConductor conductor;
@@ -146,32 +77,14 @@ TEST(ObtainStage, ShortButtonJumpsToProfilePickerAfterPdReady) {
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
 }
 
-TEST(ObtainStage, ShortButtonIgnoredWhenPdNotReady) {
-    NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
-    EXPECT_CALL(sink, begin()).WillOnce(Return(false));
-
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
-    TestConductor conductor;
-    conductor.register_stage(stage);
-    conductor.start<ObtainStage>(0);
-
-    stage.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::SHORT}, 0);
-    EXPECT_FALSE(conductor.has_pending());
-}
-
 TEST(ObtainStage, EncoderRotationJumpsToProfilePicker) {
     NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore default_prefs{mock_eeprom};
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+    ObtainStage stage(sink, default_prefs);
     NiceMock<MockDisplay> picker_display;
     ProfilePickerStage picker(picker_display, sink);
     TestConductor conductor;
@@ -188,14 +101,12 @@ TEST(ObtainStage, EncoderRotationJumpsToProfilePicker) {
 
 TEST(ObtainStage, TimeoutTransitionsToProfilePicker) {
     NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore default_prefs{mock_eeprom};
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
-    ObtainStage stage(sink);
-    stage.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+    ObtainStage stage(sink, default_prefs);
     NiceMock<MockDisplay> picker_display;
     ProfilePickerStage picker(picker_display, sink);
     TestConductor conductor;
@@ -216,16 +127,14 @@ TEST(ObtainStage, TimeoutTransitionsToProfilePicker) {
 TEST(BootStage, RequestsObtainAfterTimeout) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
-    TestQueue queue;
-    TestPublisher publisher(queue);
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore default_prefs{mock_eeprom};
 
     EXPECT_CALL(sink, begin()).WillOnce(Return(true));
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
-    EXPECT_CALL(sink, pps_count()).WillRepeatedly(Return(0));
 
     BootStage boot(display);
-    ObtainStage obtain(sink);
-    obtain.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+    ObtainStage obtain(sink, default_prefs);
     TestConductor conductor;
     conductor.register_stage(boot);
     conductor.register_stage(obtain);
@@ -242,6 +151,54 @@ TEST(BootStage, RequestsObtainAfterTimeout) {
 
     EXPECT_TRUE(conductor.apply_pending_transition(0));
     EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ObtainStage>());
+}
+
+TEST(ObtainStage, SkipPickerOnBootRequestsNormal) {
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore config{mock_eeprom, Preferences{.skip_picker_on_boot = true}};
+    NiceMock<MockDisplay> display;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
+
+    ObtainStage stage(sink, config);
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(normal);
+    conductor.start<ObtainStage>(0);
+
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition(0));
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
+}
+
+TEST(ObtainStage, SkipPickerDisabledFollowsNormalTimeoutPath) {
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockEeprom> mock_eeprom;
+    PreferencesStore config{mock_eeprom};
+    NiceMock<MockDisplay> display;
+
+    EXPECT_CALL(sink, begin()).WillOnce(Return(true));
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(2));
+
+    ObtainStage stage(sink, config);
+    ProfilePickerStage picker(display, sink);
+    TestConductor conductor;
+    conductor.register_stage(stage);
+    conductor.register_stage(picker);
+    conductor.start<ObtainStage>(0);
+
+    EXPECT_FALSE(conductor.has_pending());
+
+    conductor.tick(OBTAIN_TO_PROFILE_PICKER_MS);
+    EXPECT_TRUE(conductor.has_pending());
+    EXPECT_TRUE(conductor.apply_pending_transition(0));
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
 }
 
 int main(int argc, char** argv) {

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -382,7 +382,7 @@ TEST(ProfilePickerStage, IgnoresRLongPressAndEncoderShortPress) {
     EXPECT_FALSE(conductor.has_pending());
 }
 
-TEST(ProfilePickerStage, LongPressLExitsToNormalWithoutChangingProfile) {
+TEST(ProfilePickerStage, LongPressLExitsToMenu) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(1));
@@ -390,23 +390,19 @@ TEST(ProfilePickerStage, LongPressLExitsToNormalWithoutChangingProfile) {
     EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, pdo_max_voltage_mv(::testing::_)).WillRepeatedly(Return(5000));
     EXPECT_CALL(sink, pdo_max_current_ma(::testing::_)).WillRepeatedly(Return(3000));
-    EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
 
     ProfilePickerStage stage(display, sink);
-    NiceMock<MockOutputGate> normal_gate;
-    NormalStage normal(display, sink, normal_gate);
-    normal.prepare(7); // simulate prior session
+    MenuStage menu(display);
     TestConductor conductor;
     conductor.register_stage(stage);
-    conductor.register_stage(normal);
+    conductor.register_stage(menu);
     conductor.start<ProfilePickerStage>(0);
 
     stage.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition(0));
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<NormalStage>());
-    EXPECT_EQ(normal.active_pdo_index(), 7); // unchanged
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<MenuStage>());
 }
 
 TEST(ProfilePickerStage, ClearsBeforeDrawingAndFlushesAfter) {
@@ -488,17 +484,17 @@ TEST(ProfilePickerStage, ExitViaLDoesNotPromotePendingCursor) {
     EXPECT_EQ(stage.cursor_index(), 0); // committed cursor untouched by L exit
 }
 
-TEST(NormalStage, LongPressLReturnsToProfilePicker) {
+TEST(NormalStage, LongPressLReturnsToMenu) {
     NiceMock<MockDisplay> display;
     NiceMock<MockPdSink> sink;
     NiceMock<MockOutputGate> normal_gate;
     NormalStage normal(display, sink, normal_gate);
     EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
     EXPECT_CALL(sink, set_pdo).WillRepeatedly(Return(true));
-    ProfilePickerStage picker(display, sink);
+    MenuStage menu(display);
     TestConductor conductor;
     conductor.register_stage(normal);
-    conductor.register_stage(picker);
+    conductor.register_stage(menu);
     normal.prepare(0);
     conductor.start<NormalStage>(0);
 
@@ -506,7 +502,7 @@ TEST(NormalStage, LongPressLReturnsToProfilePicker) {
 
     EXPECT_TRUE(conductor.has_pending());
     EXPECT_TRUE(conductor.apply_pending_transition(0));
-    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<ProfilePickerStage>());
+    EXPECT_EQ(conductor.current_index(), TestConductor::index_of<MenuStage>());
 }
 
 TEST(NormalStage, IgnoresOtherButtonsAndShortPressOnL) {

--- a/test/test_v2_settings/test.cpp
+++ b/test/test_v2_settings/test.cpp
@@ -1,0 +1,119 @@
+#define VERSION "\"test\""
+
+#include <MockDisplay.h>
+#include <MockEeprom.h>
+#include <MockOutputGate.h>
+#include <MockPdSink.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <tempo/stage/conductor.h>
+
+#include "v2/app.h"
+#include "v2/preferences_store.h"
+#include "v2/events.h"
+#include "v2/hal/eeprom.h"
+
+using namespace pocketpd;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::_;
+
+using TestConductor = App::Conductor;
+
+namespace {
+
+    struct Harness {
+        NiceMock<MockDisplay> display;
+        NiceMock<MockPdSink> sink;
+        NiceMock<MockOutputGate> gate;
+        NiceMock<MockEeprom> eeprom;
+        PreferencesStore prefs{eeprom};
+        SettingsStage stage{display, prefs};
+        MenuStage menu{display};
+        ProfilePickerStage picker{display, sink};
+        NormalStage normal{display, sink, gate};
+        TestConductor conductor;
+
+        Harness() {
+            conductor.register_stage(stage);
+            conductor.register_stage(menu);
+            conductor.register_stage(picker);
+            conductor.register_stage(normal);
+        }
+    };
+
+} // namespace
+
+TEST(SettingsStage, RendersOneRowWithUncheckedBox) {
+    Harness h;
+    EXPECT_CALL(h.display, draw_text(0, 9, StrEq(">"))).Times(1);
+    EXPECT_CALL(h.display, draw_text(10, 9, StrEq("[ ] Skip picker"))).Times(1);
+    h.conductor.start<SettingsStage>(0);
+}
+
+TEST(SettingsStage, RendersCheckedWhenSettingTrue) {
+    Harness h;
+    h.prefs.set_skip_picker_on_boot(true);
+    EXPECT_CALL(h.display, draw_text(_, _, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(h.display, draw_text(10, 9, StrEq("[x] Skip picker"))).Times(1);
+    h.conductor.start<SettingsStage>(0);
+}
+
+TEST(SettingsStage, EncoderLongTogglesInRamWithoutSaving) {
+    Harness h;
+    h.conductor.start<SettingsStage>(0);
+
+    EXPECT_CALL(h.eeprom, save(_)).Times(0);
+
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+    EXPECT_TRUE(h.prefs.skip_picker_on_boot());
+    EXPECT_TRUE(h.prefs.dirty());
+}
+
+TEST(SettingsStage, ExitFlushesPendingToggleToEeprom) {
+    Harness h;
+    h.conductor.start<SettingsStage>(0);
+
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+
+    EXPECT_CALL(h.eeprom, save(_))
+        .WillOnce([](const Preferences& s) {
+            EXPECT_TRUE(s.skip_picker_on_boot);
+            return true;
+        });
+
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+    EXPECT_TRUE(h.conductor.apply_pending_transition(0));
+}
+
+TEST(SettingsStage, MultipleTogglesCollapseToSingleSaveOnExit) {
+    Harness h;
+    h.conductor.start<SettingsStage>(0);
+
+    EXPECT_CALL(h.eeprom, save(_)).Times(1).WillOnce(Return(true));
+
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+    EXPECT_TRUE(h.prefs.skip_picker_on_boot());
+
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+    EXPECT_TRUE(h.conductor.apply_pending_transition(0));
+}
+
+TEST(SettingsStage, ExitWithoutTogglesDoesNotSave) {
+    Harness h;
+    h.conductor.start<SettingsStage>(0);
+
+    EXPECT_CALL(h.eeprom, save(_)).Times(0);
+
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+    EXPECT_TRUE(h.conductor.apply_pending_transition(0));
+    EXPECT_EQ(h.conductor.current_index(), TestConductor::index_of<MenuStage>());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
Adds a top-level menu and a settings screen so users can persist preferences across power cycles. From NormalStage, L-LONG opens MenuStage with two rows: Profile Picker, Settings. Long-press encoder select an item. There is one setting right now:`Skip picker`. When on, ObtainStage skips the picker on boot and jumps straight to NormalStage on PDO 0. To prevent flash degradation, the setting is only saved on exit from Settings page. 

- `Eeprom` HAL (interface) + `ArduinoEeprom` (RP2040 flash-emulated)
- New `MenuStage` and `SettingsStage`. 
- L-LONG now behaves more like "back button"

## Linked issues

## Hardware tested
- [x ] HW1_3
- [ ] None (no hardware change)

How tested: native suite 149/149 (`pio test -e native`), `pio run -e HW1_3_V2` builds clean (Flash 6.7%, RAM 5.6%).

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)
- [x] EEPROM layout or calibration constants

## Notes

<img width="3024" height="4032" alt="IMG_3327" src="https://github.com/user-attachments/assets/f06f8d9c-305e-48a1-87a7-f5935b412692" />


