### PR TITLE
feat(v2): navigation back-stack in the Conductor

### DIFF
--- a/include/v2/stages/boot_stage.h
+++ b/include/v2/stages/boot_stage.h
@@ -41,7 +41,7 @@ namespace pocketpd {
 
         void on_tick(Conductor& conductor, uint32_t now_ms) override {
             if (m_timeout.reached(now_ms)) {
-                conductor.request<ObtainStage>();
+                conductor.replace<ObtainStage>();
             }
         }
     };

--- a/include/v2/stages/energy_stage.h
+++ b/include/v2/stages/energy_stage.h
@@ -91,7 +91,7 @@ namespace pocketpd {
                         return;
                     }
                     if (event.r_long()) {
-                        conductor.request<NormalStage>(m_active_pdo_index);
+                        conductor.pop();
                     }
                 },
                 [&](const SensorEvent& event) {

--- a/include/v2/stages/menu_stage.h
+++ b/include/v2/stages/menu_stage.h
@@ -76,16 +76,16 @@ namespace pocketpd {
                 },
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
-                        conductor.request<NormalStage>();
+                        conductor.pop();
                         return;
                     }
                     if (evt.id == ButtonId::ENCODER && evt.gesture == Gesture::LONG) {
                         switch (ITEMS[m_table.cursor()].item) {
                         case Item::PROFILE_PICKER:
-                            conductor.request<ProfilePickerStage>();
+                            conductor.push<ProfilePickerStage>();
                             break;
                         case Item::SETTINGS:
-                            conductor.request<SettingsStage>();
+                            conductor.push<SettingsStage>();
                             break;
                         }
                     }

--- a/include/v2/stages/normal_stage.h
+++ b/include/v2/stages/normal_stage.h
@@ -188,12 +188,12 @@ namespace pocketpd {
                     }
 
                     if (event.r_long()) {
-                        conductor.request<EnergyStage>(m_active_pdo_index);
+                        conductor.push<EnergyStage>(m_active_pdo_index);
                         return;
                     }
 
                     if (event.l_long()) {
-                        conductor.request<MenuStage>();
+                        conductor.push<MenuStage>();
                         return;
                     }
 

--- a/include/v2/stages/obtain_stage.h
+++ b/include/v2/stages/obtain_stage.h
@@ -55,7 +55,7 @@ namespace pocketpd {
             }
 
             if (m_prefs.skip_picker_on_boot()) {
-                conductor.request<NormalStage>();
+                conductor.replace<NormalStage>();
             }
         }
 
@@ -66,7 +66,7 @@ namespace pocketpd {
             }
 
             if (m_timeout.reached(now_ms)) {
-                conductor.request<ProfilePickerStage>();
+                conductor.reset_path<NormalStage, MenuStage, ProfilePickerStage>();
             }
         }
 
