### PR TITLE
refactor(v2): extract TableView for Menu/Settings list screens

### DIFF
--- a/include/v2/stages/menu_stage.h
+++ b/include/v2/stages/menu_stage.h
@@ -5,7 +5,6 @@
  */
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <variant>
@@ -15,6 +14,7 @@
 
 #include "v2/app.h"
 #include "v2/events.h"
+#include "v2/ui/table_view.h"
 
 namespace pocketpd {
 
@@ -23,46 +23,44 @@ namespace pocketpd {
         using Display = tempo::Display;
 
         enum class Item : uint8_t {
-            PROFILE_PICKER = 0,
-            SETTINGS = 1,
+            PROFILE_PICKER,
+            SETTINGS,
         };
 
-        static constexpr std::array<const char*, 2> ITEM_LABELS = {
-            "Profile Picker",
-            "Settings",
+        struct MenuItem {
+            Item item;
+            const char* label;
         };
+
+        static constexpr std::array<MenuItem, 2> ITEMS = {{
+            {Item::PROFILE_PICKER, "Profile Picker"},
+            {Item::SETTINGS, "Settings"},
+        }};
 
         Display& m_display;
-        uint8_t m_cursor = 0;
+        TableView m_table;
 
         int count() const {
-            return ITEM_LABELS.size();
-        }
-
-        Item current_item() const {
-            return static_cast<Item>(m_cursor);
+            return ITEMS.size();
         }
 
         void draw() {
-            m_display.clear();
-            
-            for (int i = 0; i < count(); i++) {
-                const auto y = (12 * (i + 1));
-                if (i == m_cursor) {
-                    m_display.draw_text(0, y, ">");
-                }
-
-                m_display.draw_text(10, y, ITEM_LABELS[i]);
+            std::array<TableRow, ITEMS.size()> rows{};
+            for (size_t i = 0; i < ITEMS.size(); ++i) {
+                rows[i].text = ITEMS[i].label;
             }
 
-            m_display.flush();
+            TableModel model;
+            model.rows = rows.data();
+            model.count = static_cast<uint8_t>(ITEMS.size());
+            m_table.render(m_display, model);
         }
 
     public:
         explicit MenuStage(Display& display) : m_display(display) {}
 
         void on_enter(Conductor&, uint32_t) override {
-            m_cursor = 0;
+            m_table.reset();
             draw();
         }
 
@@ -72,15 +70,9 @@ namespace pocketpd {
                     if (evt.delta == 0) {
                         return;
                     }
-
-                    const int max_idx = count() - 1;
-                    int next = std::clamp(m_cursor + evt.delta, 0, max_idx);
-                    if (next == m_cursor) {
-                        return;
+                    if (m_table.move(evt.delta, static_cast<uint8_t>(count()))) {
+                        draw();
                     }
-
-                    m_cursor = next;
-                    draw();
                 },
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
@@ -88,10 +80,13 @@ namespace pocketpd {
                         return;
                     }
                     if (evt.id == ButtonId::ENCODER && evt.gesture == Gesture::LONG) {
-                        if (current_item() == Item::PROFILE_PICKER) {
+                        switch (ITEMS[m_table.cursor()].item) {
+                        case Item::PROFILE_PICKER:
                             conductor.request<ProfilePickerStage>();
-                        } else {
+                            break;
+                        case Item::SETTINGS:
                             conductor.request<SettingsStage>();
+                            break;
                         }
                     }
                 },

--- a/include/v2/stages/settings_stage.h
+++ b/include/v2/stages/settings_stage.h
@@ -5,7 +5,6 @@
  */
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdio>
@@ -15,8 +14,9 @@
 #include <tempo/hardware/display.h>
 
 #include "v2/app.h"
-#include "v2/preferences_store.h"
 #include "v2/events.h"
+#include "v2/preferences_store.h"
+#include "v2/ui/table_view.h"
 
 namespace pocketpd {
 
@@ -24,19 +24,27 @@ namespace pocketpd {
     private:
         using Display = tempo::Display;
 
-        enum class Item : uint8_t { SKIP_PICKER = 0, VOLTAGE_COMP = 1 };
-
-        static constexpr std::array<const char*, 2> ITEM_LABELS = {
-            "Skip picker",
-            "Voltage comp",
+        enum class Item : uint8_t {
+            SKIP_PICKER,
+            VOLTAGE_COMP,
         };
+
+        struct SettingItem {
+            Item item;
+            const char* label;
+        };
+
+        static constexpr std::array<SettingItem, 2> ITEMS = {{
+            {Item::SKIP_PICKER, "Skip picker"},
+            {Item::VOLTAGE_COMP, "Voltage comp"},
+        }};
 
         Display& m_display;
         PreferencesStore& m_prefs;
-        uint8_t m_cursor = 0;
+        TableView m_table{};
 
         int count() const {
-            return ITEM_LABELS.size();
+            return ITEMS.size();
         }
 
         bool value_at(Item item) const {
@@ -50,7 +58,7 @@ namespace pocketpd {
         }
 
         void toggle_current() {
-            switch (static_cast<Item>(m_cursor)) {
+            switch (ITEMS[m_table.cursor()].item) {
             case Item::SKIP_PICKER:
                 m_prefs.set_skip_picker_on_boot(!m_prefs.skip_picker_on_boot());
                 break;
@@ -63,35 +71,28 @@ namespace pocketpd {
         }
 
         void draw() {
-            m_display.clear();
-
-            std::array<char, 32> buffer{};
-            for (int i = 0; i < count(); ++i) {
-                const int y = 12 * (i + 1);
-                if (i == m_cursor) {
-                    m_display.draw_text(0, y, ">");
-                }
-
-                const char mark = value_at(static_cast<Item>(i)) ? 'X' : ' ';
-                std::snprintf(buffer.data(), buffer.size(), "[%c] %s", mark, ITEM_LABELS[i]);
-                m_display.draw_text(10, y, buffer.data());
+            std::array<std::array<char, 32>, ITEMS.size()> buffers{};
+            std::array<TableRow, ITEMS.size()> rows{};
+            for (size_t i = 0; i < ITEMS.size(); ++i) {
+                const char mark = value_at(ITEMS[i].item) ? 'X' : ' ';
+                std::snprintf(
+                    buffers[i].data(), buffers[i].size(), "[%c] %s", mark, ITEMS[i].label
+                );
+                rows[i].text = buffers[i].data();
             }
 
-            m_display.flush();
+            TableModel model;
+            model.rows = rows.data();
+            model.count = static_cast<uint8_t>(ITEMS.size());
+            m_table.render(m_display, model);
         }
 
     public:
-        static constexpr const char* LOG_TAG = "Settings";
-
         SettingsStage(Display& display, PreferencesStore& prefs)
             : m_display(display), m_prefs(prefs) {}
 
-        const char* name() const override {
-            return "SETTINGS";
-        }
-
         void on_enter(Conductor&, uint32_t) override {
-            m_cursor = 0;
+            m_table.reset();
             draw();
         }
 
@@ -104,12 +105,12 @@ namespace pocketpd {
         void on_event(Conductor& conductor, const Event& event, uint32_t) override {
             auto handler = tempo::overloaded{
                 [&](const EncoderEvent& evt) {
-                    if (evt.delta == 0) return;
-                    const int max_idx = count() - 1;
-                    int next = std::clamp(static_cast<int>(m_cursor) + evt.delta, 0, max_idx);
-                    if (next == m_cursor) return;
-                    m_cursor = static_cast<uint8_t>(next);
-                    draw();
+                    if (evt.delta == 0) {
+                        return;
+                    }
+                    if (m_table.move(evt.delta, static_cast<uint8_t>(count()))) {
+                        draw();
+                    }
                 },
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {

--- a/include/v2/ui/table_view.h
+++ b/include/v2/ui/table_view.h
@@ -1,0 +1,107 @@
+/**
+ * @file table_view.h
+ * @brief Reusable list/table view that owns its cursor and scroll window.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include <tempo/hardware/display.h>
+
+namespace pocketpd {
+
+    struct TableRow {
+        const char* text = nullptr;
+    };
+
+    struct TableModel {
+        const TableRow* rows = nullptr;
+        uint8_t count = 0;
+    };
+
+    struct TableStyle {
+        uint8_t row_height = 12;
+        uint8_t first_y = 12;
+        uint8_t text_x = 10;
+        uint8_t cursor_x = 0;
+        uint8_t visible_rows = 5;
+        const char* cursor_glyph = ">";
+    };
+
+    class TableView {
+    private:
+        TableStyle m_style;
+        uint8_t m_cursor = 0;
+        uint8_t m_scroll_top = 0;
+
+        /**
+         * @brief Index of the top visible row. Sticky — moves only when the cursor leaves view.
+         */
+        uint8_t next_scroll_top(uint8_t count) const {
+            const uint8_t cap = m_style.visible_rows;
+            if (count <= cap) {
+                return 0;
+            }
+
+            uint8_t top = m_scroll_top;
+            if (m_cursor < top) {
+                top = m_cursor;
+            } else if (m_cursor >= top + cap) {
+                top = m_cursor - cap + 1;
+            }
+
+            const auto max_top = count - cap;
+            return top > max_top ? max_top : top;
+        }
+
+    public:
+        explicit TableView(TableStyle style = {}) : m_style(style) {}
+
+        uint8_t cursor() const {
+            return m_cursor;
+        }
+
+        uint8_t capacity() const {
+            return m_style.visible_rows;
+        }
+
+        void reset() {
+            m_cursor = 0;
+            m_scroll_top = 0;
+        }
+
+        bool move(int delta, uint8_t count) {
+            if (count == 0) {
+                return false;
+            }
+
+            const int next = std::clamp(m_cursor + delta, 0, count - 1);
+            if (next == m_cursor) {
+                return false;
+            }
+
+            m_cursor = next;
+            return true;
+        }
+
+        void render(tempo::Display& display, const TableModel& model) {
+            m_scroll_top = next_scroll_top(model.count);
+
+            display.clear();
+
+            const auto last = std::min<uint8_t>(model.count, m_scroll_top + m_style.visible_rows);
+            for (auto i = m_scroll_top; i < last; ++i) {
+                const auto y = m_style.first_y + (i - m_scroll_top) * m_style.row_height;
+                if (i == m_cursor) {
+                    display.draw_text(m_style.cursor_x, y, m_style.cursor_glyph);
+                }
+
+                display.draw_text(m_style.text_x, y, model.rows[i].text);
+            }
+
+            display.flush();
+        }
+    };
+
+} // namespace pocketpd

--- a/test/test_v2_table_view/test.cpp
+++ b/test/test_v2_table_view/test.cpp
@@ -1,0 +1,194 @@
+/**
+ * @file test.cpp
+ * @brief TableView render + cursor/scroll-window unit tests against MockDisplay.
+ */
+#define VERSION "\"test\""
+
+#include <array>
+
+#include <MockDisplay.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "v2/ui/table_view.h"
+
+using namespace pocketpd;
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::NiceMock;
+using ::testing::StrEq;
+
+TEST(TableView, RendersRowsWithCursorGlyph) {
+    NiceMock<MockDisplay> display;
+    std::array<TableRow, 2> rows{};
+    rows[0].text = "Alpha";
+    rows[1].text = "Beta";
+
+    TableModel model;
+    model.rows = rows.data();
+    model.count = 2;
+
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, clear()).Times(1);
+    EXPECT_CALL(display, draw_text(0, 12, StrEq(">"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 12, StrEq("Alpha"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 24, StrEq("Beta"))).Times(1);
+    EXPECT_CALL(display, draw_text(0, 24, StrEq(">"))).Times(0);
+    EXPECT_CALL(display, flush()).Times(1);
+
+    TableView view;
+    view.render(display, model);
+}
+
+TEST(TableView, DrawsRowTextVerbatim) {
+    // The view is content-agnostic: it draws whatever the stage formatted into text,
+    // including leading markers like a checkbox. It does not know what a row means.
+    NiceMock<MockDisplay> display;
+    std::array<TableRow, 2> rows{};
+    rows[0].text = "[X] On";
+    rows[1].text = "[ ] Off";
+
+    TableModel model;
+    model.rows = rows.data();
+    model.count = 2;
+
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(10, 12, StrEq("[X] On"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 24, StrEq("[ ] Off"))).Times(1);
+
+    TableView view;
+    view.render(display, model);
+}
+
+TEST(TableView, MoveClampsAndReportsChange) {
+    TableView view;
+    EXPECT_FALSE(view.move(-1, 3)); // already at top
+    EXPECT_EQ(view.cursor(), 0);
+    EXPECT_TRUE(view.move(2, 3)); // 0 -> 2
+    EXPECT_EQ(view.cursor(), 2);
+    EXPECT_FALSE(view.move(5, 3)); // clamped at bottom, no change
+    EXPECT_EQ(view.cursor(), 2);
+    EXPECT_TRUE(view.move(-2, 3)); // 2 -> 0
+    EXPECT_EQ(view.cursor(), 0);
+    EXPECT_FALSE(view.move(1, 0)); // empty list
+}
+
+TEST(TableView, ScrollsWindowToKeepCursorVisible) {
+    // A view with capacity 2, cursor moved to row 2, derives scroll_top=1 on its own.
+    NiceMock<MockDisplay> display;
+    std::array<TableRow, 4> rows{};
+    rows[0].text = "r0";
+    rows[1].text = "r1";
+    rows[2].text = "r2";
+    rows[3].text = "r3";
+
+    TableModel model;
+    model.rows = rows.data();
+    model.count = 4;
+
+    TableStyle style;
+    style.visible_rows = 2;
+    TableView view{style};
+    view.move(2, 4); // cursor -> 2, below the initial window
+
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(10, 12, StrEq("r1"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 24, StrEq("r2"))).Times(1);
+    EXPECT_CALL(display, draw_text(0, 24, StrEq(">"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, _, StrEq("r0"))).Times(0);
+    EXPECT_CALL(display, draw_text(10, _, StrEq("r3"))).Times(0);
+
+    view.render(display, model);
+}
+
+TEST(TableView, StickyScrollPersistsAcrossRenders) {
+    // Scroll state lives in the view across frames: paging down then back up one
+    // keeps the window sticky without the consumer tracking anything.
+    NiceMock<MockDisplay> display;
+    std::array<TableRow, 4> rows{};
+    rows[0].text = "r0";
+    rows[1].text = "r1";
+    rows[2].text = "r2";
+    rows[3].text = "r3";
+
+    TableModel model;
+    model.rows = rows.data();
+    model.count = 4;
+
+    TableStyle style;
+    style.visible_rows = 2;
+    TableView view{style};
+
+    view.move(3, 4); // cursor -> 3, window becomes r2/r3
+    view.render(display, model);
+
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(10, 12, StrEq("r2"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 24, StrEq("r3"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, _, StrEq("r0"))).Times(0);
+    EXPECT_CALL(display, draw_text(10, _, StrEq("r1"))).Times(0);
+
+    view.move(-1, 4); // cursor -> 2, still inside window: stays r2/r3
+    view.render(display, model);
+}
+
+TEST(TableView, ScrollsBackUpWhenCursorMovesAboveWindow) {
+    NiceMock<MockDisplay> display;
+    std::array<TableRow, 4> rows{};
+    rows[0].text = "r0";
+    rows[1].text = "r1";
+    rows[2].text = "r2";
+    rows[3].text = "r3";
+
+    TableModel model;
+    model.rows = rows.data();
+    model.count = 4;
+
+    TableStyle style;
+    style.visible_rows = 2;
+    TableView view{style};
+
+    view.move(3, 4); // window r2/r3
+    view.render(display, model);
+
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(0, 12, StrEq(">"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 12, StrEq("r0"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 24, StrEq("r1"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, _, StrEq("r2"))).Times(0);
+    EXPECT_CALL(display, draw_text(10, _, StrEq("r3"))).Times(0);
+
+    view.move(-3, 4); // cursor -> 0, window follows up to r0/r1
+    view.render(display, model);
+}
+
+TEST(TableView, NoScrollWhenAllRowsFit) {
+    // count <= capacity: scroll_top stays 0, every row drawn top-down.
+    NiceMock<MockDisplay> display;
+    std::array<TableRow, 3> rows{};
+    rows[0].text = "a";
+    rows[1].text = "b";
+    rows[2].text = "c";
+
+    TableModel model;
+    model.rows = rows.data();
+    model.count = 3;
+
+    TableStyle style;
+    style.visible_rows = 5;
+    TableView view{style};
+    view.move(2, 3); // cursor -> 2
+
+    EXPECT_CALL(display, draw_text(_, _, _)).Times(AnyNumber());
+    EXPECT_CALL(display, draw_text(10, 12, StrEq("a"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 24, StrEq("b"))).Times(1);
+    EXPECT_CALL(display, draw_text(10, 36, StrEq("c"))).Times(1);
+    EXPECT_CALL(display, draw_text(0, 36, StrEq(">"))).Times(1);
+
+    view.render(display, model);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
Menu and Settings both carried their own copy of the list code: the draw loop, cursor clamping, and scroll tracking. This moves that into a reusable `TableView` (`include/v2/ui/table_view.h`). The view holds the cursor and scroll window, so a screen just hands it rows and reacts when one gets picked. Rendering and navigation work the same as before.

- `TableView` renders a `TableModel` (`{rows, count}`) and tracks the cursor and sticky scroll itself. `move(delta, count)` reports whether the cursor changed, so a screen skips the redraw when it hits a clamp edge.
- New `test_v2_table_view` covers rendering, cursor clamping, and scrolling: follow down, follow up, sticky across frames, and no scroll when everything fits.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested:
Native suite green (184 tests). `make build-v2` links and produces the HW1_3_V2 UF2.

## Breaking change / migration

Details:
None. Behavior identical on-device.

## Notes
NavStack (back-stack navigation) is a separate, still-pending change. TableView scrolls on its own once a list exceeds the visible rows, so future screens with more entries need no extra wiring.