### PR TITLE
feat(v2): cable IR drop compensation on PPS profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,112 @@
 .worktrees
 compile_commands.json
 dist/
+
+
+# — MacOS
+
+# General
+.DS_Store
+.localized
+__MACOSX/
+.AppleDouble
+.LSOverride
+Icon[
+]
+
+# Resource forks
+._*
+
+# Files and directories that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.com.apple.timemachine.supported
+.PKInstallSandboxManager
+.PKInstallSandboxManager-SystemSoftware
+.hotfiles.btree
+.vol
+.file
+.disk_label*
+lost+found
+.HFS+ Private Directory Data[
+]
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Mac OS 6 to 9
+Desktop DB
+Desktop DF
+TheFindByContentFolder
+TheVolumeSettingsFolder
+.FBCIndex
+.FBCSemaphoreFile
+.FBCLockFolder
+
+# Quota system
+.quota.group
+.quota.user
+.quota.ops.group
+.quota.ops.user
+
+# TimeMachine
+Backups.backupdb
+.MobileBackups
+.MobileBackups.trash
+MobileBackups.trash
+tmbootpicker.efi
+
+# — Windows
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# — Linux
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# Metadata left by Dolphin file manager, which comes with KDE Plasma
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Log files created by default by the nohup command
+nohup.out

--- a/include/v2/events.h
+++ b/include/v2/events.h
@@ -124,6 +124,21 @@ namespace pocketpd {
         uint32_t total_seconds = 0;
     };
 
-    using Event = tempo::Events<PdReadyEvent, ButtonEvent, EncoderEvent, SensorEvent, EnergyEvent>;
+    /**
+     * @brief Active PPS target. `pdo_index = -1` means no PPS profile is active.
+     */
+    struct PpsTargetEvent {
+        int pdo_index = -1;
+        int target_mv = 0;
+        int target_ma = 0;
+    };
+
+    struct CompStateEvent {
+        int32_t offset_mv = 0;
+    };
+
+    using Event = tempo::Events<
+        PdReadyEvent, ButtonEvent, EncoderEvent, SensorEvent, EnergyEvent,
+        PpsTargetEvent, CompStateEvent>;
 
 } // namespace pocketpd

--- a/include/v2/hal/eeprom.h
+++ b/include/v2/hal/eeprom.h
@@ -20,9 +20,10 @@ namespace pocketpd {
 
     struct Preferences {
         bool skip_picker_on_boot = false;
+        bool voltage_comp_enabled = false;
     };
 
-    static constexpr uint8_t PREFERENCES_LAYOUT_VERSION = 1;
+    static constexpr uint8_t PREFERENCES_LAYOUT_VERSION = 2;
     static constexpr size_t SIZE = sizeof(Preferences);
     static constexpr size_t EEPROM_PREFERENCES_BYTES = 1 + SIZE + 1;
 

--- a/include/v2/preferences_store.h
+++ b/include/v2/preferences_store.h
@@ -58,6 +58,19 @@ namespace pocketpd {
             m_preferences.skip_picker_on_boot = v;
             m_dirty = true;
         }
+
+        bool voltage_comp_enabled() const {
+            return m_preferences.voltage_comp_enabled;
+        }
+
+        void set_voltage_comp_enabled(bool v) {
+            if (m_preferences.voltage_comp_enabled == v) {
+                return;
+            }
+
+            m_preferences.voltage_comp_enabled = v;
+            m_dirty = true;
+        }
     };
 
 } // namespace pocketpd