@@ -75,12 +75,12 @@ namespace pocketpd {
             auto handler = tempo::overloaded{
                 [&](const ButtonEvent& evt) {
                     if (evt.gesture == Gesture::SHORT) {
-                        conductor.request<ProfilePickerStage>();
+                        conductor.reset_path<NormalStage, MenuStage, ProfilePickerStage>();
                     }
                 },
                 [&](const EncoderEvent& evt) {
                     if (evt.delta != 0) {
-                        conductor.request<ProfilePickerStage>();
+                        conductor.reset_path<NormalStage, MenuStage, ProfilePickerStage>();
                     }
                 },
                 [](const auto&) {

--- a/include/v2/stages/profile_picker_stage.h
+++ b/include/v2/stages/profile_picker_stage.h
@@ -40,7 +40,7 @@ namespace pocketpd {
                 return; // empty-PDO fallback: long-press is a no-op
             }
             m_cursor = m_pending_cursor;
-            conductor.request<NormalStage>(static_cast<int8_t>(m_cursor));
+            conductor.reset_root<NormalStage>(static_cast<int8_t>(m_cursor));
         }
 
     public:
@@ -74,7 +74,7 @@ namespace pocketpd {
 
         void on_tick(Conductor& conductor, uint32_t now_ms) override {
             if (m_passthrough_timeout.reached(now_ms)) {
-                conductor.request<NormalStage>(static_cast<int8_t>(-1));
+                conductor.reset_root<NormalStage>(static_cast<int8_t>(-1));
             }
         }
 
@@ -82,8 +82,8 @@ namespace pocketpd {
             // Passthrough-only screen: any user input drops to NormalStage in passthrough.
             if (power_source_type() == PowerSourceType::NON_PD) {
                 auto pass_handler = tempo::overloaded{
-                    [&](const ButtonEvent&) { conductor.request<NormalStage>(-1); },
-                    [&](const EncoderEvent& evt) { conductor.request<NormalStage>(-1); },
+                    [&](const ButtonEvent&) { conductor.reset_root<NormalStage>(-1); },
+                    [&](const EncoderEvent& evt) { conductor.reset_root<NormalStage>(-1); },
                     [](const auto&) {},
                 };
                 std::visit(pass_handler, event);
@@ -103,7 +103,7 @@ namespace pocketpd {
                 },
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
-                        conductor.request<MenuStage>();
+                        conductor.pop();
                         return;
                     }
 

--- a/include/v2/stages/settings_stage.h
+++ b/include/v2/stages/settings_stage.h
@@ -114,7 +114,7 @@ namespace pocketpd {
                 },
                 [&](const ButtonEvent& evt) {
                     if (evt.id == ButtonId::L && evt.gesture == Gesture::LONG) {
-                        conductor.request<MenuStage>();
+                        conductor.pop();
                         return;
                     }
                     if (evt.id == ButtonId::ENCODER && evt.gesture == Gesture::LONG) {

--- a/lib/tempo/include/tempo/core/type_list.h
+++ b/lib/tempo/include/tempo/core/type_list.h
@@ -29,4 +29,17 @@ namespace tempo {
     template <typename T, typename... Ts>
     constexpr inline size_t type_index_v = type_index<T, Ts...>::value;
 
+    // —— Compile-time type at index I in Ts... (reverse of type_index)
+
+    template <size_t I, typename T, typename... Ts>
+    struct type_at : type_at<I - 1, Ts...> {};
+
+    template <typename T, typename... Ts>
+    struct type_at<0, T, Ts...> {
+        using type = T;
+    };
+
+    template <size_t I, typename... Ts>
+    using type_at_t = typename type_at<I, Ts...>::type;
+
 } // namespace tempo

--- a/lib/tempo/include/tempo/stage/conductor.h
+++ b/lib/tempo/include/tempo/stage/conductor.h
@@ -18,7 +18,7 @@ namespace tempo {
      *
      * Stage identity = type. Each Stage S has a slot index equal to its position in the
      * Stages... type list. Use register_stage<S>(stage) to bind a slot to a Stage instance,
-     * and request<S>() to schedule a transition.
+     * and the navigation ops (push/pop/replace/reset_root/reset_path) to move between stages.
      *
      * Up to 32 stages (mirrors StageMask).
      *
@@ -50,6 +50,33 @@ namespace tempo {
 
         bool m_has_pending = false;
         size_t m_pending_idx = 0;
+
+        std::array<size_t, 8> m_nav{};
+        size_t m_nav_depth = 0;
+
+        // —— Low-level transition primitives (navigation goes through the public ops)
+
+        template <typename S, typename... Args>
+        void request(Args&&... args) {
+            constexpr size_t idx = index_of<S>();
+            m_pending_idx = idx;
+            m_has_pending = true;
+
+            if constexpr (sizeof...(Args) > 0) {
+                if (auto* slot = m_slots[idx]) {
+                    static_cast<S*>(slot)->prepare(std::forward<Args>(args)...);
+                }
+            }
+        }
+
+        template <size_t... Is>
+        void request_index_impl(size_t idx, std::index_sequence<Is...>) {
+            ((idx == Is ? request<type_at_t<Is, Stages...>>() : void()), ...);
+        }
+
+        void request_index(size_t idx) {
+            request_index_impl(idx, std::make_index_sequence<STAGE_COUNT>{});
+        }
 
         StageType* lookup(size_t idx) const {
             if (idx >= STAGE_COUNT) {
@@ -83,29 +110,58 @@ namespace tempo {
         template <typename S>
         void start(uint32_t now_ms) {
             constexpr size_t idx = index_of<S>();
+            m_nav[0] = idx;
+            m_nav_depth = 1;
             m_current_idx = idx;
             m_current = lookup(idx);
             m_current->on_enter(*this, now_ms);
         }
 
-        /**
-         * @brief Request a transition to stage S. on_enter(Conductor&, uint32_t) is called when
-         * the transition is applied.
-         *
-         * Optional payload-passing form: `request<S>(args...)` calls `S::prepare(args...)`
-         * on the target slot immediately, then schedules the transition.
-         */
+        /** @brief Push S onto the stack. No-op if S is already the top. */
         template <typename S, typename... Args>
-        void request(Args&&... args) {
-            constexpr size_t idx = index_of<S>();
-            m_pending_idx = idx;
-            m_has_pending = true;
-
-            if constexpr (sizeof...(Args) > 0) {
-                if (auto* slot = m_slots[idx]) {
-                    static_cast<S*>(slot)->prepare(std::forward<Args>(args)...);
-                }
+        void push(Args&&... args) {
+            if (m_nav_depth && m_nav[m_nav_depth - 1] == index_of<S>()) {
+                return;
             }
+            if (m_nav_depth < m_nav.size()) {
+                m_nav[m_nav_depth++] = index_of<S>();
+            }
+            request<S>(std::forward<Args>(args)...);
+        }
+
+        /** @brief Pop the top, returning to the stage below. No-op at the root. */
+        void pop() {
+            if (m_nav_depth > 1) {
+                request_index(m_nav[--m_nav_depth - 1]);
+            }
+        }
+
+        /** @brief Replace the top with S. */
+        template <typename S, typename... Args>
+        void replace(Args&&... args) {
+            if (m_nav_depth == 0) {
+                return; // no current top to replace
+            }
+            m_nav[m_nav_depth - 1] = index_of<S>();
+            request<S>(std::forward<Args>(args)...);
+        }
+
+        /** @brief Reset the stack to `[S]`. */
+        template <typename S, typename... Args>
+        void reset_root(Args&&... args) {
+            m_nav[0] = index_of<S>();
+            m_nav_depth = 1;
+            request<S>(std::forward<Args>(args)...);
+        }
+
+        /** @brief Reset the stack to `Path...` and enter its top (lower stages get no on_enter). */
+        template <typename... Path>
+        void reset_path() {
+            static_assert(sizeof...(Path) > 0, "reset_path needs at least one stage");
+            static_assert(sizeof...(Path) <= 8, "path deeper than the nav stack");
+            m_nav_depth = 0;
+            ((m_nav[m_nav_depth++] = index_of<Path>()), ...);
+            request_index(m_nav[m_nav_depth - 1]);
         }
 
         bool has_pending() const {

--- a/lib/tempo/test/test_tempo_navstack/test.cpp
+++ b/lib/tempo/test/test_tempo_navstack/test.cpp
@@ -1,0 +1,125 @@
+/**
+ * GoogleTest suite for the Conductor navigation stack: request_index, push, pop,
+ * replace, reset_root, and the top == current invariant.
+ */
+#include <variant>
+
+#include <gtest/gtest.h>
+#include <tempo/stage/conductor.h>
+#include <tempo/stage/stage.h>
+
+namespace {
+
+    using TestEvent = std::variant<std::monostate>;
+
+    class StageA;
+    class StageB;
+    class StageC;
+
+    using TestConductor = tempo::Conductor<TestEvent, StageA, StageB, StageC>;
+    using TestStage = tempo::Stage<TestEvent, StageA, StageB, StageC>;
+
+    class StageA : public TestStage {};
+    class StageB : public TestStage {};
+    class StageC : public TestStage {};
+
+    struct Fixture {
+        StageA a;
+        StageB b;
+        StageC c;
+        TestConductor conductor;
+        Fixture() {
+            conductor.register_stage(a);
+            conductor.register_stage(b);
+            conductor.register_stage(c);
+        }
+    };
+
+} // namespace
+
+TEST(NavStack, PushPopWalksBack) {
+    Fixture f;
+    f.conductor.start<StageA>(0);
+    f.conductor.push<StageB>();
+    f.conductor.apply_pending_transition(0);
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageB>());
+    f.conductor.push<StageC>();
+    f.conductor.apply_pending_transition(0);
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageC>());
+
+    f.conductor.pop();
+    EXPECT_TRUE(f.conductor.apply_pending_transition(0));
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageB>());
+    f.conductor.pop();
+    EXPECT_TRUE(f.conductor.apply_pending_transition(0));
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageA>());
+}
+
+TEST(NavStack, PushCurrentStageIsNoOp) {
+    Fixture f;
+    f.conductor.start<StageA>(0);
+    f.conductor.push<StageA>();
+    EXPECT_FALSE(f.conductor.has_pending());
+}
+
+TEST(NavStack, PopAtRootIsNoOp) {
+    Fixture f;
+    f.conductor.start<StageA>(0);
+    f.conductor.pop();
+    EXPECT_FALSE(f.conductor.has_pending());
+}
+
+TEST(NavStack, ReplaceSwapsTopThenPopGoesToRoot) {
+    Fixture f;
+    f.conductor.start<StageA>(0);
+    f.conductor.push<StageB>();
+    f.conductor.apply_pending_transition(0);
+    f.conductor.replace<StageC>();
+    f.conductor.apply_pending_transition(0);
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageC>());
+    f.conductor.pop();
+    EXPECT_TRUE(f.conductor.apply_pending_transition(0));
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageA>());
+}
+
+TEST(NavStack, ReplaceWithoutCurrentIsNoOp) {
+    Fixture f;
+    // No start(): the stack is empty, so there is no top to replace.
+    f.conductor.replace<StageB>();
+    EXPECT_FALSE(f.conductor.has_pending());
+}
+
+TEST(NavStack, ResetRootCollapsesStack) {
+    Fixture f;
+    f.conductor.start<StageA>(0);
+    f.conductor.push<StageB>();
+    f.conductor.apply_pending_transition(0);
+    f.conductor.push<StageC>();
+    f.conductor.apply_pending_transition(0);
+    f.conductor.reset_root<StageA>();
+    EXPECT_TRUE(f.conductor.apply_pending_transition(0));
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageA>());
+    f.conductor.pop();
+    EXPECT_FALSE(f.conductor.has_pending());
+}
+
+TEST(NavStack, ResetPathSeedsStackAndEntersTop) {
+    Fixture f;
+    f.conductor.start<StageA>(0);
+    f.conductor.reset_path<StageA, StageB, StageC>();
+    EXPECT_TRUE(f.conductor.apply_pending_transition(0));
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageC>());
+
+    // The seeded stages below the top are real back-targets.
+    f.conductor.pop();
+    EXPECT_TRUE(f.conductor.apply_pending_transition(0));
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageB>());
+    f.conductor.pop();
+    EXPECT_TRUE(f.conductor.apply_pending_transition(0));
+    EXPECT_EQ(f.conductor.current_index(), TestConductor::index_of<StageA>());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/tempo/test/test_tempo_request_payload/test.cpp
+++ b/lib/tempo/test/test_tempo_request_payload/test.cpp
@@ -1,9 +1,9 @@
 /**
- * GoogleTest suite for `Conductor::request<S>(Args...)` payload-passing transitions.
+ * GoogleTest suite for payload-passing navigation.
  *
- * Verifies the payload form forwards arguments to `S::prepare(...)` immediately
- * (before the transition is applied) and that stages without prepare still
- * accept the zero-arg `request<S>()` form unchanged.
+ * `push`/`replace` forward their args to `S::prepare(...)` immediately (before the
+ * transition is applied), and stages without prepare accept the zero-arg forms unchanged.
+ * `push` rejects re-entering the current stage, so same-stage re-entry uses `replace`.
  */
 #include <gtest/gtest.h>
 #include <tempo/bus/event.h>
@@ -58,7 +58,7 @@ namespace {
 
 } // namespace
 
-TEST(RequestPayload, RequestWithoutArgsLeavesStageDefaults) {
+TEST(Payload, PushWithoutArgsLeavesStageDefaults) {
     StageWithPayload payload;
     PlainStage plain;
     TestConductor c;
@@ -66,7 +66,7 @@ TEST(RequestPayload, RequestWithoutArgsLeavesStageDefaults) {
     c.register_stage(plain);
     c.start<PlainStage>(0);
 
-    c.request<StageWithPayload>();
+    c.push<StageWithPayload>();
     EXPECT_EQ(payload.prepare_call_count, 0);
 
     c.apply_pending_transition(0);
@@ -74,7 +74,7 @@ TEST(RequestPayload, RequestWithoutArgsLeavesStageDefaults) {
     EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::REVIEW);
 }
 
-TEST(RequestPayload, RequestWithArgCallsPrepareImmediately) {
+TEST(Payload, PushWithArgCallsPrepareImmediately) {
     StageWithPayload payload;
     PlainStage plain;
     TestConductor c;
@@ -82,7 +82,7 @@ TEST(RequestPayload, RequestWithArgCallsPrepareImmediately) {
     c.register_stage(plain);
     c.start<PlainStage>(0);
 
-    c.request<StageWithPayload>(Mode::SELECT);
+    c.push<StageWithPayload>(Mode::SELECT);
 
     // prepare runs at request time, before apply.
     EXPECT_EQ(payload.prepare_call_count, 1);
@@ -94,7 +94,7 @@ TEST(RequestPayload, RequestWithArgCallsPrepareImmediately) {
     EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::SELECT);
 }
 
-TEST(RequestPayload, LatestRequestWins) {
+TEST(Payload, LatestPayloadWins) {
     StageWithPayload payload;
     PlainStage plain;
     TestConductor c;
@@ -102,15 +102,15 @@ TEST(RequestPayload, LatestRequestWins) {
     c.register_stage(plain);
     c.start<PlainStage>(0);
 
-    c.request<StageWithPayload>(Mode::REVIEW);
-    c.request<StageWithPayload>(Mode::SELECT);
+    c.replace<StageWithPayload>(Mode::REVIEW);
+    c.replace<StageWithPayload>(Mode::SELECT);
     EXPECT_EQ(payload.prepare_call_count, 2);
 
     c.apply_pending_transition(0);
     EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::SELECT);
 }
 
-TEST(RequestPayload, PlainStageStillTransitions) {
+TEST(Payload, PlainStageStillTransitions) {
     StageWithPayload payload;
     PlainStage plain;
     TestConductor c;
@@ -118,12 +118,12 @@ TEST(RequestPayload, PlainStageStillTransitions) {
     c.register_stage(plain);
     c.start<StageWithPayload>(0);
 
-    c.request<PlainStage>();
+    c.push<PlainStage>();
     c.apply_pending_transition(0);
     EXPECT_EQ(plain.on_enter_count, 1);
 }
 
-TEST(RequestPayload, SameStageRequestReFiresLifecycleWithNewPayload) {
+TEST(Payload, SameStageReplaceReFiresLifecycleWithNewPayload) {
     StageWithPayload payload;
     PlainStage plain;
     TestConductor c;
@@ -135,8 +135,8 @@ TEST(RequestPayload, SameStageRequestReFiresLifecycleWithNewPayload) {
     EXPECT_EQ(payload.on_enter_count, 1);
     EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::REVIEW);
 
-    // Same-stage request with a different payload should re-fire on_enter.
-    c.request<StageWithPayload>(Mode::SELECT);
+    // Same-stage replace with a different payload re-fires on_enter.
+    c.replace<StageWithPayload>(Mode::SELECT);
     EXPECT_TRUE(c.apply_pending_transition(0));
     EXPECT_EQ(payload.on_enter_count, 2);
     EXPECT_EQ(payload.mode_seen_in_on_enter, Mode::SELECT);

--- a/lib/tempo/test/test_tempo_stage_events/test.cpp
+++ b/lib/tempo/test/test_tempo_stage_events/test.cpp
@@ -89,7 +89,7 @@ TEST(StageEvents, DispatchAfterTransitionReachesNewActiveStage) {
     c.register_stage(b);
     c.start<StageA>(0);
 
-    c.request<StageB>();
+    c.push<StageB>();
     c.apply_pending_transition(0);
 
     c.dispatch_event(TestEvent{Ping{1}}, 2000);

--- a/test/test_v2_energy/test.cpp
+++ b/test/test_v2_energy/test.cpp
@@ -223,8 +223,10 @@ TEST(EnergyStage, RLongReturnsToNormalStageWithStoredProfile) {
     conductor.register_stage(normal);
     conductor.register_stage(energy);
 
-    energy.prepare(3);
-    conductor.start<EnergyStage>(0);
+    normal.prepare(3);
+    conductor.start<NormalStage>(0);
+    conductor.push<EnergyStage>(3);
+    conductor.apply_pending_transition(0);
     energy.on_event(conductor, ButtonEvent{ButtonId::R, Gesture::LONG}, 0);
 
     EXPECT_TRUE(conductor.has_pending());

--- a/test/test_v2_menu/test.cpp
+++ b/test/test_v2_menu/test.cpp
@@ -116,7 +116,9 @@ TEST(MenuStage, LLongReturnsToNormalStage) {
     Harness h;
     EXPECT_CALL(h.sink, is_index_pps(_)).WillRepeatedly(Return(false));
     EXPECT_CALL(h.sink, set_pdo(_)).WillRepeatedly(Return(true));
-    h.conductor.start<MenuStage>(0);
+    h.conductor.start<NormalStage>(0);
+    h.conductor.push<MenuStage>();
+    h.conductor.apply_pending_transition(0);
 
     h.menu.on_event(h.conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
 

--- a/test/test_v2_profile_picker/test.cpp
+++ b/test/test_v2_profile_picker/test.cpp
@@ -396,7 +396,9 @@ TEST(ProfilePickerStage, LongPressLExitsToMenu) {
     TestConductor conductor;
     conductor.register_stage(stage);
     conductor.register_stage(menu);
-    conductor.start<ProfilePickerStage>(0);
+    conductor.start<MenuStage>(0);
+    conductor.push<ProfilePickerStage>();
+    conductor.apply_pending_transition(0);
 
     stage.on_event(conductor, ButtonEvent{ButtonId::L, Gesture::LONG}, 0);
 

--- a/test/test_v2_settings/test.cpp
+++ b/test/test_v2_settings/test.cpp
@@ -74,7 +74,9 @@ TEST(SettingsStage, EncoderLongTogglesInRamWithoutSaving) {
 
 TEST(SettingsStage, ExitFlushesPendingToggleToEeprom) {
     Harness h;
-    h.conductor.start<SettingsStage>(0);
+    h.conductor.start<MenuStage>(0);
+    h.conductor.push<SettingsStage>();
+    h.conductor.apply_pending_transition(0);
 
     h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);
 
@@ -90,7 +92,9 @@ TEST(SettingsStage, ExitFlushesPendingToggleToEeprom) {
 
 TEST(SettingsStage, MultipleTogglesCollapseToSingleSaveOnExit) {
     Harness h;
-    h.conductor.start<SettingsStage>(0);
+    h.conductor.start<MenuStage>(0);
+    h.conductor.push<SettingsStage>();
+    h.conductor.apply_pending_transition(0);
 
     EXPECT_CALL(h.eeprom, save(_)).Times(1).WillOnce(Return(true));
 
@@ -105,7 +109,9 @@ TEST(SettingsStage, MultipleTogglesCollapseToSingleSaveOnExit) {
 
 TEST(SettingsStage, ExitWithoutTogglesDoesNotSave) {
     Harness h;
-    h.conductor.start<SettingsStage>(0);
+    h.conductor.start<MenuStage>(0);
+    h.conductor.push<SettingsStage>();
+    h.conductor.apply_pending_transition(0);
 
     EXPECT_CALL(h.eeprom, save(_)).Times(0);
 
@@ -147,7 +153,9 @@ TEST(SettingsStage, EncoderLongOnVoltageCompTogglesPreference) {
 
 TEST(SettingsStage, ExitFlushesVoltageCompToggle) {
     Harness h;
-    h.conductor.start<SettingsStage>(0);
+    h.conductor.start<MenuStage>(0);
+    h.conductor.push<SettingsStage>();
+    h.conductor.apply_pending_transition(0);
 
     h.stage.on_event(h.conductor, EncoderEvent{1}, 0);
     h.stage.on_event(h.conductor, ButtonEvent{ButtonId::ENCODER, Gesture::LONG}, 0);


### PR DESCRIPTION
## Summary
Each screen used to hardcode their "back" target with a fixed `request<SomeStage>()`, which gets highly coupled as we have more screens. This adds a navigation stack to the tempo `Conductor`: a small fixed stack of stage slots whose top is always the current stage. Stages navigate with `push`, `pop`, `replace`, and `reset_root`. For any given time, the top most stage is the current stage.

## Linked issues

## Hardware tested
- [x] HW1_3

How tested:
Basic navigations on HW1.3 device 

## Breaking change / migration
- [x] User-visible behavior (UI, button mapping, menu)

Details:


## Notes