--- a/include/v2/stages/normal/normal_view.h
+++ b/include/v2/stages/normal/normal_view.h
@@ -31,6 +31,7 @@ namespace pocketpd {
         LoadReading load_reading{};
         SupplyReading supply_reading{};
         Mode mode = PassthroughMode{};
+        int32_t comp_offset_mv = 0;
     };
 
     class NormalView {
@@ -148,6 +149,11 @@ namespace pocketpd {
             std::snprintf(buf.data(), buf.size(), "%ld mV", static_cast<long>(mode.target_mv));
             auto w = d.text_width(buf.data());
             d.draw_text(static_cast<uint8_t>(TARGET_RIGHT_X - w), V_TARGET_Y, buf.data());
+
+            if (vm.comp_offset_mv > 0) {
+                std::snprintf(buf.data(), buf.size(), "+%d", vm.comp_offset_mv);
+                d.draw_text(TARGET_RIGHT_X + 2, V_TARGET_Y, buf.data());
+            }
 
             std::snprintf(buf.data(), buf.size(), "%ld mA", static_cast<long>(mode.target_ma));
             w = d.text_width(buf.data());

--- a/include/v2/stages/normal/pps_mode.h
+++ b/include/v2/stages/normal/pps_mode.h
@@ -55,30 +55,16 @@ namespace pocketpd {
             }
         }
 
-        /**
-         * @brief Apply an encoder delta to the focused target and reissue.
-         *
-         * @return Result of the underlying `set_pps_pdo` call. `true` when the
-         * delta is zero (no reissue needed). `false` only on actual sink
-         * failure.
-         */
-        [[nodiscard]] bool on_encoder(const EncoderEvent& evt) {
+        void on_encoder(const EncoderEvent& evt) {
             if (evt.delta == 0) {
-                return true;
+                return;
             }
-
             apply_encoder_delta(-evt.delta);
-            return apply();
+            clamp_to_pdo();
         }
 
-        /**
-         * @brief Clamp the current target to PDO + step grid and push to sink.
-         *
-         * @return Result of `set_pps_pdo`. Stage log on `false`.
-         */
-        [[nodiscard]] bool apply() {
+        void clamp() {
             clamp_to_pdo();
-            return m_sink->set_pps_pdo(m_pdo_idx, target_mv, target_ma);
         }
 
         uint8_t cursor_index() const {

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -20,7 +20,9 @@
 
 namespace pocketpd {
 
-    class NormalStage : public App::Stage, public App::UseLog<NormalStage> {
+    class NormalStage : public App::Stage,
+                        public App::UseLog<NormalStage>,
+                        public App::UsePublisher<NormalStage> {
     private:
         using Display = tempo::Display;
         using IntervalTimer = tempo::IntervalTimer;
@@ -44,6 +46,8 @@ namespace pocketpd {
         bool m_blink_visible = true;
         
         bool m_locked = false;
+        int32_t m_comp_offset_mv = 0;
+        
         // After OFF->ON, the first INA226 read returns a stale conversion (latched while FET
         // was off; observed ~200 mV instead of true VBUS). Discard N load samples and hold the
         // seeded supply value until the sensor has a fresh conversion in hand.
@@ -71,6 +75,10 @@ namespace pocketpd {
 
         bool locked() const {
             return m_locked;
+        }
+
+        int32_t comp_offset_mv() const {
+            return m_comp_offset_mv;
         }
 
         const Mode& mode() const {
@@ -112,6 +120,7 @@ namespace pocketpd {
             int count = m_pd_sink.pdo_count();
             if (count == 0) {
                 m_mode = PassthroughMode{};
+                publish(PpsTargetEvent{-1, 0, 0});
                 draw();
                 return;
             }
@@ -202,10 +211,8 @@ namespace pocketpd {
                         return;
                     }
 
-                    if (!pps->on_encoder(event)) {
-                        const auto msg = "set_pps_pdo({}, {}, {}) failed";
-                        log.error(msg, m_active_pdo_index, pps->target_mv, pps->target_ma);
-                    }
+                    pps->on_encoder(event);
+                    publish(PpsTargetEvent{m_active_pdo_index, pps->target_mv, pps->target_ma});
                 },
                 [&](const SensorEvent& event) {
                     if (m_postenable_discard_left > 0) {
@@ -226,6 +233,9 @@ namespace pocketpd {
                         }
                     }
                 },
+                [&](const CompStateEvent& evt) {
+                    m_comp_offset_mv = evt.offset_mv;
+                },
                 [](const auto&) {},
             };
 
@@ -233,10 +243,6 @@ namespace pocketpd {
         }
 
     private:
-        /**
-         * @brief Enter (or re-enter) a PPS profile. Construct fresh state on profile change or
-         * mode switch; otherwise preserve the user's prior target edits and reissue.
-         */
         void enter_pps_profile() {
             bool same_profile = m_active_pdo_index == m_last_active_index;
             if (!same_profile) {
@@ -248,15 +254,10 @@ namespace pocketpd {
             }
 
             auto& pps = std::get<PPSMode>(m_mode);
-            if (!pps.apply()) {
-                const auto msg = "set_pps_pdo({}, {}, {}) failed";
-                log.error(msg, m_active_pdo_index, pps.target_mv, pps.target_ma);
-            }
+            pps.clamp();
+            publish(PpsTargetEvent{m_active_pdo_index, pps.target_mv, pps.target_ma});
         }
 
-        /**
-         * @brief Enter a fixed PDO profile. Trigger `set_pdo` on every entry.
-         */
         void enter_fixed_profile() {
             m_mode = FixedMode{
                 .pdo_max_mv = m_pd_sink.pdo_max_voltage_mv(m_active_pdo_index),
@@ -267,6 +268,7 @@ namespace pocketpd {
             if (!m_pd_sink.set_pdo(m_active_pdo_index)) {
                 log.error("set_pdo({}) failed", m_active_pdo_index);
             }
+            publish(PpsTargetEvent{-1, 0, 0});
         }
 
         NormalViewModel build_view_model() const {
@@ -279,6 +281,7 @@ namespace pocketpd {
                 .load_reading = m_load_reading,
                 .supply_reading = m_supply_reading,
                 .mode = m_mode,
+                .comp_offset_mv = m_comp_offset_mv,
             };
         }
 

--- a/include/v2/stages/settings_stage.h
+++ b/include/v2/stages/settings_stage.h
@@ -24,10 +24,11 @@ namespace pocketpd {
     private:
         using Display = tempo::Display;
 
-        enum class Item : uint8_t { SKIP_PICKER = 0 };
+        enum class Item : uint8_t { SKIP_PICKER = 0, VOLTAGE_COMP = 1 };
 
-        static constexpr std::array<const char*, 1> ITEM_LABELS = {
+        static constexpr std::array<const char*, 2> ITEM_LABELS = {
             "Skip picker",
+            "Voltage comp",
         };
 
         Display& m_display;
@@ -42,6 +43,8 @@ namespace pocketpd {
             switch (item) {
             case Item::SKIP_PICKER:
                 return m_prefs.skip_picker_on_boot();
+            case Item::VOLTAGE_COMP:
+                return m_prefs.voltage_comp_enabled();
             }
             return false;
         }
@@ -50,6 +53,9 @@ namespace pocketpd {
             switch (static_cast<Item>(m_cursor)) {
             case Item::SKIP_PICKER:
                 m_prefs.set_skip_picker_on_boot(!m_prefs.skip_picker_on_boot());
+                break;
+            case Item::VOLTAGE_COMP:
+                m_prefs.set_voltage_comp_enabled(!m_prefs.voltage_comp_enabled());
                 break;
             }
 
@@ -61,12 +67,12 @@ namespace pocketpd {
 
             std::array<char, 32> buffer{};
             for (int i = 0; i < count(); ++i) {
-                const int y = 9 * (i + 1);
+                const int y = 12 * (i + 1);
                 if (i == m_cursor) {
                     m_display.draw_text(0, y, ">");
                 }
 
-                const char mark = value_at(static_cast<Item>(i)) ? 'x' : ' ';
+                const char mark = value_at(static_cast<Item>(i)) ? 'X' : ' ';
                 std::snprintf(buffer.data(), buffer.size(), "[%c] %s", mark, ITEM_LABELS[i]);
                 m_display.draw_text(10, y, buffer.data());
             }

--- a/include/v2/tasks/pps_control_task.h
+++ b/include/v2/tasks/pps_control_task.h
@@ -1,0 +1,148 @@
+/**
+ * @file pps_control_task.h
+ * @brief Owns PPS sink writes during NormalStage: applies user target + cable comp offset.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <variant>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/hal/output_gate.h"
+#include "v2/hal/pd_sink_controller.h"
+#include "v2/pocketpd.h"
+#include "v2/preferences_store.h"
+
+namespace pocketpd {
+
+    class PpsControlTask : public App::StageScopedTask,
+                           public App::UseLog<PpsControlTask>,
+                           public App::UsePublisher<PpsControlTask> {
+    private:
+        static constexpr int STEP_MV = PPS_VOLTAGE_STEP_MV;
+        static constexpr int DEAD_BAND_MV = 20;
+        static constexpr int MAX_COMP_MV = 500;
+        static constexpr uint32_t MIN_CURRENT_MA = 100;
+
+        const PreferencesStore& m_prefs;
+        OutputGate& m_gate;
+        PdSinkController& m_sink;
+
+        int m_pdo_index = -1;
+        int m_target_mv = 0;
+        int m_target_ma = 0;
+        int m_comp_offset_mv = 0;
+
+        LoadReading m_load{};
+        bool m_load_init = false;
+        bool m_was_enabled = false;
+
+    public:
+        static constexpr uint32_t PERIOD_MS = 250;
+        static constexpr const char* LOG_TAG = "PpsCtrl";
+
+        PpsControlTask(const PreferencesStore& prefs, OutputGate& gate, PdSinkController& sink)
+            : App::StageScopedTask(PERIOD_MS, App::StageMask::of<NormalStage>()),
+              m_prefs(prefs),
+              m_gate(gate),
+              m_sink(sink) {}
+
+        const char* name() const override {
+            return LOG_TAG;
+        }
+
+        int comp_offset_mv() const {
+            return m_comp_offset_mv;
+        }
+
+        void on_event(const Event& event, uint32_t) override {
+            if (const auto* pps = std::get_if<PpsTargetEvent>(&event)) {
+                const bool pdo_changed = pps->pdo_index != m_pdo_index;
+                m_pdo_index = pps->pdo_index;
+                m_target_mv = pps->target_mv;
+                m_target_ma = pps->target_ma;
+                if (pdo_changed) {
+                    const bool had_offset = m_comp_offset_mv != 0;
+                    m_comp_offset_mv = 0;
+                    m_load_init = false;
+                    if (had_offset) {
+                        publish(CompStateEvent{0});
+                    }
+                }
+                write_request();
+                return;
+            }
+
+            if (const auto* sensor = std::get_if<SensorEvent>(&event)) {
+                m_load = sensor->load;
+                m_load_init = true;
+            }
+        }
+
+        void on_tick(uint32_t) override {
+            if (!m_prefs.voltage_comp_enabled()) {
+                if (m_was_enabled && m_pdo_index >= 0 && m_comp_offset_mv != 0) {
+                    m_comp_offset_mv = 0;
+                    if (write_request()) {
+                        publish(CompStateEvent{0});
+                    }
+                }
+                m_was_enabled = false;
+                return;
+            }
+            m_was_enabled = true;
+
+            if (m_pdo_index < 0 || !m_gate.is_enabled() || !m_load_init) {
+                return;
+            }
+            if (m_load.current_ma < MIN_CURRENT_MA) {
+                return;
+            }
+
+            const int error = m_target_mv - static_cast<int>(m_load.vbus_mv);
+            if (std::abs(error) <= DEAD_BAND_MV) {
+                return;
+            }
+
+            const int delta = (error > 0) ? STEP_MV : -STEP_MV;
+            int max_offset = MAX_COMP_MV;
+            if (delta > 0) {
+                const int pdo_max = m_sink.pdo_max_voltage_mv(m_pdo_index);
+                const int headroom = std::max(0, pdo_max - m_target_mv);
+                max_offset = std::min(MAX_COMP_MV, headroom);
+            }
+            const int new_offset = std::clamp(m_comp_offset_mv + delta, 0, max_offset);
+            if (new_offset == m_comp_offset_mv) {
+                return;
+            }
+
+            const int prev_offset = m_comp_offset_mv;
+            m_comp_offset_mv = new_offset;
+            if (write_request()) {
+                publish(CompStateEvent{m_comp_offset_mv});
+            } else {
+                m_comp_offset_mv = prev_offset;
+            }
+        }
+
+    private:
+        bool write_request() {
+            if (m_pdo_index < 0) {
+                return false;
+            }
+            const int offset = m_prefs.voltage_comp_enabled() ? m_comp_offset_mv : 0;
+            const int request_mv = m_target_mv + offset;
+            if (!m_sink.set_pps_pdo(m_pdo_index, request_mv, m_target_ma)) {
+                log.error(
+                    "ppsctrl set_pps_pdo({}, {}, {}) failed", m_pdo_index, request_mv, m_target_ma
+                );
+                return false;
+            }
+            return true;
+        }
+    };
+
+} // namespace pocketpd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include "v2/tasks/encoder_task.h"
 #include "v2/tasks/energy_task.h"
 #include "v2/tasks/sensor_task.h"
+#include "v2/tasks/pps_control_task.h"
 
 namespace pocketpd {
 
@@ -76,6 +77,7 @@ namespace pocketpd {
     SensorTask sensor_task{power_monitor, supply_voltage_source};
     EnergyTask energy_task{output_gate};
     CommandTask command_task{arduino_stream_reader, arduino_stream_writer};
+    PpsControlTask pps_control_task{prefs, output_gate, pd_sink};
 
 } // namespace pocketpd
 
@@ -113,6 +115,7 @@ void setup() {
     app.add_task(sensor_task);
     app.add_task(energy_task);
     app.add_task(command_task);
+    app.add_task(pps_control_task);
 
     app.start<BootStage>();
 }

--- a/test/test_v2_eeprom/test.cpp
+++ b/test/test_v2_eeprom/test.cpp
@@ -47,6 +47,26 @@ TEST(EepromCodec, CrcCorruptionFailsDecode) {
     EXPECT_FALSE(decode_preferences(buf.data(), out));
 }
 
+TEST(EepromCodec, VoltageCompFieldRoundTrips) {
+    std::array<uint8_t, EEPROM_PREFERENCES_BYTES> buf{};
+
+    Preferences in{
+        .skip_picker_on_boot = false,
+        .voltage_comp_enabled = true,
+    };
+    encode_preferences(in, buf.data());
+
+    Preferences out{};
+    EXPECT_TRUE(decode_preferences(buf.data(), out));
+    EXPECT_FALSE(out.skip_picker_on_boot);
+    EXPECT_TRUE(out.voltage_comp_enabled);
+}
+
+TEST(EepromCodec, DefaultsHaveVoltageCompOff) {
+    Preferences p{};
+    EXPECT_FALSE(p.voltage_comp_enabled);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/test_v2_normal/test.cpp
+++ b/test/test_v2_normal/test.cpp
@@ -13,6 +13,8 @@
 #include <MockPdSink.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <tempo/bus/event_queue.h>
+#include <tempo/bus/publisher.h>
 #include <tempo/stage/conductor.h>
 
 #include "v2/app.h"
@@ -21,10 +23,26 @@
 #include "v2/stages/profile_picker_stage.h"
 
 using namespace pocketpd;
+using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
+using ::testing::StrEq;
 
 using TestConductor = App::Conductor;
+
+using TestQueue = tempo::EventQueue<Event, 32>;
+using TestPublisher = tempo::QueuePublisher<Event, 32>;
+
+namespace {
+    template <typename T>
+    const T* pop_as(TestQueue& q) {
+        static Event last;
+        if (!q.pop(last)) {
+            return nullptr;
+        }
+        return std::get_if<T>(&last);
+    }
+}
 
 TEST(NormalStage, OnEnterPdoProfileRequestsFixedPdo) {
     NiceMock<MockDisplay> display;
@@ -53,7 +71,7 @@ TEST(NormalStage, OnEnterPpsProfileResetsTargetsToDefaults) {
     EXPECT_CALL(sink, pdo_max_voltage_mv(1)).WillRepeatedly(Return(11000));
     EXPECT_CALL(sink, pdo_max_current_ma(1)).WillRepeatedly(Return(3000));
     EXPECT_CALL(sink, set_pdo).Times(0);
-    EXPECT_CALL(sink, set_pps_pdo(1, 5000, 1000)).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(sink, set_pps_pdo).Times(0);  // PpsControlTask owns sink writes
 
     NormalStage normal(display, sink, gate);
     TestConductor conductor;
@@ -235,7 +253,6 @@ namespace {
 
 TEST(NormalStage, EncoderDeltaInVoltageModeAdjustsTargetMv) {
     PpsHarness h;
-    EXPECT_CALL(h.sink, set_pps_pdo(1, 8000, 1000)).Times(1).WillOnce(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-3}, 0);
     EXPECT_EQ(h.normal.target_mv(), 8000);
     EXPECT_EQ(h.normal.adjust_mode(), AdjustMode::VOLTAGE);
@@ -246,7 +263,6 @@ TEST(NormalStage, EncoderDeltaInCurrentModeAdjustsTargetMa) {
     h.normal.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::SHORT}, 0);
     ASSERT_EQ(h.normal.adjust_mode(), AdjustMode::CURRENT);
 
-    EXPECT_CALL(h.sink, set_pps_pdo(1, 5000, 3000)).Times(1).WillOnce(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-4}, 0);
     EXPECT_EQ(h.normal.target_ma(), 3000);
 }
@@ -273,7 +289,6 @@ TEST(NormalStage, EncoderEditUsesActiveIncrementMagnitude) {
     PpsHarness h;
     ASSERT_EQ(h.normal.voltage_increment_index(), 0);
 
-    EXPECT_CALL(h.sink, set_pps_pdo(1, 6000, 1000)).Times(1).WillOnce(Return(true));
     h.normal.on_event(h.conductor, EncoderEvent{-1}, 0);
     EXPECT_EQ(h.normal.target_mv(), 6000);
 }
@@ -557,6 +572,200 @@ TEST(NormalStage, LockedIgnoresRLong) {
 
     normal.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
     EXPECT_TRUE(normal.locked());
+}
+
+namespace {
+    // Pops events from the queue and returns the first PpsTargetEvent matching `match`,
+    // or nullptr if the queue is exhausted. `pop_as` already consumes one event per call.
+    template <typename Pred>
+    bool find_pps_event(TestQueue& q, Pred match) {
+        while (true) {
+            const PpsTargetEvent* evt = pop_as<PpsTargetEvent>(q);
+            if (evt == nullptr) return false;     // queue empty
+            if (match(*evt)) return true;
+        }
+    }
+}
+
+TEST(NormalStagePublishing, EmitsPpsTargetOnPpsEntry) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(::testing::_)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(::testing::_)).WillRepeatedly(Return(11000));
+    EXPECT_CALL(sink, pdo_max_current_ma(::testing::_)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, set_pps_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    normal.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(1);
+    conductor.start<NormalStage>(0);
+
+    EXPECT_TRUE(find_pps_event(queue, [](const PpsTargetEvent& e) {
+        return e.pdo_index == 1 && e.target_mv == 5000 && e.target_ma == 1000;
+    }));
+}
+
+TEST(NormalStagePublishing, EmitsInactivePpsOnFixedEntry) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(sink, set_pdo(2)).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    normal.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(2);
+    conductor.start<NormalStage>(0);
+
+    EXPECT_TRUE(find_pps_event(queue, [](const PpsTargetEvent& e) {
+        return e.pdo_index == -1 && e.target_mv == 0 && e.target_ma == 0;
+    }));
+}
+
+TEST(NormalStagePublishing, EmitsInactivePpsOnPassthroughEntry) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, pdo_count()).WillRepeatedly(Return(0));
+
+    NormalStage normal(display, sink, gate);
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    normal.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    conductor.start<NormalStage>(0);
+
+    EXPECT_TRUE(find_pps_event(queue, [](const PpsTargetEvent& e) {
+        return e.pdo_index == -1;
+    }));
+}
+
+TEST(NormalStagePublishing, EmitsRefreshedPpsTargetOnEncoderApply) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv(::testing::_)).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv(::testing::_)).WillRepeatedly(Return(11000));
+    EXPECT_CALL(sink, pdo_max_current_ma(::testing::_)).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, set_pps_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestQueue queue;
+    TestPublisher publisher(queue);
+    normal.attach_publisher_INTERNAL_DO_NOT_USE(publisher);
+
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(0);
+    conductor.start<NormalStage>(0);
+
+    // Drain entry events.
+    while (pop_as<PpsTargetEvent>(queue) != nullptr) {}
+
+    normal.on_event(conductor, EncoderEvent{-1}, 0);
+
+    // The encoder delta is sign-flipped inside PPSMode::on_encoder; encoder -1 with
+    // voltage_idx = 0 yields target += VOLTAGE_INCREMENTS_MV[0] = +1000 mV.
+    const int32_t expected = 5000 + static_cast<int32_t>(pocketpd::VOLTAGE_INCREMENTS_MV[0]);
+    EXPECT_TRUE(find_pps_event(queue, [&](const PpsTargetEvent& e) {
+        return e.pdo_index == 0 && e.target_mv == expected;
+    }));
+}
+
+TEST(NormalStageCompState, CachesCompStateEventForViewModel) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    NiceMock<MockOutputGate> gate;
+    EXPECT_CALL(sink, is_index_pps(::testing::_)).WillRepeatedly(Return(true));
+    EXPECT_CALL(sink, pdo_min_voltage_mv).WillRepeatedly(Return(3300));
+    EXPECT_CALL(sink, pdo_max_voltage_mv).WillRepeatedly(Return(11000));
+    EXPECT_CALL(sink, pdo_max_current_ma).WillRepeatedly(Return(3000));
+    EXPECT_CALL(sink, set_pps_pdo).WillRepeatedly(Return(true));
+
+    NormalStage normal(display, sink, gate);
+    TestConductor conductor;
+    conductor.register_stage(normal);
+    normal.prepare(0);
+    conductor.start<NormalStage>(0);
+
+    normal.on_event(conductor, CompStateEvent{60}, 0);
+    EXPECT_EQ(normal.comp_offset_mv(), 60);
+
+    normal.on_event(conductor, CompStateEvent{0}, 0);
+    EXPECT_EQ(normal.comp_offset_mv(), 0);
+}
+
+namespace {
+    // Helper that builds a PPSMode pinned to a stub sink. PPSMode has no default ctor;
+    // it requires a PdSinkController&. The clamp call inside its ctor consults the sink
+    // for min/max voltage and max current — stub those to wide-open values.
+    PPSMode make_pps_mode(MockPdSink& sink, int32_t target_mv, int32_t target_ma) {
+        ON_CALL(sink, pdo_min_voltage_mv(_)).WillByDefault(Return(3300));
+        ON_CALL(sink, pdo_max_voltage_mv(_)).WillByDefault(Return(11000));
+        ON_CALL(sink, pdo_max_current_ma(_)).WillByDefault(Return(3000));
+        PPSMode mode{sink, 0};
+        mode.target_mv = target_mv;
+        mode.target_ma = target_ma;
+        return mode;
+    }
+}
+
+TEST(PpsViewRender, OffsetSuffixHiddenWhenZero) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(display, draw_text(_, _, ::testing::HasSubstr("+"))).Times(0);
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, text_width(_)).WillRepeatedly(Return(20));
+    EXPECT_CALL(display, set_font).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, clear).Times(1);
+    EXPECT_CALL(display, draw_box).Times(::testing::AnyNumber());
+
+    NormalViewModel vm{};
+    vm.mode = make_pps_mode(sink, 5000, 1000);
+    vm.active_pdo_index = 0;
+    vm.comp_offset_mv = 0;
+    vm.output_enabled = true;
+    vm.readout_visible = true;
+
+    NormalView::render(display, vm);
+}
+
+TEST(PpsViewRender, OffsetSuffixRenderedWhenNonZero) {
+    NiceMock<MockDisplay> display;
+    NiceMock<MockPdSink> sink;
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, draw_text(_, _, StrEq("+60"))).Times(1);
+    EXPECT_CALL(display, text_width(_)).WillRepeatedly(Return(20));
+    EXPECT_CALL(display, set_font).Times(::testing::AnyNumber());
+    EXPECT_CALL(display, clear).Times(1);
+    EXPECT_CALL(display, draw_box).Times(::testing::AnyNumber());
+
+    NormalViewModel vm{};
+    vm.mode = make_pps_mode(sink, 5000, 1000);
+    vm.active_pdo_index = 0;
+    vm.comp_offset_mv = 60;
+    vm.output_enabled = true;
+    vm.readout_visible = true;
+
+    NormalView::render(display, vm);
 }
 
 int main(int argc, char** argv) {

--- a/test/test_v2_pps_control/test.cpp
+++ b/test/test_v2_pps_control/test.cpp
@@ -1,0 +1,297 @@
+#define VERSION "\"test\""
+
+#include <MockEeprom.h>
+#include <MockOutputGate.h>
+#include <MockPdSink.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "v2/app.h"
+#include "v2/events.h"
+#include "v2/preferences_store.h"
+#include "v2/tasks/pps_control_task.h"
+
+using namespace pocketpd;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::_;
+
+namespace {
+
+    struct Harness {
+        NiceMock<MockPdSink> sink;
+        NiceMock<MockOutputGate> gate;
+        NiceMock<MockEeprom> eeprom;
+        PreferencesStore prefs{eeprom};
+        PpsControlTask task{prefs, gate, sink};
+
+        Harness() {
+            ON_CALL(sink, pdo_max_voltage_mv(_)).WillByDefault(Return(11000));
+        }
+    };
+
+    LoadReading load_with(uint32_t mv, uint32_t ma, uint32_t ts = 1) {
+        return LoadReading{ts, mv, ma};
+    }
+
+} // namespace
+
+// —— Sentinel + ignore paths
+
+TEST(PpsControlTask, SentinelPpsTargetMakesNoSinkCall) {
+    Harness h;
+    EXPECT_CALL(h.sink, set_pps_pdo).Times(0);
+
+    h.task.on_event(PpsTargetEvent{-1, 0, 0}, 0);
+}
+
+TEST(PpsControlTask, IgnoresUnrelatedEventTypes) {
+    Harness h;
+    EXPECT_CALL(h.sink, set_pps_pdo).Times(0);
+
+    h.task.on_event(ButtonEvent{ButtonId::ENCODER, Gesture::SHORT}, 0);
+    h.task.on_event(EncoderEvent{1}, 0);
+    h.task.on_event(EnergyEvent{1.0, 1.0, 1}, 0);
+    h.task.on_event(CompStateEvent{42}, 0);
+    EXPECT_EQ(h.task.comp_offset_mv(), 0);
+}
+
+// —— Write-on-PpsTargetEvent (task is sole sink writer)
+
+TEST(PpsControlTask, WritesBareTargetOnPpsTargetWhenDisabled) {
+    Harness h;
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+}
+
+TEST(PpsControlTask, WritesBareTargetOnPpsTargetWhenEnabledButOffsetIsZero) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+}
+
+TEST(PpsControlTask, ReissuesWithOffsetOnSamePdoTargetChange) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+
+    // Build offset = 60 via ticks.
+    EXPECT_CALL(h.sink, set_pps_pdo).WillRepeatedly(Return(true));
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    for (int i = 0; i < 3; ++i) {
+        h.task.on_tick((i + 1) * PpsControlTask::PERIOD_MS);
+    }
+    EXPECT_EQ(h.task.comp_offset_mv(), 60);
+
+    // User turns encoder; NormalStage publishes new target. Task must re-issue with offset.
+    ::testing::Mock::VerifyAndClearExpectations(&h.sink);
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5160, 1000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5100, 1000}, 1000);
+}
+
+TEST(PpsControlTask, NewPdoResetsOffsetAndWritesBareTarget) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+
+    EXPECT_CALL(h.sink, set_pps_pdo).WillRepeatedly(Return(true));
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 20);
+
+    ::testing::Mock::VerifyAndClearExpectations(&h.sink);
+    EXPECT_CALL(h.sink, set_pps_pdo(1, 9000, 2000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{1, 9000, 2000}, 500);
+    EXPECT_EQ(h.task.comp_offset_mv(), 0);
+}
+
+// —— Closed-loop control
+
+TEST(PpsControlTaskTick, StepsUpOncePerTickWhenErrorPositive) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+
+    ::testing::InSequence seq;
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).WillOnce(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5020, 1000)).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 20);
+}
+
+TEST(PpsControlTaskTick, DeadBandSuppressesUpdates) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4985, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 0);
+}
+
+TEST(PpsControlTaskTick, NegativeErrorStepsDown) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+
+    EXPECT_CALL(h.sink, set_pps_pdo).WillRepeatedly(Return(true));
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    for (int i = 0; i < 5; ++i) {
+        h.task.on_tick((i + 1) * PpsControlTask::PERIOD_MS);
+    }
+    EXPECT_EQ(h.task.comp_offset_mv(), 100);
+
+    ::testing::Mock::VerifyAndClearExpectations(&h.sink);
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5080, 1000)).WillOnce(Return(true));
+    h.task.on_event(SensorEvent{load_with(5050, 1500), {}}, 2000);
+    h.task.on_tick(2000);
+    EXPECT_EQ(h.task.comp_offset_mv(), 80);
+}
+
+TEST(PpsControlTaskTick, LowCurrentHoldsOffset) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 50), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 0);
+}
+
+TEST(PpsControlTaskTick, OutputOffSuppressesAndPreservesOffset) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+
+    EXPECT_CALL(h.gate, is_enabled())
+        .WillOnce(Return(true))
+        .WillOnce(Return(true))
+        .WillRepeatedly(Return(false));
+    EXPECT_CALL(h.sink, set_pps_pdo).Times(3).WillRepeatedly(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    h.task.on_tick(2 * PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 40);
+
+    ::testing::Mock::VerifyAndClearExpectations(&h.sink);
+    EXPECT_CALL(h.sink, set_pps_pdo).Times(0);
+    h.task.on_tick(3 * PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 40);
+}
+
+TEST(PpsControlTaskTick, SaturatesAtMaxComp) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo).WillRepeatedly(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4000, 1500), {}}, 1);
+
+    for (int i = 0; i < 30; ++i) {
+        h.task.on_tick((i + 1) * PpsControlTask::PERIOD_MS);
+    }
+    EXPECT_EQ(h.task.comp_offset_mv(), 500);
+
+    ::testing::Mock::VerifyAndClearExpectations(&h.sink);
+    EXPECT_CALL(h.sink, set_pps_pdo).Times(0);
+    h.task.on_tick(31 * PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 500);
+}
+
+TEST(PpsControlTaskTick, FailedSinkOnTickHoldsOffsetForRetry) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+
+    {
+        ::testing::InSequence seq;
+        EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).WillOnce(Return(true));   // initial OK
+        EXPECT_CALL(h.sink, set_pps_pdo(0, 5020, 1000)).WillOnce(Return(false));  // tick fails
+        EXPECT_CALL(h.sink, set_pps_pdo(0, 5020, 1000)).WillOnce(Return(true));   // retry OK
+    }
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 0);
+
+    h.task.on_tick(2 * PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 20);
+}
+
+TEST(PpsControlTaskTick, PreferenceFlipOffEmitsCleanupAndZeroes) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+
+    EXPECT_CALL(h.sink, set_pps_pdo).Times(3).WillRepeatedly(Return(true));
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    h.task.on_tick(2 * PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 40);
+
+    h.prefs.set_voltage_comp_enabled(false);
+    ::testing::Mock::VerifyAndClearExpectations(&h.sink);
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_tick(3 * PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 0);
+
+    ::testing::Mock::VerifyAndClearExpectations(&h.sink);
+    EXPECT_CALL(h.sink, set_pps_pdo).Times(0);
+    h.task.on_tick(4 * PpsControlTask::PERIOD_MS);
+}
+
+TEST(PpsControlTaskTick, ClampsRequestToPdoMax) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(h.sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5000));
+
+    // target == pdo_max: initial write at 5000 happens; on_tick saturates at offset=0.
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).Times(1).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 0);
+}
+
+TEST(PpsControlTaskTick, PartialPdoClampStopsAtCeiling) {
+    Harness h;
+    h.prefs.set_voltage_comp_enabled(true);
+    EXPECT_CALL(h.gate, is_enabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(h.sink, pdo_max_voltage_mv(0)).WillRepeatedly(Return(5010));
+
+    ::testing::InSequence seq;
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5000, 1000)).WillOnce(Return(true));
+    EXPECT_CALL(h.sink, set_pps_pdo(0, 5010, 1000)).WillOnce(Return(true));
+
+    h.task.on_event(PpsTargetEvent{0, 5000, 1000}, 0);
+    h.task.on_event(SensorEvent{load_with(4800, 1500), {}}, 1);
+    h.task.on_tick(PpsControlTask::PERIOD_MS);
+    EXPECT_EQ(h.task.comp_offset_mv(), 10);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_v2_settings/test.cpp
+++ b/test/test_v2_settings/test.cpp
@@ -47,8 +47,9 @@ namespace {
 
 TEST(SettingsStage, RendersOneRowWithUncheckedBox) {
     Harness h;
-    EXPECT_CALL(h.display, draw_text(0, 9, StrEq(">"))).Times(1);
-    EXPECT_CALL(h.display, draw_text(10, 9, StrEq("[ ] Skip picker"))).Times(1);
+    EXPECT_CALL(h.display, draw_text(_, _, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(h.display, draw_text(0, 12, StrEq(">"))).Times(1);
+    EXPECT_CALL(h.display, draw_text(10, 12, StrEq("[ ] Skip picker"))).Times(1);
     h.conductor.start<SettingsStage>(0);
 }
 
@@ -56,7 +57,7 @@ TEST(SettingsStage, RendersCheckedWhenSettingTrue) {
     Harness h;
     h.prefs.set_skip_picker_on_boot(true);
     EXPECT_CALL(h.display, draw_text(_, _, _)).Times(::testing::AnyNumber());
-    EXPECT_CALL(h.display, draw_text(10, 9, StrEq("[x] Skip picker"))).Times(1);
+    EXPECT_CALL(h.display, draw_text(10, 12, StrEq("[X] Skip picker"))).Times(1);
     h.conductor.start<SettingsStage>(0);
 }
 
@@ -111,6 +112,55 @@ TEST(SettingsStage, ExitWithoutTogglesDoesNotSave) {
     h.stage.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
     EXPECT_TRUE(h.conductor.apply_pending_transition(0));
     EXPECT_EQ(h.conductor.current_index(), TestConductor::index_of<MenuStage>());
+}
+
+TEST(SettingsStage, RendersVoltageCompRowBelowSkipPicker) {
+    Harness h;
+    EXPECT_CALL(h.display, draw_text(_, _, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(h.display, draw_text(10, 12, StrEq("[ ] Skip picker"))).Times(1);
+    EXPECT_CALL(h.display, draw_text(10, 24, StrEq("[ ] Voltage comp"))).Times(1);
+    h.conductor.start<SettingsStage>(0);
+}
+
+TEST(SettingsStage, EncoderMovesCursorToVoltageCompRow) {
+    Harness h;
+    h.conductor.start<SettingsStage>(0);
+    ::testing::Mock::VerifyAndClearExpectations(&h.display);
+
+    EXPECT_CALL(h.display, draw_text(_, _, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(h.display, draw_text(0, 24, StrEq(">"))).Times(1);
+    EXPECT_CALL(h.display, draw_text(0, 12, StrEq(">"))).Times(0);
+
+    h.stage.on_event(h.conductor, EncoderEvent{1}, 0);
+}
+
+TEST(SettingsStage, EncoderLongOnVoltageCompTogglesPreference) {
+    Harness h;
+    h.conductor.start<SettingsStage>(0);
+
+    h.stage.on_event(h.conductor, EncoderEvent{1}, 0);
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+
+    EXPECT_TRUE(h.prefs.voltage_comp_enabled());
+    EXPECT_TRUE(h.prefs.dirty());
+}
+
+TEST(SettingsStage, ExitFlushesVoltageCompToggle) {
+    Harness h;
+    h.conductor.start<SettingsStage>(0);
+
+    h.stage.on_event(h.conductor, EncoderEvent{1}, 0);
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
+
+    EXPECT_CALL(h.eeprom, save(_))
+        .WillOnce([](const Preferences& s) {
+            EXPECT_TRUE(s.voltage_comp_enabled);
+            EXPECT_FALSE(s.skip_picker_on_boot);
+            return true;
+        });
+
+    h.stage.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
+    EXPECT_TRUE(h.conductor.apply_pending_transition(0));
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

Voltage compensation for IR drop on PPS profiles. When `Voltage comp` is enabled in Settings, a new `PpsControlTask` watches the INA226 load reading and steps the requested PPS voltage up by 20 mV every 250 ms until the measured output matches the user's target mv.

- `PpsControlTask` (`include/v2/tasks/pps_control_task.h`) subscribes to `PpsTargetEvent` and `SensorEvent`, publishes `CompStateEvent` for the UI offset indicator. `PpsControlTask` is the sole writer to PD sink so nothing else can mess up the compensation calculation.
- New `Voltage comp` row in `SettingsStage`, off by default. `PREFERENCES_LAYOUT_VERSION` bumped 1 to 2.
- `pps_view` shows a `+<N>mv` next to the target mv when the active offset is non-zero.

## Linked issues
- Closes #44

## Hardware tested
- [x] HW1_3
- [ ] None (no hardware change)

How tested: native suite 178/178 (\`pio test -e native\`). \`pio run -e HW1_3_V2\` builds clean (Flash 6.7%, RAM 5.7%). 

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)
- [x] EEPROM layout or calibration constants

## Notes

<img width="3024" height="4032" alt="IMG_3340" src="https://github.com/user-attachments/assets/959949eb-d48a-4305-830f-7a9670e45efd" />



